### PR TITLE
PERA-1491 :: Add bouncycastle init to AlgoSdkUtilsImpl.kt

### DIFF
--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/AlgoSdkUtilsImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/AlgoSdkUtilsImpl.kt
@@ -13,9 +13,15 @@
 package com.algorand.wallet.algosdk
 
 import com.algorand.algosdk.crypto.Address
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.security.Security
 import javax.inject.Inject
 
 internal class AlgoSdkUtilsImpl @Inject constructor() : AlgoSdkUtils {
+    init {
+        Security.removeProvider("BC")
+        Security.insertProviderAt(BouncyCastleProvider(), 0)
+    }
 
     override fun isValidAddress(address: String?): Boolean {
         if (address.isNullOrBlank()) {


### PR DESCRIPTION
# Pull Request Template

## Description
- Add bouncycastle init to `AlgoSdkUtilsImpl.kt`

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1491

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- This is a quick fix so we can unblock `5.202501.0` build....we can optimize later to only put the bouncycastle init in one spot
