### PR TITLE
PERA-993 :: add github workflows

### DIFF
--- a/.github/workflows/android-app-tests.yml
+++ b/.github/workflows/android-app-tests.yml
@@ -1,0 +1,52 @@
+name: "Android App Tests"
+
+on:
+
+  push:
+  pull_request:
+
+jobs:
+
+    android-unit-tests:
+      name: "Android App Unit Tests"
+      runs-on: ubuntu-latest
+      steps:
+        - name: "Checkout"
+          uses: actions/checkout@v4
+        - name: "Install JDK 17"
+          uses: actions/setup-java@v4
+          with:
+            distribution: "zulu"
+            java-version: "17"
+            cache: "gradle"
+        - name: "Run Unit Tests"
+          run: ./gradlew test
+        - name: "Archive App Unit Tests Report"
+          uses: actions/upload-artifact@v4
+          if: ${{ always() }}
+          with:
+            name: "app-unit-tests-results"
+            path: ./**/build/reports/**
+            overwrite: true
+
+    android-lint:
+      name: "Android App Lint Checks"
+      runs-on: ubuntu-latest
+      steps:
+        - name: "Checkout"
+          uses: actions/checkout@v4
+        - name: "Install JDK 17"
+          uses: actions/setup-java@v4
+          with:
+            distribution: "zulu"
+            java-version: "17"
+            cache: "gradle"
+        - name: "Run Lint Checks"
+          run: ./gradlew lint
+        - name: "Archive App Lint Test Results"
+          uses: actions/upload-artifact@v4
+          if: ${{ always() }}
+          with:
+            name: "app-lint-results"
+            path: ./**/build/reports/**
+            overwrite: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 android.enableJetifier=true
 android.useAndroidX=true
 kotlin.code.style=official
-org.gradle.jvmargs=-Xms1024m -Xmx4096m
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=4g
 org.gradle.vfs.watch=true
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
## Description
- Add In Github workflows to test repo code (Unit Tests, Lint) for any new changes (since CI minutes are free for open source repos)
- Bumped up gradle memory so `./gradlew test` command would not throw "out of memory" exceptions

## Additional Notes
- Closes https://algorandfoundation.atlassian.net/browse/PERA-993
- I think it's ok to merge this code into `dev` branch even if underlying unit/lint tests don't pass since it's not blocking and somewhat surfacing pre-existing lint issues.  
- I skipped adding a ui test github workflow job because the github android emulator is really flaky right now (open issue)
