### PR TITLE
PERA-1159 :: Auto-select account address for ARC-78 if it exists

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,6 +25,10 @@
 -keep class com.algorand.android.** { *; }
 -keep class androidx.** { *; }
 -keep class com.algorand.android.**.model.** { *; }
+-keep class com.algorand.android.modules.algosdk.data.model.** { *; }
+-keep class com.algorand.android.modules.algosdk.domain.model.** { *; }
+-keep class com.algorand.android.modules.keyreg.domain.model.** { *; }
+-keep class com.algorand.android.modules.keyreg.ui.model.** { *; }
 
 -keep class com.algorand.android.ui.wctransactionrequest.WalletConnectTransactionListItem
 # ---------------- END PERA ---------------------

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -151,7 +151,6 @@
 -keep public class * extends java.lang.Exception
 -keep class com.crashlytics.** { *; }
 -dontwarn com.crashlytics.**
-
 # ---------------- END CRASHLYTICS -------------------
 
 
@@ -166,6 +165,14 @@
 # ---------------- END AlgoSDK -------------------
 
 
+# ---------------- BEGIN BouncyCastle -------------------
+-keep class org.bouncycastle.jcajce.provider.** { *; }
+-keep class org.bouncycastle.jce.provider.** { *; }
+
+-dontwarn javax.naming.**
+# ---------------- END BouncyCastle -------------------
+
+
 # ---------------- BEGIN WALLET CONNECT -------------------
 -keep class org.walletconnect.** { *; }
 -keep interface org.walletconnect.** { *; }
@@ -176,8 +183,6 @@
 
 
 # ---------------- BEGIN OTHERS -------------------
--keep class com.google.gson.examples.android.model.** { <fields>; }
-
 # Prevent R8 from leaving Data object members always null
 -keepclassmembers,allowobfuscation class * {
   @com.google.gson.annotations.SerializedName <fields>;

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,10 +25,6 @@
 -keep class com.algorand.android.** { *; }
 -keep class androidx.** { *; }
 -keep class com.algorand.android.**.model.** { *; }
--keep class com.algorand.android.modules.algosdk.data.model.** { *; }
--keep class com.algorand.android.modules.algosdk.domain.model.** { *; }
--keep class com.algorand.android.modules.keyreg.domain.model.** { *; }
--keep class com.algorand.android.modules.keyreg.ui.model.** { *; }
 
 -keep class com.algorand.android.ui.wctransactionrequest.WalletConnectTransactionListItem
 # ---------------- END PERA ---------------------

--- a/app/src/main/java/com/algorand/android/modules/basesingleaccountselection/ui/BaseSingleAccountSelectionFragment.kt
+++ b/app/src/main/java/com/algorand/android/modules/basesingleaccountselection/ui/BaseSingleAccountSelectionFragment.kt
@@ -51,7 +51,7 @@ abstract class BaseSingleAccountSelectionFragment : BaseFragment(R.layout.fragme
         listener = baseSingleAccountSelectionAdapterListener
     )
 
-    private val singleAccountSelectionListItemsCollector: suspend (
+    val singleAccountSelectionListItemsCollector: suspend (
         List<SingleAccountSelectionListItem>?
     ) -> Unit = { accountSelectionItemList ->
         baseSingleAccountSelectionAdapter.submitList(accountSelectionItemList)

--- a/app/src/main/java/com/algorand/android/modules/basesingleaccountselection/ui/model/SingleAccountSelectionListItem.kt
+++ b/app/src/main/java/com/algorand/android/modules/basesingleaccountselection/ui/model/SingleAccountSelectionListItem.kt
@@ -27,6 +27,7 @@ sealed class SingleAccountSelectionListItem : RecyclerListItem {
     }
 
     abstract val itemType: ItemType
+    abstract val address: String?
 
     data class TitleItem(
         @StringRes val textResId: Int
@@ -34,6 +35,9 @@ sealed class SingleAccountSelectionListItem : RecyclerListItem {
 
         override val itemType: ItemType
             get() = ItemType.TITLE_ITEM
+
+        override val address: String?
+            get() = null
 
         override fun areItemsTheSame(other: RecyclerListItem): Boolean {
             return other is TitleItem && textResId == other.textResId
@@ -50,6 +54,9 @@ sealed class SingleAccountSelectionListItem : RecyclerListItem {
 
         override val itemType: ItemType
             get() = ItemType.DESCRIPTION_ITEM
+
+        override val address: String?
+            get() = null
 
         override fun areItemsTheSame(other: RecyclerListItem): Boolean {
             return other is DescriptionItem && descriptionAnnotatedString == other.descriptionAnnotatedString
@@ -69,6 +76,9 @@ sealed class SingleAccountSelectionListItem : RecyclerListItem {
 
         override val itemType: ItemType
             get() = ItemType.ACCOUNT_ITEM
+
+        override val address: String
+            get() = accountDisplayName.getRawAccountAddress()
 
         override fun areItemsTheSame(other: RecyclerListItem): Boolean {
             return other is AccountItem &&

--- a/app/src/main/java/com/algorand/android/modules/keyreg/ui/KeyRegAccountSelectionFragment.kt
+++ b/app/src/main/java/com/algorand/android/modules/keyreg/ui/KeyRegAccountSelectionFragment.kt
@@ -1,12 +1,20 @@
 package com.algorand.android.modules.keyreg.ui
 
+import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.algorand.android.R
 import com.algorand.android.models.FragmentConfiguration
 import com.algorand.android.models.ToolbarConfiguration
 import com.algorand.android.modules.basesingleaccountselection.ui.BaseSingleAccountSelectionFragment
 import com.algorand.android.modules.basesingleaccountselection.ui.BaseSingleAccountSelectionViewModel
+import com.algorand.android.modules.basesingleaccountselection.ui.model.SingleAccountSelectionListItem
+import com.algorand.android.modules.keyreg.ui.KeyRegTransactionFragment.Companion.NAV_BACK_FRAGMENT_KEY
+import com.algorand.android.utils.extensions.collectLatestOnLifecycle
+import com.algorand.android.utils.showAlertDialog
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.map
 
 @AndroidEntryPoint
 class KeyRegAccountSelectionFragment : BaseSingleAccountSelectionFragment() {
@@ -29,5 +37,50 @@ class KeyRegAccountSelectionFragment : BaseSingleAccountSelectionFragment() {
                     signingAccountAddress = accountAddress
                 )
         )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<String>(NAV_BACK_FRAGMENT_KEY)?.observe(viewLifecycleOwner) { result ->
+                if (result == "KeyRegTransactionFragment") {
+                    navBack() // goes back to account selection screen
+                    navBack() // goes back to camera screen
+                }
+            }
+        findNavController().previousBackStackEntry?.savedStateHandle?.set(NAV_BACK_FRAGMENT_KEY, null)
+        initObservers()
+    }
+
+    private fun initObservers() {
+        with(singleAccountSelectionViewModel.singleAccountSelectionFieldsFlow) {
+            collectLatestOnLifecycle(
+                flow = map { it?.singleAccountSelectionListItems },
+                collection = singleAccountSelectionListItemsCollectorKeyReg
+            )
+        }
+    }
+
+    val singleAccountSelectionListItemsCollectorKeyReg: suspend (
+        List<SingleAccountSelectionListItem>?
+    ) -> Unit = { accountSelectionItemList ->
+        var addressFound = false
+        accountSelectionItemList?.forEach { accountSelectionItem ->
+            accountSelectionItem.itemType
+            if (accountSelectionItem.itemType == SingleAccountSelectionListItem.ItemType.ACCOUNT_ITEM) {
+                if (accountSelectionItem.address == keyRegAccountSelectionViewModel.keyRegTransactionDetail.address) {
+                    addressFound = true
+                    onAccountSelected(accountSelectionItem.address.toString())
+                }
+            }
+        }
+        if (!accountSelectionItemList.isNullOrEmpty() && !addressFound) {
+            activity?.showAlertDialog(
+                getString(R.string.error),
+                "Please add wallet address (" +
+                        "${keyRegAccountSelectionViewModel.keyRegTransactionDetail.address}) on app before scanning"
+            )
+            navBack()
+        }
     }
 }

--- a/app/src/main/java/com/algorand/android/modules/keyreg/ui/KeyRegAccountSelectionFragment.kt
+++ b/app/src/main/java/com/algorand/android/modules/keyreg/ui/KeyRegAccountSelectionFragment.kt
@@ -77,8 +77,8 @@ class KeyRegAccountSelectionFragment : BaseSingleAccountSelectionFragment() {
         if (!accountSelectionItemList.isNullOrEmpty() && !addressFound) {
             activity?.showAlertDialog(
                 getString(R.string.error),
-                "Please add wallet address (" +
-                        "${keyRegAccountSelectionViewModel.keyRegTransactionDetail.address}) on app before scanning"
+                "You don't have any authorized account matching with " +
+                        keyRegAccountSelectionViewModel.keyRegTransactionDetail.address
             )
             navBack()
         }

--- a/app/src/main/java/com/algorand/android/modules/keyreg/ui/KeyRegTransactionFragment.kt
+++ b/app/src/main/java/com/algorand/android/modules/keyreg/ui/KeyRegTransactionFragment.kt
@@ -19,6 +19,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.algorand.android.HomeNavigationDirections
 import com.algorand.android.R
 import com.algorand.android.core.TransactionBaseFragment
@@ -53,12 +54,17 @@ import kotlin.properties.Delegates
 
 @AndroidEntryPoint
 class KeyRegTransactionFragment : TransactionBaseFragment(R.layout.fragment_key_reg_transaction) {
-
     private val toolbarConfiguration = ToolbarConfiguration(
         startIconResId = R.drawable.ic_left_arrow,
         titleResId = R.string.key_reg_transaction_title,
-        startIconClick = ::navBack
+        startIconClick = ::customNavBack
     )
+
+    fun customNavBack() {
+        findNavController().previousBackStackEntry?.savedStateHandle
+            ?.set(NAV_BACK_FRAGMENT_KEY, "KeyRegTransactionFragment")
+        navBack()
+    }
 
     override val fragmentConfiguration =
         FragmentConfiguration(toolbarConfiguration = toolbarConfiguration)
@@ -346,5 +352,6 @@ class KeyRegTransactionFragment : TransactionBaseFragment(R.layout.fragment_key_
 
     companion object {
         const val ADD_EDIT_NOTE_BUTTON_VERTICAL_BIAS = 0.5f
+        const val NAV_BACK_FRAGMENT_KEY = "navBackFragmentKey"
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
- Auto-selects account address for ARC-78 screen if it exists
- Shows an error message if it can find the QR address is device wallet address list
- Add proguard fix for `bouncycastle`

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1159
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1267

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Implementation only display no valid account address if wallet address count is > 0 since list initialization returns an empty list

![Screenshot_20241211_142805](https://github.com/user-attachments/assets/1ef1d9eb-9101-4324-ba41-15b3f2916881)

