### PR TITLE
PERA-929 :: Amount of ASA in asset inbox not displayed correctly

### DIFF
--- a/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/data/mapper/AssetInboxOneAccountMapperImpl.kt
+++ b/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/data/mapper/AssetInboxOneAccountMapperImpl.kt
@@ -10,11 +10,10 @@
  * limitations under the License
  */
 
-package com.algorand.android.modules.assetinbox.assetinboxallaccounts.data.mapper
+package com.algorand.android.modules.assetinbox.assetinboxoneaccount.data.mapper
 
 import com.algorand.android.assetsearch.data.mapper.VerificationTierDTODecider
 import com.algorand.android.assetsearch.domain.mapper.VerificationTierDecider
-import com.algorand.android.modules.assetinbox.assetinboxoneaccount.data.mapper.AssetInboxOneAccountMapper
 import com.algorand.android.modules.assetinbox.assetinboxoneaccount.data.model.AssetInboxOneAccountPaginatedResponse
 import com.algorand.android.modules.assetinbox.assetinboxoneaccount.data.model.AssetInboxOneAccountPaginatedResponse.AssetInboxOneAccountResultResponse
 import com.algorand.android.modules.assetinbox.assetinboxoneaccount.data.model.AssetInboxOneAccountPaginatedResponse.AssetResponse
@@ -63,7 +62,7 @@ class AssetInboxOneAccountMapperImpl @Inject constructor(
     private fun mapToAssetInboxOneAccountResult(response: AssetInboxOneAccountResultResponse?):
             AssetInboxOneAccountResult {
         return AssetInboxOneAccountResult(
-            totalAmount = response?.totalAmount ?: 0,
+            totalAmount = response?.totalAmount ?: BigInteger.ZERO,
             asset = mapToAsset(response?.asset),
             algoGainOnClaim = response?.algoGainOnClaim ?: BigInteger.ZERO,
             algoGainOnReject = response?.algoGainOnReject ?: BigInteger.ZERO,

--- a/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/data/model/AssetInboxOneAccountPaginatedResponse.kt
+++ b/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/data/model/AssetInboxOneAccountPaginatedResponse.kt
@@ -33,7 +33,7 @@ data class AssetInboxOneAccountPaginatedResponse(
 
     data class AssetInboxOneAccountResultResponse(
         @SerializedName("total_amount")
-        val totalAmount: Int?,
+        val totalAmount: BigInteger?,
         @SerializedName("asset")
         val asset: AssetResponse?,
         @SerializedName("algo_gain_on_claim")

--- a/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/di/AssetInboxOneAccountRepositoryModule.kt
+++ b/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/di/AssetInboxOneAccountRepositoryModule.kt
@@ -10,9 +10,9 @@
  *  limitations under the License
  */
 
-package com.algorand.android.modules.assetinbox.assetinboxoneaccount.data.di
+package com.algorand.android.modules.assetinbox.assetinboxoneaccount.di
 
-import com.algorand.android.modules.assetinbox.assetinboxallaccounts.data.mapper.AssetInboxOneAccountMapperImpl
+import com.algorand.android.modules.assetinbox.assetinboxoneaccount.data.mapper.AssetInboxOneAccountMapperImpl
 import com.algorand.android.modules.assetinbox.assetinboxoneaccount.data.mapper.AssetInboxOneAccountMapper
 import com.algorand.android.modules.assetinbox.assetinboxoneaccount.data.repository.AssetInboxOneAccountRepositoryImpl
 import com.algorand.android.modules.assetinbox.assetinboxoneaccount.data.service.AssetInboxOneAccountApiService

--- a/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/domain/model/AssetInboxOneAccountPaginated.kt
+++ b/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/domain/model/AssetInboxOneAccountPaginated.kt
@@ -26,7 +26,7 @@ data class AssetInboxOneAccountPaginated(
 )
 
 data class AssetInboxOneAccountResult(
-    val totalAmount: Int,
+    val totalAmount: BigInteger,
     val asset: Asset,
     val algoGainOnClaim: BigInteger,
     val algoGainOnReject: BigInteger,

--- a/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/ui/mapper/AssetInboxOneAccountPreviewMapperImpl.kt
+++ b/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/ui/mapper/AssetInboxOneAccountPreviewMapperImpl.kt
@@ -26,6 +26,7 @@ import com.algorand.android.utils.assetdrawable.BaseAssetDrawableProvider
 import com.algorand.android.utils.formatAmount
 import com.algorand.android.utils.formatAsAssetAmount
 import com.algorand.android.utils.formatAsCurrency
+import com.algorand.android.utils.multiplyOrZero
 import com.algorand.android.utils.toShortenedAddress
 import java.math.BigInteger
 import javax.inject.Inject
@@ -61,7 +62,11 @@ class AssetInboxOneAccountPreviewMapperImpl @Inject constructor(
                 result.asset.logo
             )
             if (result.asset.collectible != null) {
-                createCollectiblePreview(assetInboxOneAccountPaginated, result, assetDrawableProvider)
+                createCollectiblePreview(
+                    assetInboxOneAccountPaginated,
+                    result,
+                    assetDrawableProvider
+                )
             } else {
                 createAssetPreview(assetInboxOneAccountPaginated, result, assetDrawableProvider)
             }
@@ -116,12 +121,13 @@ class AssetInboxOneAccountPreviewMapperImpl @Inject constructor(
         result: AssetInboxOneAccountResult,
         assetDrawableProvider: BaseAssetDrawableProvider
     ): AsaPreview {
+
         return AsaPreview.AssetPreview(
             id = result.asset.assetId,
             receiverAddress = assetInboxOneAccountPaginated.receiverAddress,
             assetName = result.asset.name,
             shortName = result.asset.unitName,
-            usdValue = getFormattedUsdValue(result.asset.usdValue),
+            usdValue = getFormattedUsdValue(result),
             amount = getTotalAssetAmount(result),
             logo = result.asset.collectible?.primaryImage,
             senderAccounts = result.senders.results.map {
@@ -175,9 +181,11 @@ class AssetInboxOneAccountPreviewMapperImpl @Inject constructor(
             .formatAsAssetAmount(result.asset.unitName)
     }
 
-    private fun getFormattedUsdValue(usdValue: String): String {
-        return usdValue.toBigDecimalOrNull()
-            ?.formatAsCurrency(Currency.USD.symbol, isCompact = true)
-            .orEmpty()
+    private fun getFormattedUsdValue(result: AssetInboxOneAccountResult): String {
+        return getTotalAssetAmount(result)
+            .toBigDecimal()
+            .movePointLeft(result.asset.decimals)
+            .multiplyOrZero(result.asset.usdValue.toBigDecimal())
+            .formatAsCurrency(Currency.USD.symbol, isCompact = true)
     }
 }

--- a/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/ui/mapper/AssetInboxOneAccountPreviewMapperImpl.kt
+++ b/app/src/main/java/com/algorand/android/modules/assetinbox/assetinboxoneaccount/ui/mapper/AssetInboxOneAccountPreviewMapperImpl.kt
@@ -28,7 +28,6 @@ import com.algorand.android.utils.formatAsAssetAmount
 import com.algorand.android.utils.formatAsCurrency
 import com.algorand.android.utils.multiplyOrZero
 import com.algorand.android.utils.toShortenedAddress
-import java.math.BigInteger
 import javax.inject.Inject
 
 class AssetInboxOneAccountPreviewMapperImpl @Inject constructor(
@@ -128,7 +127,7 @@ class AssetInboxOneAccountPreviewMapperImpl @Inject constructor(
             assetName = result.asset.name,
             shortName = result.asset.unitName,
             usdValue = getFormattedUsdValue(result),
-            amount = getTotalAssetAmount(result),
+            amount = result.totalAmount,
             logo = result.asset.collectible?.primaryImage,
             senderAccounts = result.senders.results.map {
                 SenderPreview(
@@ -171,21 +170,17 @@ class AssetInboxOneAccountPreviewMapperImpl @Inject constructor(
         )
     }
 
-    private fun getTotalAssetAmount(result: AssetInboxOneAccountResult): BigInteger {
-        return result.senders.results.sumOf { it.amount }
-    }
-
     private fun getFormattedAssetAmount(result: AssetInboxOneAccountResult): String {
-        return getTotalAssetAmount(result)
+        return result.totalAmount
             .formatAmount(result.asset.decimals)
             .formatAsAssetAmount(result.asset.unitName)
     }
 
     private fun getFormattedUsdValue(result: AssetInboxOneAccountResult): String {
-        return getTotalAssetAmount(result)
+        return result.totalAmount
             .toBigDecimal()
             .movePointLeft(result.asset.decimals)
-            .multiplyOrZero(result.asset.usdValue.toBigDecimal())
+            .multiplyOrZero(result.asset.usdValue.toBigDecimalOrNull())
             .formatAsCurrency(Currency.USD.symbol, isCompact = true)
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
Fixed the calculation of the asset usd value in asa inbox screens. 

## Related Issues
- Closes [https://algorandfoundation.atlassian.net/browse/PERA-929](https://algorandfoundation.atlassian.net/browse/PERA-929)
- Closes [https://algorandfoundation.atlassian.net/browse/PERA-702](https://algorandfoundation.atlassian.net/browse/PERA-702)
- Closes [https://algorandfoundation.atlassian.net/browse/PERA-1002](https://algorandfoundation.atlassian.net/browse/PERA-1002)
- Closes [https://algorandfoundation.atlassian.net/browse/PERA-703](https://algorandfoundation.atlassian.net/browse/PERA-703)

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
