### PR TITLE
PERA-1267 :: Missing default minimum fee in ARC-78 implementation

### DIFF
--- a/app/src/main/java/com/algorand/android/modules/keyreg/ui/components/KeyRegTable.kt
+++ b/app/src/main/java/com/algorand/android/modules/keyreg/ui/components/KeyRegTable.kt
@@ -91,7 +91,7 @@ fun keyRegTable(
                     .fillMaxHeight(),
                 ) {
                 items(itemsList) { item ->
-                    keyRegTableRowItem(item.first, item.second)
+                    keyRegTableRowItem(item.first, item.second.toString())
                 }
             }
         }

--- a/app/src/main/java/com/algorand/android/modules/keyreg/ui/mapper/KeyRegTransactionPreviewMapper.kt
+++ b/app/src/main/java/com/algorand/android/modules/keyreg/ui/mapper/KeyRegTransactionPreviewMapper.kt
@@ -25,7 +25,7 @@ class KeyRegTransactionPreviewMapper @Inject constructor() {
         return KeyRegTransactionPreview(
             isLoadingVisible = false,
             address = detail.address,
-            fee = detail.fee?.toString() ?: "",
+            fee = detail.fee ?: MINIMUM_TXN_FEE.toBigInteger(),
             type = detail.type,
             selectionKey = detail.selectionPublicKey.orEmpty(),
             votingKey = detail.voteKey.orEmpty(),
@@ -39,5 +39,9 @@ class KeyRegTransactionPreviewMapper @Inject constructor() {
             signTransactionEvent = null,
             showErrorEvent = null
         )
+    }
+
+    companion object {
+        const val MINIMUM_TXN_FEE = 1000
     }
 }

--- a/app/src/main/java/com/algorand/android/modules/keyreg/ui/model/KeyRegTransactionPreview.kt
+++ b/app/src/main/java/com/algorand/android/modules/keyreg/ui/model/KeyRegTransactionPreview.kt
@@ -14,11 +14,12 @@ package com.algorand.android.modules.keyreg.ui.model
 
 import com.algorand.android.modules.keyreg.domain.model.KeyRegTransaction
 import com.algorand.android.utils.Event
+import java.math.BigInteger
 
 data class KeyRegTransactionPreview(
     val isLoadingVisible: Boolean,
     val address: String,
-    val fee: String,
+    val fee: BigInteger,
     val type: String,
     val selectionKey: String,
     val votingKey: String,


### PR DESCRIPTION
# Pull Request Template

## Description
- Missing default minimum fee in ARC-78 implementation if not passed in params

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1267

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- If it's possible, please test on a mainnet account for key reg online/offline is working as expected
- @yasin-ce maybe you might know how to make it network minimum instead of hardcoded .001 Algo fee
- Urtho seems to still run into issues beyond this, but this solved issues on my end so maybe we can at least land this fix and troubleshoot further
