### PR TITLE
PERA-1209 :: Handle new discover, staking and cards deeplinks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,8 +69,8 @@ android {
         buildConfigField "String", "VERSION_NAME", "\"$versionName\""
         buildConfigField "Integer", "VERSION_CODE", "$versionCode"
 
-        buildConfigField "String", "DISCOVER_TESTNET_URL", '"https://discover-mobile-staging.perawallet.app/"'
-        buildConfigField "String", "DISCOVER_MAINNET_URL", '"https://discover-mobile.perawallet.app/"'
+        buildConfigField "String", "DISCOVER_TESTNET_URL", '"https://discover-mobile-staging.perawallet.app"'
+        buildConfigField "String", "DISCOVER_MAINNET_URL", '"https://discover-mobile.perawallet.app"'
         buildConfigField "String", "DISCOVER_BROWSE_DAPP_TESTNET_URL", '"https://discover-mobile-staging.perawallet.app/main/browser"'
         buildConfigField "String", "DISCOVER_BROWSE_DAPP_MAINNET_URL", '"https://discover-mobile.perawallet.app/main/browser"'
         buildConfigField "String", "CARDS_TESTNET_URL", '"https://cards-mobile-staging.perawallet.app"'

--- a/app/src/main/java/com/algorand/android/CoreActionsTabBarViewModel.kt
+++ b/app/src/main/java/com/algorand/android/CoreActionsTabBarViewModel.kt
@@ -54,7 +54,7 @@ class CoreActionsTabBarViewModel @Inject constructor(
         } else {
             DISCOVER_MAINNET_URL
         }
-        return "$baseDiscoverUrl$path"
+        return "$baseDiscoverUrl/$path"
     }
 
     fun isConnectedToTestnet(): Boolean {

--- a/app/src/main/java/com/algorand/android/CoreActionsTabBarViewModel.kt
+++ b/app/src/main/java/com/algorand/android/CoreActionsTabBarViewModel.kt
@@ -15,6 +15,8 @@ package com.algorand.android
 import androidx.lifecycle.ViewModel
 import com.algorand.android.BuildConfig.DISCOVER_BROWSE_DAPP_MAINNET_URL
 import com.algorand.android.BuildConfig.DISCOVER_BROWSE_DAPP_TESTNET_URL
+import com.algorand.android.BuildConfig.DISCOVER_MAINNET_URL
+import com.algorand.android.BuildConfig.DISCOVER_TESTNET_URL
 import com.algorand.android.usecase.GetIsActiveNodeTestnetUseCase
 import com.algorand.common.remoteconfig.domain.usecase.IMMERSVE_BUTTON_TOGGLE
 import com.algorand.common.remoteconfig.domain.usecase.IsFeatureToggleEnabled
@@ -44,6 +46,15 @@ class CoreActionsTabBarViewModel @Inject constructor(
             DISCOVER_BROWSE_DAPP_TESTNET_URL
         else
             DISCOVER_BROWSE_DAPP_MAINNET_URL
+    }
+
+    fun getDiscoverUrlWithPath(path: String): String {
+        val baseDiscoverUrl = if (isConnectedToTestnet()) {
+            DISCOVER_TESTNET_URL
+        } else {
+            DISCOVER_MAINNET_URL
+        }
+        return "$baseDiscoverUrl$path"
     }
 
     fun isConnectedToTestnet(): Boolean {

--- a/app/src/main/java/com/algorand/android/MainActivity.kt
+++ b/app/src/main/java/com/algorand/android/MainActivity.kt
@@ -858,11 +858,11 @@ class MainActivity :
         nav(HomeNavigationDirections.actionGlobalDiscoverUrlViewerNavigation(webUrl))
     }
 
-    private fun navToCardsFragment(path: String? = null) {
+    fun navToCardsFragment(path: String? = null) {
         nav(HomeNavigationDirections.actionGlobalCardsFragment(path))
     }
 
-    private fun navToStakingFragment(path: String? = null) {
+    fun navToStakingFragment(path: String? = null) {
         nav(HomeNavigationDirections.actionGlobalStakingFragment(path))
     }
 
@@ -892,7 +892,7 @@ class MainActivity :
         }
     }
 
-    private fun navToDiscoverWithPath(path: String) {
+    fun navToDiscoverWithPath(path: String) {
         binding.apply {
             coreActionsTabBarView.hideWithAnimation()
             bottomNavigationView.menu.findItem(R.id.discoverHomeNavigation).isChecked = true

--- a/app/src/main/java/com/algorand/android/MainActivity.kt
+++ b/app/src/main/java/com/algorand/android/MainActivity.kt
@@ -323,6 +323,21 @@ class MainActivity :
             return true
         }
 
+        override fun onDiscoverDeepLink(path: String): Boolean {
+            navToDiscoverWithPath(path)
+            return true
+        }
+
+        override fun onCardsDeepLink(path: String): Boolean {
+            navToCardsFragment(path)
+            return true
+        }
+
+        override fun onStakingDeepLink(path: String): Boolean {
+            navToStakingFragment(path)
+            return true
+        }
+
         override fun onAssetInboxDeepLink(
             accountAddress: String,
             notificationGroupType: NotificationGroupType
@@ -708,11 +723,11 @@ class MainActivity :
             }
 
             override fun onCardsClick() {
-                nav(HomeNavigationDirections.actionGlobalCardsFragment())
+                navToCardsFragment()
             }
 
             override fun onStakingClick() {
-                nav(HomeNavigationDirections.actionGlobalStakingFragment())
+                navToStakingFragment()
             }
         })
     }
@@ -843,6 +858,14 @@ class MainActivity :
         nav(HomeNavigationDirections.actionGlobalDiscoverUrlViewerNavigation(webUrl))
     }
 
+    private fun navToCardsFragment(path: String? = null) {
+        nav(HomeNavigationDirections.actionGlobalCardsFragment(path))
+    }
+
+    private fun navToStakingFragment(path: String? = null) {
+        nav(HomeNavigationDirections.actionGlobalStakingFragment(path))
+    }
+
     fun showMaxAccountLimitExceededError() {
         showGlobalError(
             title = getString(R.string.too_many_accounts),
@@ -861,8 +884,22 @@ class MainActivity :
         binding.apply {
             coreActionsTabBarView.hideWithAnimation()
             bottomNavigationView.menu.findItem(R.id.discoverHomeNavigation).isChecked = true
-            navController.navigateSafe(actionGlobalDiscoverHomeNavigation(
-                coreActionsTabBarViewModel.getDiscoverBrowseDappUrl())
+            navController.navigateSafe(
+                actionGlobalDiscoverHomeNavigation(
+                    coreActionsTabBarViewModel.getDiscoverBrowseDappUrl()
+                )
+            )
+        }
+    }
+
+    private fun navToDiscoverWithPath(path: String) {
+        binding.apply {
+            coreActionsTabBarView.hideWithAnimation()
+            bottomNavigationView.menu.findItem(R.id.discoverHomeNavigation).isChecked = true
+            navController.navigateSafe(
+                actionGlobalDiscoverHomeNavigation(
+                    coreActionsTabBarViewModel.getDiscoverUrlWithPath(path)
+                )
             )
         }
     }

--- a/app/src/main/java/com/algorand/android/modules/card/CardsViewModel.kt
+++ b/app/src/main/java/com/algorand/android/modules/card/CardsViewModel.kt
@@ -12,6 +12,7 @@
 
 package com.algorand.android.modules.card
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.algorand.android.BuildConfig.CARDS_MAINNET_URL
 import com.algorand.android.BuildConfig.CARDS_TESTNET_URL
@@ -38,8 +39,11 @@ class CardsViewModel @Inject constructor(
     private val getAuthorizedAddressesWebMessage: GetAuthorizedAddressesWebMessage,
     private val getDeviceIdWebMessage: GetDeviceIdWebMessage,
     private val parseOpenSystemBrowserUrl: ParseOpenSystemBrowserUrl,
-    private val currencyUseCase: CurrencyUseCase
+    private val currencyUseCase: CurrencyUseCase,
+    savedStateHandle: SavedStateHandle
 ) : BasePeraWebViewViewModel() {
+
+    private val args = CardsFragmentArgs.fromSavedStateHandle(savedStateHandle)
 
     private val _cardsPreviewFlow = MutableStateFlow<CardsPreview>(CardsPreview())
     val cardsPreviewFlow: StateFlow<CardsPreview>
@@ -48,13 +52,6 @@ class CardsViewModel @Inject constructor(
     override fun onPageFinished(title: String?, url: String?) {
         super.onPageFinished(title, url)
         _cardsPreviewFlow.value = cardsPreviewFlow.value.copy(onPageFinished = Event(Unit))
-    }
-
-    fun getCardsUrl(): String {
-        return if (isConnectedToTestnet())
-            CARDS_TESTNET_URL
-        else
-            CARDS_MAINNET_URL
     }
 
     fun getAuthorizedAddresses() {
@@ -101,5 +98,14 @@ class CardsViewModel @Inject constructor(
 
     fun isConnectedToTestnet(): Boolean {
         return getIsActiveNodeTestnetUseCase.invoke()
+    }
+
+    fun getCardsUrl(): String {
+        val cardsBaseUrl = if (isConnectedToTestnet())
+            CARDS_TESTNET_URL
+        else
+            CARDS_MAINNET_URL
+
+        return "$cardsBaseUrl/${args.path.orEmpty()}"
     }
 }

--- a/app/src/main/java/com/algorand/android/modules/deeplink/ui/DeeplinkHandler.kt
+++ b/app/src/main/java/com/algorand/android/modules/deeplink/ui/DeeplinkHandler.kt
@@ -47,6 +47,7 @@ class DeeplinkHandler @Inject constructor(
             is DeepLink.AssetOptIn -> handleAssetOptInDeepLink(deepLink.assetId)
             is DeepLink.AssetTransfer -> handleAssetTransferDeepLink(deepLink)
             is DeepLink.DiscoverBrowser -> handleDiscoverBrowserDeepLink(deepLink)
+            is DeepLink.Discover -> handleDiscoverDeepLink(deepLink)
             is DeepLink.Mnemonic -> handleMnemonicDeepLink(deepLink)
             is DeepLink.Notification -> handleNotificationDeepLink(deepLink)
             is DeepLink.Undefined -> handleUndefinedDeepLink(deepLink)
@@ -54,6 +55,8 @@ class DeeplinkHandler @Inject constructor(
             is DeepLink.WebImportQrCode -> handleWebImportQrCodeDeepLink(deepLink)
             is DeepLink.KeyReg -> handleKeyRegDeepLink(deepLink)
             is DeepLink.AssetInbox -> handleAssetInboxDeepLink(deepLink)
+            is DeepLink.Cards -> handleCardsDeepLink(deepLink)
+            is DeepLink.Staking -> handleStakingDeepLink(deepLink)
         }
         if (!isDeeplinkHandled) listener?.onDeepLinkNotHandled(deepLink)
     }
@@ -87,6 +90,18 @@ class DeeplinkHandler @Inject constructor(
 
     private fun handleDiscoverBrowserDeepLink(deepLink: DeepLink.DiscoverBrowser): Boolean {
         return triggerListener { it.onDiscoverBrowserDeepLink(deepLink.webUrl); true }
+    }
+
+    private fun handleDiscoverDeepLink(deepLink: DeepLink.Discover): Boolean {
+        return triggerListener { it.onDiscoverDeepLink(deepLink.path); true }
+    }
+
+    private fun handleCardsDeepLink(deepLink: DeepLink.Cards): Boolean {
+        return triggerListener { it.onCardsDeepLink(deepLink.path); true }
+    }
+
+    private fun handleStakingDeepLink(deepLink: DeepLink.Staking): Boolean {
+        return triggerListener { it.onStakingDeepLink(deepLink.path); true }
     }
 
     private fun handleWebImportQrCodeDeepLink(deepLink: DeepLink.WebImportQrCode): Boolean {
@@ -160,8 +175,11 @@ class DeeplinkHandler @Inject constructor(
         ): Boolean = false
 
         fun onDiscoverBrowserDeepLink(webUrl: String): Boolean = false
+        fun onDiscoverDeepLink(path: String): Boolean = false
         fun onAssetInboxDeepLink(accountAddress: String, notificationGroupType: NotificationGroupType): Boolean = false
         fun onKeyRegDeeplink(deepLink: DeepLink.KeyReg): Boolean = false
+        fun onCardsDeepLink(path: String): Boolean = false
+        fun onStakingDeepLink(path: String): Boolean = false
         fun onUndefinedDeepLink(deepLink: DeepLink.Undefined)
         fun onDeepLinkNotHandled(deepLink: DeepLink)
     }

--- a/app/src/main/java/com/algorand/android/modules/qrscanning/BaseQrScannerFragment.kt
+++ b/app/src/main/java/com/algorand/android/modules/qrscanning/BaseQrScannerFragment.kt
@@ -19,6 +19,7 @@ import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import com.algorand.android.HomeNavigationDirections
+import com.algorand.android.MainActivity
 import com.algorand.android.R
 import com.algorand.android.core.BaseFragment
 import com.algorand.android.databinding.FragmentQrCodeScannerBinding
@@ -206,6 +207,21 @@ abstract class BaseQrScannerFragment(
 
         nav(HomeNavigationDirections.actionGlobalConfirmKeyRegAccountSelectionFragment(txnDetail))
 
+        return true
+    }
+
+    override fun onDiscoverDeepLink(path: String): Boolean {
+        (activity as? MainActivity)?.navToDiscoverWithPath(path)
+        return true
+    }
+
+    override fun onCardsDeepLink(path: String): Boolean {
+        (activity as? MainActivity)?.navToCardsFragment(path)
+        return true
+    }
+
+    override fun onStakingDeepLink(path: String): Boolean {
+        (activity as? MainActivity)?.navToStakingFragment(path)
         return true
     }
 }

--- a/app/src/main/java/com/algorand/android/modules/staking/StakingViewModel.kt
+++ b/app/src/main/java/com/algorand/android/modules/staking/StakingViewModel.kt
@@ -12,11 +12,13 @@
 
 package com.algorand.android.modules.staking
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.algorand.android.BuildConfig.STAKING_MAINNET_URL
 import com.algorand.android.BuildConfig.STAKING_TESTNET_URL
 import com.algorand.android.discover.common.ui.model.WebViewError
 import com.algorand.android.discover.home.domain.model.DappInfo
+import com.algorand.android.modules.card.CardsFragmentArgs
 import com.algorand.android.modules.currency.domain.usecase.CurrencyUseCase
 import com.algorand.android.modules.perawebview.GetAuthorizedAddressesWebMessage
 import com.algorand.android.modules.perawebview.GetDeviceIdWebMessage
@@ -41,18 +43,23 @@ class StakingViewModel @Inject constructor(
     private val getDeviceIdWebMessage: GetDeviceIdWebMessage,
     private val parseOpenSystemBrowserUrl: ParseOpenSystemBrowserUrl,
     private val currencyUseCase: CurrencyUseCase,
-    private val gson: Gson
+    private val gson: Gson,
+    savedStateHandle: SavedStateHandle
 ) : BasePeraWebViewViewModel() {
+
+    private val args = CardsFragmentArgs.fromSavedStateHandle(savedStateHandle)
 
     private val _stakingPreviewFlow = MutableStateFlow<StakingPreview>(StakingPreview())
     val stakingPreviewFlow: StateFlow<StakingPreview?>
         get() = _stakingPreviewFlow.asStateFlow()
 
     fun getStakingUrl(): String {
-        return if (isConnectedToTestnet())
+        val stakingBaseUrl = if (isConnectedToTestnet())
             STAKING_TESTNET_URL
         else
             STAKING_MAINNET_URL
+
+        return "$stakingBaseUrl/${args.path.orEmpty()}"
     }
 
     fun getAuthorizedAddresses() {

--- a/app/src/main/res/navigation/home_navigation.xml
+++ b/app/src/main/res/navigation/home_navigation.xml
@@ -596,13 +596,24 @@
         android:id="@+id/cardsFragment"
         android:name="com.algorand.android.modules.card.CardsFragment"
         android:label="CardsFragment"
-        tools:layout="@layout/fragment_cards" />
+        tools:layout="@layout/fragment_cards">
+        <argument
+            android:name="path"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+    </fragment>
 
     <fragment
         android:id="@+id/stakingFragment"
         android:name="com.algorand.android.modules.staking.StakingFragment"
         android:label="StakingFragment"
         tools:layout="@layout/fragment_staking">
+        <argument
+            android:name="path"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
         <action
             android:id="@+id/action_stakingFragment_to_discoverDappNavigation"
             app:destination="@id/discoverDappNavigation">

--- a/wallet-sdk/src/androidUnitTest/kotlin/com/algorand/common/deeplink/CreateDeepLinkImplTest.kt
+++ b/wallet-sdk/src/androidUnitTest/kotlin/com/algorand/common/deeplink/CreateDeepLinkImplTest.kt
@@ -52,10 +52,19 @@ class CreateDeepLinkImplTest {
     private val discoverBrowserDeepLinkBuilder: DeepLinkBuilder = mockk {
         every { doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns false
     }
+    private val discoverDeepLinkBuilder: DeepLinkBuilder = mockk {
+        every { doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns false
+    }
     private val assetInboxDeepLinkBuilder: DeepLinkBuilder = mockk {
         every { doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns false
     }
     private val keyRegTransactionDeepLinkBuilder: DeepLinkBuilder = mockk {
+        every { doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns false
+    }
+    private val cardsDeepLinkBuilder: DeepLinkBuilder = mockk {
+        every { doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns false
+    }
+    private val stakingDeepLinkBuilder: DeepLinkBuilder = mockk {
         every { doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns false
     }
 
@@ -69,8 +78,11 @@ class CreateDeepLinkImplTest {
         webImportQrCodeDeepLinkBuilder,
         notificationGroupDeepLinkBuilder,
         discoverBrowserDeepLinkBuilder,
+        discoverDeepLinkBuilder,
         assetInboxDeepLinkBuilder,
-        keyRegTransactionDeepLinkBuilder
+        keyRegTransactionDeepLinkBuilder,
+        cardsDeepLinkBuilder,
+        stakingDeepLinkBuilder
     )
 
     @Test
@@ -124,6 +136,18 @@ class CreateDeepLinkImplTest {
         every { parseDeepLinkPayload("discoverBrowserDeepLink") } returns DEEP_LINK_PAYLOAD
 
         val result = sut("discoverBrowserDeepLink")
+
+        assertEquals(deepLink, result)
+    }
+
+    @Test
+    fun `EXPECT discover deep link`() {
+        val deepLink = DeepLink.Discover("path")
+        every { discoverDeepLinkBuilder.doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns true
+        every { discoverDeepLinkBuilder.createDeepLink(DEEP_LINK_PAYLOAD) } returns deepLink
+        every { parseDeepLinkPayload("discoverDeepLink") } returns DEEP_LINK_PAYLOAD
+
+        val result = sut("discoverDeepLink")
 
         assertEquals(deepLink, result)
     }
@@ -196,6 +220,30 @@ class CreateDeepLinkImplTest {
         every { keyRegTransactionDeepLinkBuilder.createDeepLink(DEEP_LINK_PAYLOAD) } returns deepLink
 
         val result = sut("keyRegTransactionDeepLink")
+
+        assertEquals(deepLink, result)
+    }
+
+    @Test
+    fun `EXPECT cards deep link`() {
+        val deepLink = DeepLink.Cards("path")
+        every { parseDeepLinkPayload("cardsDeepLink") } returns DEEP_LINK_PAYLOAD
+        every { cardsDeepLinkBuilder.doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns true
+        every { cardsDeepLinkBuilder.createDeepLink(DEEP_LINK_PAYLOAD) } returns deepLink
+
+        val result = sut("cardsDeepLink")
+
+        assertEquals(deepLink, result)
+    }
+
+    @Test
+    fun `EXPECT staking deep link`() {
+        val deepLink = DeepLink.Staking("path")
+        every { parseDeepLinkPayload("stakingDeepLink") } returns DEEP_LINK_PAYLOAD
+        every { stakingDeepLinkBuilder.doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns true
+        every { stakingDeepLinkBuilder.createDeepLink(DEEP_LINK_PAYLOAD) } returns deepLink
+
+        val result = sut("stakingDeepLink")
 
         assertEquals(deepLink, result)
     }

--- a/wallet-sdk/src/androidUnitTest/kotlin/com/algorand/common/deeplink/parser/ParseDeepLinkPayloadImplTest.kt
+++ b/wallet-sdk/src/androidUnitTest/kotlin/com/algorand/common/deeplink/parser/ParseDeepLinkPayloadImplTest.kt
@@ -81,6 +81,8 @@ class ParseDeepLinkPayloadImplTest {
             votelst = "votelst",
             votekd = "votekd",
             type = "type",
+            host = "perawallet.app",
+            path = "path",
             rawDeepLinkUri = URI
         )
         assertEquals(expected, result)
@@ -106,6 +108,7 @@ class ParseDeepLinkPayloadImplTest {
                 "votelst" to "votelst",
                 "votekd" to "votekd",
                 "votekey" to "votekey",
+                "path" to "path",
                 "fee" to "1"
             ),
             fragment = "",

--- a/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/builder/CardsDeepLinkBuilder.kt
+++ b/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/builder/CardsDeepLinkBuilder.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.common.deeplink.builder
+
+import com.algorand.common.deeplink.model.DeepLink
+import com.algorand.common.deeplink.model.DeepLinkPayload
+
+internal class CardsDeepLinkBuilder : DeepLinkBuilder {
+
+    override fun doesDeeplinkMeetTheRequirements(payload: DeepLinkPayload): Boolean {
+        return with(payload) {
+            host == CARDS_HOST_NAME && path != null
+        }
+    }
+
+    override fun createDeepLink(payload: DeepLinkPayload): DeepLink {
+        return DeepLink.Cards(path = payload.path.orEmpty())
+    }
+
+    companion object {
+        private const val CARDS_HOST_NAME = "cards"
+    }
+}

--- a/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/builder/DiscoverDeepLinkBuilder.kt
+++ b/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/builder/DiscoverDeepLinkBuilder.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.common.deeplink.builder
+
+import com.algorand.common.deeplink.model.DeepLink
+import com.algorand.common.deeplink.model.DeepLinkPayload
+
+internal class DiscoverDeepLinkBuilder : DeepLinkBuilder {
+
+    override fun doesDeeplinkMeetTheRequirements(payload: DeepLinkPayload): Boolean {
+        return with(payload) {
+            host == DISCOVER_HOST_NAME && path != null
+        }
+    }
+
+    override fun createDeepLink(payload: DeepLinkPayload): DeepLink {
+        return DeepLink.Discover(path = payload.path.orEmpty())
+    }
+
+    companion object {
+        private const val DISCOVER_HOST_NAME = "discover"
+    }
+}

--- a/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/builder/StakingDeepLinkBuilder.kt
+++ b/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/builder/StakingDeepLinkBuilder.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.common.deeplink.builder
+
+import com.algorand.common.deeplink.model.DeepLink
+import com.algorand.common.deeplink.model.DeepLinkPayload
+
+internal class StakingDeepLinkBuilder : DeepLinkBuilder {
+
+    override fun doesDeeplinkMeetTheRequirements(payload: DeepLinkPayload): Boolean {
+        return with(payload) {
+            host == STAKING_HOST_NAME && path != null
+        }
+    }
+
+    override fun createDeepLink(payload: DeepLinkPayload): DeepLink {
+        return DeepLink.Staking(path = payload.path.orEmpty())
+    }
+
+    companion object {
+        private const val STAKING_HOST_NAME = "staking"
+    }
+}

--- a/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/di/DeepLinkKoinModule.kt
+++ b/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/di/DeepLinkKoinModule.kt
@@ -16,10 +16,13 @@ import com.algorand.common.deeplink.builder.AccountAddressDeepLinkBuilder
 import com.algorand.common.deeplink.builder.AssetInboxDeepLinkBuilder
 import com.algorand.common.deeplink.builder.AssetOptInDeepLinkBuilder
 import com.algorand.common.deeplink.builder.AssetTransferDeepLinkBuilder
+import com.algorand.common.deeplink.builder.CardsDeepLinkBuilder
 import com.algorand.common.deeplink.builder.DiscoverBrowserDeepLinkBuilder
+import com.algorand.common.deeplink.builder.DiscoverDeepLinkBuilder
 import com.algorand.common.deeplink.builder.KeyRegTransactionDeepLinkBuilder
 import com.algorand.common.deeplink.builder.MnemonicDeepLinkBuilder
 import com.algorand.common.deeplink.builder.NotificationDeepLinkBuilder
+import com.algorand.common.deeplink.builder.StakingDeepLinkBuilder
 import com.algorand.common.deeplink.builder.WalletConnectConnectionDeepLinkBuilder
 import com.algorand.common.deeplink.builder.WebImportQrCodeDeepLinkBuilder
 import com.algorand.common.deeplink.parser.CreateDeepLink
@@ -65,8 +68,11 @@ val deepLinkModule = module {
             webImportQrCodeDeepLinkBuilder = WebImportQrCodeDeepLinkBuilder(),
             notificationGroupDeepLinkBuilder = NotificationDeepLinkBuilder(),
             discoverBrowserDeepLinkBuilder = DiscoverBrowserDeepLinkBuilder(),
+            discoverDeepLinkBuilder = DiscoverDeepLinkBuilder(),
             assetInboxDeepLinkBuilder = AssetInboxDeepLinkBuilder(),
-            keyRegTransactionDeepLinkBuilder = KeyRegTransactionDeepLinkBuilder()
+            keyRegTransactionDeepLinkBuilder = KeyRegTransactionDeepLinkBuilder(),
+            cardsDeepLinkBuilder = CardsDeepLinkBuilder(),
+            stakingDeepLinkBuilder = StakingDeepLinkBuilder()
         )
     }
 }

--- a/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/model/DeepLink.kt
+++ b/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/model/DeepLink.kt
@@ -65,6 +65,12 @@ sealed interface DeepLink {
 
     data class DiscoverBrowser(val webUrl: String) : DeepLink
 
+    data class Discover(val path: String) : DeepLink
+
+    data class Cards(val path: String) : DeepLink
+
+    data class Staking(val path: String) : DeepLink
+
     data class Notification(
         val address: String,
         val assetId: Long,

--- a/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/model/DeepLinkPayload.kt
+++ b/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/model/DeepLinkPayload.kt
@@ -34,6 +34,8 @@ internal data class DeepLinkPayload(
     val votelst: String? = null,
     val votekd: String? = null,
     val type: String? = null,
+    val host: String? = null,
+    val path: String? = null,
     val rawDeepLinkUri: String,
 )
 

--- a/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/parser/CreateDeepLinkImpl.kt
+++ b/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/parser/CreateDeepLinkImpl.kt
@@ -25,12 +25,16 @@ internal class CreateDeepLinkImpl(
     private val webImportQrCodeDeepLinkBuilder: DeepLinkBuilder,
     private val notificationGroupDeepLinkBuilder: DeepLinkBuilder,
     private val discoverBrowserDeepLinkBuilder: DeepLinkBuilder,
+    private val discoverDeepLinkBuilder: DeepLinkBuilder,
     private val assetInboxDeepLinkBuilder: DeepLinkBuilder,
-    private val keyRegTransactionDeepLinkBuilder: DeepLinkBuilder
+    private val keyRegTransactionDeepLinkBuilder: DeepLinkBuilder,
+    private val cardsDeepLinkBuilder: DeepLinkBuilder,
+    private val stakingDeepLinkBuilder: DeepLinkBuilder
 ) : CreateDeepLink {
 
     override fun invoke(url: String): DeepLink {
         val payload = parseDeepLinkPayload(url)
+
         return when {
             accountAddressDeepLinkBuilder.doesDeeplinkMeetTheRequirements(payload) -> {
                 accountAddressDeepLinkBuilder.createDeepLink(payload)
@@ -56,11 +60,20 @@ internal class CreateDeepLinkImpl(
             discoverBrowserDeepLinkBuilder.doesDeeplinkMeetTheRequirements(payload) -> {
                 discoverBrowserDeepLinkBuilder.createDeepLink(payload)
             }
+            discoverDeepLinkBuilder.doesDeeplinkMeetTheRequirements(payload) -> {
+                discoverDeepLinkBuilder.createDeepLink(payload)
+            }
             notificationGroupDeepLinkBuilder.doesDeeplinkMeetTheRequirements(payload) -> {
                 notificationGroupDeepLinkBuilder.createDeepLink(payload)
             }
             assetInboxDeepLinkBuilder.doesDeeplinkMeetTheRequirements(payload) -> {
                 assetInboxDeepLinkBuilder.createDeepLink(payload)
+            }
+            cardsDeepLinkBuilder.doesDeeplinkMeetTheRequirements(payload) -> {
+                cardsDeepLinkBuilder.createDeepLink(payload)
+            }
+            stakingDeepLinkBuilder.doesDeeplinkMeetTheRequirements(payload) -> {
+                stakingDeepLinkBuilder.createDeepLink(payload)
             }
             else -> DeepLink.Undefined(url)
         }

--- a/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/parser/ParseDeepLinkPayloadImpl.kt
+++ b/wallet-sdk/src/commonMain/kotlin/com/algorand/common/deeplink/parser/ParseDeepLinkPayloadImpl.kt
@@ -52,6 +52,8 @@ internal class ParseDeepLinkPayloadImpl(
             votelst = peraUri.getQueryParam(VOTELST_QUERY_KEY),
             votekd = peraUri.getQueryParam(VOTEKD_QUERY_KEY),
             type = peraUri.getQueryParam(TYPE_QUERY_KEY),
+            path = peraUri.getQueryParam(PATH_KEY),
+            host = peraUri.host,
             rawDeepLinkUri = url
         )
     }
@@ -71,5 +73,6 @@ internal class ParseDeepLinkPayloadImpl(
         const val VOTEKD_QUERY_KEY = "votekd"
         const val VOTEKEY_QUERY_KEY = "votekey"
         const val FEE_QUERY_KEY = "fee"
+        const val PATH_KEY = "path"
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
- Added support for the deeplinks listed below: 

> 1. perawallet://cards?path=onboarding/select-country
> 2. perawallet://cards?path=card/deposit
> 3. perawallet://cards?path=card/withdraw
> 4. perawallet://cards?path=card/transactions
> 5. perawallet://staking?path=test
> 6. perawallet://discover?path=main/browser
> 7. perawallet://discover?path=main/markets
> 8. perawallet://discover?path=token-detail/31566704
> 9. perawallet://discover?path=token-detail/algo
> 10. perawallet://discover?path=news
> 11. perawallet://discover?path=news/3621282894169872116

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1209

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?
