### PR TITLE
PERA-1023 :: Define concurrency to cancel active workflow

### DIFF
--- a/.github/workflows/android-app-tests.yml
+++ b/.github/workflows/android-app-tests.yml
@@ -5,6 +5,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
     android-unit-tests:


### PR DESCRIPTION
## Description

With this implementation, we will let only one workflow to run with the same group id

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1023
