### PR TITLE
PERA-546 :: hide loader if register info fragment content loads

### DIFF
--- a/app/src/main/java/com/algorand/android/modules/accounts/ui/AccountsFragment.kt
+++ b/app/src/main/java/com/algorand/android/modules/accounts/ui/AccountsFragment.kt
@@ -24,6 +24,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.NavDirections
 import com.algorand.android.HomeNavigationDirections
+import com.algorand.android.MainActivity
 import com.algorand.android.MainNavigationDirections
 import com.algorand.android.R
 import com.algorand.android.core.DaggerBaseFragment
@@ -145,6 +146,7 @@ class AccountsFragment : DaggerBaseFragment(R.layout.fragment_accounts),
     private val accountListCollector: suspend (List<BaseAccountListItem>?) -> Unit = { accountList ->
         accountList?.let { safeList ->
             loadAccountsAndBalancePreview(safeList)
+            (activity as MainActivity).hideProgress()
         }
     }
 

--- a/app/src/main/java/com/algorand/android/ui/register/registerintro/RegisterIntroFragment.kt
+++ b/app/src/main/java/com/algorand/android/ui/register/registerintro/RegisterIntroFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import com.algorand.android.LoginNavigationDirections
+import com.algorand.android.MainActivity
 import com.algorand.android.R
 import com.algorand.android.core.DaggerBaseFragment
 import com.algorand.android.customviews.toolbar.buttoncontainer.model.TextButton
@@ -44,6 +45,7 @@ class RegisterIntroFragment : DaggerBaseFragment(R.layout.fragment_register_type
     private val registerIntroPreviewCollector: suspend (RegisterIntroPreview) -> Unit = {
         binding.titleTextView.setText(it.titleRes)
         configureToolbar(it.isCloseButtonVisible, it.isSkipButtonVisible)
+        (activity as MainActivity).hideProgress()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
# Pull Request Template

## Description
- Hide loader if register info fragment content loads
- Hide loader if account list fetch call is successful

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-546

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- If you know other fragments we should add this quick fix to, please mention in PR.