### PR TITLE
PERA-1627 :: Move getRekeyedAccountAddresses function to the core module

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/removeaccount/ui/RemoveAccountConfirmationViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/removeaccount/ui/RemoveAccountConfirmationViewModel.kt
@@ -13,9 +13,11 @@
 package com.algorand.android.modules.accountdetail.removeaccount.ui
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.algorand.android.core.BaseViewModel
 import com.algorand.android.modules.accountdetail.removeaccount.ui.model.RemoveAccountConfirmationPreview
 import com.algorand.android.modules.accountdetail.removeaccount.ui.usecase.RemoveAccountConfirmationPreviewUseCase
+import com.algorand.android.utils.launchIO
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,8 +41,13 @@ class RemoveAccountConfirmationViewModel @Inject constructor(
         get() = _removeAccountConfirmationPreviewFlow
 
     fun onRemoveAccountClick() {
-        _removeAccountConfirmationPreviewFlow.update { preview ->
-            removeAccountConfirmationPreviewUseCase.updatePreviewWithRemoveAccountConfirmation(preview, accountAddress)
+        viewModelScope.launchIO {
+            _removeAccountConfirmationPreviewFlow.update { preview ->
+                removeAccountConfirmationPreviewUseCase.updatePreviewWithRemoveAccountConfirmation(
+                    preview,
+                    accountAddress
+                )
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/removeaccount/ui/usecase/RemoveAccountConfirmationPreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/removeaccount/ui/usecase/RemoveAccountConfirmationPreviewUseCase.kt
@@ -19,11 +19,13 @@ import com.algorand.android.modules.accountdetail.removeaccount.ui.mapper.Remove
 import com.algorand.android.modules.accountdetail.removeaccount.ui.model.RemoveAccountConfirmationPreview
 import com.algorand.android.usecase.AccountDetailUseCase
 import com.algorand.android.utils.Event
+import com.algorand.wallet.account.detail.domain.usecase.GetLocalRekeyedAccountCount
 import javax.inject.Inject
 
 class RemoveAccountConfirmationPreviewUseCase @Inject constructor(
     private val accountDetailUseCase: AccountDetailUseCase,
-    private val removeAccountConfirmationPreviewMapper: RemoveAccountConfirmationPreviewMapper
+    private val removeAccountConfirmationPreviewMapper: RemoveAccountConfirmationPreviewMapper,
+    private val getLocalRekeyedAccountCount: GetLocalRekeyedAccountCount
 ) {
 
     fun getRemoveAccountConfirmationPreview(): RemoveAccountConfirmationPreview {
@@ -41,7 +43,7 @@ class RemoveAccountConfirmationPreviewUseCase @Inject constructor(
         }
     }
 
-    fun updatePreviewWithRemoveAccountConfirmation(
+    suspend fun updatePreviewWithRemoveAccountConfirmation(
         preview: RemoveAccountConfirmationPreview,
         accountAddress: String
     ): RemoveAccountConfirmationPreview {
@@ -55,13 +57,13 @@ class RemoveAccountConfirmationPreviewUseCase @Inject constructor(
             return preview.copy(navBackEvent = Event(true))
         }
 
-        val rekeyedAccountAddresses = accountDetailUseCase.getRekeyedAccountAddresses(accountAddress)
+        val rekeyedAccountCount = getLocalRekeyedAccountCount(accountAddress)
 
         return preview.copy(
             showGlobalErrorEvent = Event(
                 PluralAnnotatedString(
                     pluralStringResId = R.plurals.you_can_t_remove_this_account,
-                    quantity = rekeyedAccountAddresses.count()
+                    quantity = rekeyedAccountCount
                 )
             ),
             navBackEvent = Event(false)

--- a/app/src/main/kotlin/com/algorand/android/usecase/AccountDetailUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/usecase/AccountDetailUseCase.kt
@@ -165,17 +165,4 @@ class AccountDetailUseCase @Inject constructor(
             authAccountAddress == accountAddress && getAccountType(cachedAccountAddress) != Account.Type.WATCH
         }
     }
-
-    fun getRekeyedAccountAddresses(accountAddress: String): List<String> {
-        return getCachedAccountDetails().mapNotNull { accountDetail ->
-            val cachedAccountAddress = accountDetail.data?.account?.address ?: return@mapNotNull null
-            val authAccountDetail = getAuthAccount(cachedAccountAddress)?.data
-            val authAccountAddress = authAccountDetail?.account?.address
-            if (authAccountAddress == accountAddress && getAccountType(cachedAccountAddress) != Account.Type.WATCH) {
-                cachedAccountAddress
-            } else {
-                null
-            }
-        }
-    }
 }

--- a/app/src/test/kotlin/com/algorand/android/modules/keyreg/domain/usecase/CreateKeyRegTransactionUseCaseTest.kt
+++ b/app/src/test/kotlin/com/algorand/android/modules/keyreg/domain/usecase/CreateKeyRegTransactionUseCaseTest.kt
@@ -23,7 +23,6 @@ import com.algorand.android.modules.algosdk.domain.usecase.BuildKeyRegOnlineTran
 import com.algorand.android.modules.keyreg.domain.model.KeyRegTransaction
 import com.algorand.android.modules.keyreg.ui.model.KeyRegTransactionDetail
 import com.algorand.android.modules.transaction.domain.GetTransactionParams
-import com.algorand.test.peraFixture
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -122,7 +121,14 @@ class CreateKeyRegTransactionUseCaseTest {
             note = "note",
             xnote = null
         )
-        val TRANSACTION_PARAMS = peraFixture<TransactionParams>()
+        val TRANSACTION_PARAMS = TransactionParams(
+            minFee = 1000,
+            fee = 0,
+            genesisId = "testnet-v1.0",
+            genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+            lastRound = 14954213L
+        )
+
         val ONLINE_TXN_PAYLOAD = OnlineKeyRegTransactionPayload(
             senderAddress = ONLINE_KEY_REG_TXN_DETAIL.address,
             selectionPublicKey = ONLINE_KEY_REG_TXN_DETAIL.selectionPublicKey.orEmpty(),

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/di/AccountDetailModule.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/di/AccountDetailModule.kt
@@ -22,6 +22,8 @@ import com.algorand.wallet.account.detail.domain.usecase.GetAccountType
 import com.algorand.wallet.account.detail.domain.usecase.GetAccountTypeUseCase
 import com.algorand.wallet.account.detail.domain.usecase.GetAccountsDetails
 import com.algorand.wallet.account.detail.domain.usecase.GetAccountsDetailsUseCase
+import com.algorand.wallet.account.detail.domain.usecase.GetLocalRekeyedAccountCount
+import com.algorand.wallet.account.detail.domain.usecase.GetLocalRekeyedAccountCountUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -47,4 +49,7 @@ internal object AccountDetailModule {
 
     @Provides
     fun provideGetAccountDetail(useCase: GetAccountDetailUseCase): GetAccountDetail = useCase
+
+    @Provides
+    fun provideGetRekeyedAccountCount(useCase: GetLocalRekeyedAccountCountUseCase): GetLocalRekeyedAccountCount = useCase
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/usecase/AccountDetailUseCases.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/usecase/AccountDetailUseCases.kt
@@ -36,3 +36,7 @@ fun interface GetAccountDetail {
 fun interface GetAccountsDetails {
     suspend operator fun invoke(): List<AccountDetail>
 }
+
+fun interface GetLocalRekeyedAccountCount {
+    suspend operator fun invoke(authAddress: String): Int
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/usecase/GetLocalRekeyedAccountCountUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/usecase/GetLocalRekeyedAccountCountUseCase.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.detail.domain.usecase
+
+import com.algorand.wallet.account.info.domain.repository.AccountInformationRepository
+import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountsAddresses
+import javax.inject.Inject
+
+internal class GetLocalRekeyedAccountCountUseCase @Inject constructor(
+    private val getLocalAccountsAddresses: GetLocalAccountsAddresses,
+    private val accountInformationRepository: AccountInformationRepository
+) : GetLocalRekeyedAccountCount {
+
+    override suspend fun invoke(authAddress: String): Int {
+        val localAccountsAddresses = getLocalAccountsAddresses()
+        return accountInformationRepository.getFilteredRekeyedAccountCount(authAddress, localAccountsAddresses)
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/dao/AccountInformationDao.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/dao/AccountInformationDao.kt
@@ -31,6 +31,9 @@ internal interface AccountInformationDao {
     @Query("SELECT * FROM account_information WHERE :algoAddress = algo_address")
     suspend fun get(algoAddress: String): AccountInformationEntity?
 
+    @Query("SELECT COUNT(*) FROM account_information WHERE algo_address IN (:algoAddresses) AND :authAddress = auth_algo_address")
+    fun getAuthAccountCountFilteredByAddress(authAddress: String, algoAddresses: List<String>): Int
+
     @Query("SELECT * FROM account_information WHERE :algoAddress = algo_address")
     fun getAsFlow(algoAddress: String): Flow<AccountInformationEntity?>
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/repository/AccountInformationRepositoryImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/repository/AccountInformationRepositoryImpl.kt
@@ -25,7 +25,6 @@ import com.algorand.wallet.account.info.domain.model.AssetStatus
 import com.algorand.wallet.account.info.domain.repository.AccountInformationRepository
 import com.algorand.wallet.foundation.PeraResult
 import com.algorand.wallet.foundation.network.utils.request
-import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -33,6 +32,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
 internal class AccountInformationRepositoryImpl @Inject constructor(
     private val indexerApi: AccountInformationApiService,
@@ -165,6 +165,10 @@ internal class AccountInformationRepositoryImpl @Inject constructor(
 
     override suspend fun getRekeyAuthAddress(address: String): String? {
         return accountInformationDao.getRekeyAuthAddress(address)
+    }
+
+    override suspend fun getFilteredRekeyedAccountCount(authAddress: String, algoAddresses: List<String>): Int {
+        return accountInformationDao.getAuthAccountCountFilteredByAddress(authAddress, algoAddresses)
     }
 
     companion object {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/repository/AccountInformationRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/repository/AccountInformationRepository.kt
@@ -50,4 +50,6 @@ internal interface AccountInformationRepository {
     suspend fun getFailedAccountInformation(): List<String>
 
     suspend fun getRekeyAuthAddress(address: String): String?
+    
+    suspend fun getFilteredRekeyedAccountCount(authAddress: String, algoAddresses: List<String>): Int
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/database/dao/Algo25Dao.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/database/dao/Algo25Dao.kt
@@ -31,6 +31,9 @@ internal interface Algo25Dao {
     @Query("SELECT * FROM algo_25")
     suspend fun getAll(): List<Algo25Entity>
 
+    @Query("SELECT algo_address FROM algo_25")
+    suspend fun getAllAddresses(): List<String>
+
     @Query("SELECT * FROM algo_25")
     fun getAllAsFlow(): Flow<List<Algo25Entity>>
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/database/dao/HdKeyDao.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/database/dao/HdKeyDao.kt
@@ -31,6 +31,9 @@ internal interface HdKeyDao {
     @Query("SELECT * FROM hd_keys")
     suspend fun getAll(): List<HdKeyEntity>
 
+    @Query("SELECT algo_address FROM hd_keys")
+    suspend fun getAllAddresses(): List<String>
+
     @Query("SELECT * FROM hd_keys")
     fun getAllAsFlow(): Flow<List<HdKeyEntity>>
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/database/dao/LedgerBleDao.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/database/dao/LedgerBleDao.kt
@@ -31,6 +31,9 @@ internal interface LedgerBleDao {
     @Query("SELECT * FROM ledger_ble")
     suspend fun getAll(): List<LedgerBleEntity>
 
+    @Query("SELECT algo_address FROM ledger_ble")
+    suspend fun getAllAddresses(): List<String>
+
     @Query("SELECT * FROM ledger_ble")
     fun getAllAsFlow(): Flow<List<LedgerBleEntity>>
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/database/dao/NoAuthDao.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/database/dao/NoAuthDao.kt
@@ -31,6 +31,9 @@ internal interface NoAuthDao {
     @Query("SELECT * FROM no_auth")
     suspend fun getAll(): List<NoAuthEntity>
 
+    @Query("SELECT algo_address FROM no_auth")
+    suspend fun getAllAddresses(): List<String>
+
     @Query("SELECT * FROM no_auth")
     fun getAllAsFlow(): Flow<List<NoAuthEntity>>
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/repository/Algo25AccountRepositoryImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/repository/Algo25AccountRepositoryImpl.kt
@@ -50,6 +50,12 @@ internal class Algo25AccountRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getAllAddresses(): List<String> {
+        return withContext(coroutineDispatcher) {
+            algo25Dao.getAllAddresses()
+        }
+    }
+
     override suspend fun getAccount(address: String): Algo25? {
         return withContext(coroutineDispatcher) {
             algo25Dao.get(address)?.let { algo25Mapper(it) }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/repository/HdKeyAccountRepositoryImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/repository/HdKeyAccountRepositoryImpl.kt
@@ -48,6 +48,12 @@ internal class HdKeyAccountRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getAllAddresses(): List<String> {
+        return withContext(coroutineDispatcher) {
+            hdKeyDao.getAllAddresses()
+        }
+    }
+
     override suspend fun getAccount(address: String): HdKey? {
         return withContext(coroutineDispatcher) {
             hdKeyDao.get(address)?.let { hdKeyMapper(it) }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/repository/LedgerBleAccountRepositoryImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/repository/LedgerBleAccountRepositoryImpl.kt
@@ -48,6 +48,12 @@ internal class LedgerBleAccountRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getAllAddresses(): List<String> {
+        return withContext(coroutineDispatcher) {
+            ledgerBleDao.getAllAddresses()
+        }
+    }
+
     override suspend fun getAccount(address: String): LedgerBle? {
         return withContext(coroutineDispatcher) {
             val ledgerBleEntity = ledgerBleDao.get(address)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/repository/NoAuthAccountRepositoryImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/data/repository/NoAuthAccountRepositoryImpl.kt
@@ -48,6 +48,12 @@ internal class NoAuthAccountRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getAllAddresses(): List<String> {
+        return withContext(coroutineDispatcher) {
+            noAuthDao.getAllAddresses()
+        }
+    }
+
     override suspend fun getAccount(address: String): NoAuth? {
         return withContext(coroutineDispatcher) {
             val noAuthEntity = noAuthDao.get(address)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/di/LocalAccountsModule.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/di/LocalAccountsModule.kt
@@ -49,6 +49,8 @@ import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountCountFlow
 import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountCountFlowUseCase
 import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountUseCase
 import com.algorand.wallet.account.local.domain.usecase.GetLocalAccounts
+import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountsAddresses
+import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountsAddressesUseCase
 import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountsUseCase
 import com.algorand.wallet.account.local.domain.usecase.GetSecretKey
 import com.algorand.wallet.account.local.domain.usecase.IsThereAnyAccountWithAddress
@@ -175,6 +177,11 @@ internal object LocalAccountsModule {
     fun provideGetLocalAccounts(
         useCase: GetLocalAccountsUseCase
     ): GetLocalAccounts = useCase
+
+    @Provides
+    fun provideGetLocalAccountsAddresses(
+        useCase: GetLocalAccountsAddressesUseCase
+    ): GetLocalAccountsAddresses = useCase
 
     @Provides
     fun provideGetLedgerBleAccount(repository: LedgerBleAccountRepository): GetLedgerBleAccount {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/model/LocalAccount.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/model/LocalAccount.kt
@@ -24,7 +24,23 @@ sealed interface LocalAccount {
         val change: Int,
         val keyIndex: Int,
         val derivationType: Int
-    ) : LocalAccount
+    ) : LocalAccount {
+
+        override fun equals(other: Any?): Boolean {
+            return other is HdKey &&
+                    algoAddress == other.algoAddress &&
+                    publicKey.contentEquals(other.publicKey) &&
+                    seedId == other.seedId &&
+                    account == other.account &&
+                    change == other.change &&
+                    keyIndex == other.keyIndex &&
+                    derivationType == other.derivationType
+        }
+
+        override fun hashCode(): Int {
+            return algoAddress.hashCode() + publicKey.contentHashCode() + seedId + account + change + keyIndex + derivationType
+        }
+    }
 
     data class Algo25(override val algoAddress: String) : LocalAccount
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/repository/Algo25AccountRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/repository/Algo25AccountRepository.kt
@@ -23,6 +23,8 @@ internal interface Algo25AccountRepository {
 
     suspend fun getAll(): List<LocalAccount.Algo25>
 
+    suspend fun getAllAddresses(): List<String>
+
     suspend fun getAccount(address: String): LocalAccount.Algo25?
 
     suspend fun addAccount(account: LocalAccount.Algo25, privateKey: ByteArray)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/repository/HdKeyAccountRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/repository/HdKeyAccountRepository.kt
@@ -23,6 +23,8 @@ internal interface HdKeyAccountRepository {
 
     suspend fun getAll(): List<LocalAccount.HdKey>
 
+    suspend fun getAllAddresses(): List<String>
+
     suspend fun getAccount(address: String): LocalAccount.HdKey?
 
     suspend fun addAccount(account: LocalAccount.HdKey, privateKey: ByteArray)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/repository/LedgerBleAccountRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/repository/LedgerBleAccountRepository.kt
@@ -23,6 +23,8 @@ internal interface LedgerBleAccountRepository {
 
     suspend fun getAll(): List<LocalAccount.LedgerBle>
 
+    suspend fun getAllAddresses(): List<String>
+
     suspend fun getAccount(address: String): LocalAccount.LedgerBle?
 
     suspend fun addAccount(account: LocalAccount.LedgerBle)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/repository/NoAuthAccountRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/repository/NoAuthAccountRepository.kt
@@ -23,6 +23,8 @@ internal interface NoAuthAccountRepository {
 
     suspend fun getAll(): List<LocalAccount.NoAuth>
 
+    suspend fun getAllAddresses(): List<String>
+
     suspend fun getAccount(address: String): LocalAccount.NoAuth?
 
     suspend fun addAccount(account: LocalAccount.NoAuth)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/usecase/GetLocalAccountsAddressesUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/usecase/GetLocalAccountsAddressesUseCase.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.local.domain.usecase
+
+import com.algorand.wallet.account.local.domain.repository.Algo25AccountRepository
+import com.algorand.wallet.account.local.domain.repository.HdKeyAccountRepository
+import com.algorand.wallet.account.local.domain.repository.LedgerBleAccountRepository
+import com.algorand.wallet.account.local.domain.repository.NoAuthAccountRepository
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.withContext
+
+internal class GetLocalAccountsAddressesUseCase @Inject constructor(
+    private val hdKeyAccountRepository: HdKeyAccountRepository,
+    private val algo25AccountRepository: Algo25AccountRepository,
+    private val ledgerBleAccountRepository: LedgerBleAccountRepository,
+    private val noAuthAccountRepository: NoAuthAccountRepository,
+    private val dispatcher: CoroutineDispatcher
+) : GetLocalAccountsAddresses {
+
+    override suspend fun invoke(): List<String> {
+        return withContext(dispatcher) {
+            val deferredHdKeyAccountsAddresses = async { hdKeyAccountRepository.getAllAddresses() }
+            val deferredAlgo25Accounts = async { algo25AccountRepository.getAllAddresses() }
+            val deferredLedgerBleAccounts = async { ledgerBleAccountRepository.getAllAddresses() }
+            val deferredNoAuthAccounts = async { noAuthAccountRepository.getAllAddresses() }
+            awaitAll(
+                deferredHdKeyAccountsAddresses,
+                deferredAlgo25Accounts,
+                deferredLedgerBleAccounts,
+                deferredNoAuthAccounts
+            ).flatten()
+        }
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/usecase/LocalAccountUseCases.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/usecase/LocalAccountUseCases.kt
@@ -85,6 +85,10 @@ fun interface GetLocalAccounts {
     suspend operator fun invoke(): List<LocalAccount>
 }
 
+fun interface GetLocalAccountsAddresses {
+    suspend operator fun invoke(): List<String>
+}
+
 fun interface GetLocalAccount {
     suspend operator fun invoke(address: String): LocalAccount?
 }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/core/domain/usecase/GetLocalAccountsAddressesUseCaseTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/core/domain/usecase/GetLocalAccountsAddressesUseCaseTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.core.domain.usecase
+
+import com.algorand.wallet.account.local.domain.repository.Algo25AccountRepository
+import com.algorand.wallet.account.local.domain.repository.HdKeyAccountRepository
+import com.algorand.wallet.account.local.domain.repository.LedgerBleAccountRepository
+import com.algorand.wallet.account.local.domain.repository.NoAuthAccountRepository
+import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountsAddressesUseCase
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.wheneverBlocking
+
+class GetLocalAccountsAddressesUseCaseTest {
+
+    private val hdKeyAccountRepository: HdKeyAccountRepository = mock()
+    private val algo25AccountRepository: Algo25AccountRepository = mock()
+    private val ledgerBleAccountRepository: LedgerBleAccountRepository = mock()
+    private val noAuthAccountRepository: NoAuthAccountRepository = mock()
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var sut: GetLocalAccountsAddressesUseCase
+
+    @Before
+    fun setUp() {
+        sut = GetLocalAccountsAddressesUseCase(
+            hdKeyAccountRepository,
+            algo25AccountRepository,
+            ledgerBleAccountRepository,
+            noAuthAccountRepository,
+            testDispatcher
+        )
+    }
+
+    @Test
+    fun `EXPECT all addresses combined from different repositories`() = runTest(testDispatcher) {
+        val hdKeyAddresses = listOf("hdKey1", "hdKey2")
+        val algo25Addresses = listOf("algo25-1")
+        val ledgerBleAddresses = listOf("ledger-1", "ledger-2")
+        val noAuthAddresses = listOf("noAuth1")
+
+        wheneverBlocking { hdKeyAccountRepository.getAllAddresses() } doReturn hdKeyAddresses
+        wheneverBlocking { algo25AccountRepository.getAllAddresses() } doReturn algo25Addresses
+        wheneverBlocking { ledgerBleAccountRepository.getAllAddresses() } doReturn ledgerBleAddresses
+        wheneverBlocking { noAuthAccountRepository.getAllAddresses() } doReturn noAuthAddresses
+
+        val result = sut.invoke()
+
+        val expected = hdKeyAddresses + algo25Addresses + ledgerBleAddresses + noAuthAddresses
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `EXPECT empty list when all repositories return empty`() = runTest(testDispatcher) {
+        wheneverBlocking { hdKeyAccountRepository.getAllAddresses() } doReturn emptyList()
+        wheneverBlocking { algo25AccountRepository.getAllAddresses() } doReturn emptyList()
+        wheneverBlocking { ledgerBleAccountRepository.getAllAddresses() } doReturn emptyList()
+        wheneverBlocking { noAuthAccountRepository.getAllAddresses() } doReturn emptyList()
+
+        val result = sut.invoke()
+
+        assertEquals(emptyList<String>(), result)
+    }
+}

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/detail/domain/usecase/GetLocalRekeyedAccountCountUseCaseTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/detail/domain/usecase/GetLocalRekeyedAccountCountUseCaseTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.detail.domain.usecase
+
+import com.algorand.wallet.account.info.domain.repository.AccountInformationRepository
+import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountsAddresses
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GetLocalRekeyedAccountCountUseCaseTest {
+
+    private val getLocalAccountsAddresses: GetLocalAccountsAddresses = mockk()
+    private val accountInformationRepository: AccountInformationRepository = mockk()
+    private val sut = GetLocalRekeyedAccountCountUseCase(getLocalAccountsAddresses, accountInformationRepository)
+
+    @Test
+    fun `EXPECT rekeyed account count WHEN invoke is called`() = runTest {
+        val authAddress = "authAddress"
+        val localAddresses = listOf("address1", "address2")
+        val expectedCount = 2
+
+        coEvery { getLocalAccountsAddresses() } returns localAddresses
+        coEvery { accountInformationRepository.getFilteredRekeyedAccountCount(authAddress, localAddresses) } returns expectedCount
+
+        val result = sut.invoke(authAddress)
+
+        coVerify { getLocalAccountsAddresses() }
+        coVerify { accountInformationRepository.getFilteredRekeyedAccountCount(authAddress, localAddresses) }
+        assertEquals(expectedCount, result)
+    }
+}

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/repository/AccountInformationRepositoryImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/repository/AccountInformationRepositoryImplTest.kt
@@ -12,6 +12,7 @@
 
 package com.algorand.wallet.account.info.data.repository
 
+import com.algorand.wallet.account.info.data.cache.AccountInformationErrorCache
 import com.algorand.wallet.account.info.data.database.dao.AccountInformationDao
 import com.algorand.wallet.account.info.data.database.dao.AssetHoldingDao
 import com.algorand.wallet.account.info.data.mapper.AccountInformationMapper
@@ -35,6 +36,7 @@ class AccountInformationRepositoryImplTest {
     private val assetHoldingMapper: AssetHoldingMapper = mockk()
     private val assetStatusEntityMapper: AssetStatusEntityMapper = mockk()
     private val assetHoldingEntityMapper: AssetHoldingEntityMapper = mockk()
+    private val accountInformationErrorCache: AccountInformationErrorCache = mockk()
     private val sut = AccountInformationRepositoryImpl(
         indexerApi,
         accountInformationMapper,
@@ -44,7 +46,8 @@ class AccountInformationRepositoryImplTest {
         mockk(),
         mockk(),
         assetStatusEntityMapper,
-        assetHoldingEntityMapper
+        assetHoldingEntityMapper,
+        accountInformationErrorCache
     )
 
     @Test

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/repository/AccountInformationRepositoryImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/repository/AccountInformationRepositoryImplTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.info.data.repository
+
+import com.algorand.wallet.account.info.data.database.dao.AccountInformationDao
+import com.algorand.wallet.account.info.data.database.dao.AssetHoldingDao
+import com.algorand.wallet.account.info.data.mapper.AccountInformationMapper
+import com.algorand.wallet.account.info.data.mapper.AssetHoldingEntityMapper
+import com.algorand.wallet.account.info.data.mapper.AssetHoldingMapper
+import com.algorand.wallet.account.info.data.mapper.AssetStatusEntityMapper
+import com.algorand.wallet.account.info.data.service.AccountInformationApiService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AccountInformationRepositoryImplTest {
+
+    private val indexerApi: AccountInformationApiService = mockk()
+    private val accountInformationMapper: AccountInformationMapper = mockk()
+    private val accountInformationDao: AccountInformationDao = mockk()
+    private val assetHoldingDao: AssetHoldingDao = mockk()
+    private val assetHoldingMapper: AssetHoldingMapper = mockk()
+    private val assetStatusEntityMapper: AssetStatusEntityMapper = mockk()
+    private val assetHoldingEntityMapper: AssetHoldingEntityMapper = mockk()
+    private val sut = AccountInformationRepositoryImpl(
+        indexerApi,
+        accountInformationMapper,
+        accountInformationDao,
+        assetHoldingDao,
+        assetHoldingMapper,
+        mockk(),
+        mockk(),
+        assetStatusEntityMapper,
+        assetHoldingEntityMapper
+    )
+
+    @Test
+    fun `EXPECT rekeyed account count WHEN getFilteredRekeyedAccountCount is invoked`() = runTest {
+        val authAddress = "authAddress"
+        val algoAddresses = listOf("address1", "address2")
+        val expectedCount = 2
+
+        coEvery {
+            accountInformationDao.getAuthAccountCountFilteredByAddress(authAddress, algoAddresses)
+        } returns expectedCount
+
+        val result = sut.getFilteredRekeyedAccountCount(authAddress, algoAddresses)
+
+        coVerify { accountInformationDao.getAuthAccountCountFilteredByAddress(authAddress, algoAddresses) }
+        assertEquals(expectedCount, result)
+    }
+
+}

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/local/data/repository/Algo25AccountRepositoryImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/local/data/repository/Algo25AccountRepositoryImplTest.kt
@@ -12,6 +12,7 @@
 
 package com.algorand.wallet.account.local.data.repository
 
+import com.algorand.test.test
 import com.algorand.wallet.account.local.data.database.dao.Algo25Dao
 import com.algorand.wallet.account.local.data.database.model.Algo25Entity
 import com.algorand.wallet.account.local.data.mapper.entity.Algo25EntityMapper
@@ -21,8 +22,8 @@ import com.algorand.wallet.encryption.AESPlatformManager
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -39,6 +40,29 @@ class Algo25AccountRepositoryImplTest {
         algo25Mapper,
         aesPlatformManager
     )
+
+    @Test
+    fun `EXPECT all accounts as flow WHEN getAllAsFlow is invoked`() = runTest {
+        val entitiesFlow = MutableStateFlow(
+            listOf(
+                Algo25Entity("address1", byteArrayOf()),
+                Algo25Entity("address2", byteArrayOf())
+            )
+        )
+        val expectedAccounts = listOf(
+            LocalAccount.Algo25("address1"),
+            LocalAccount.Algo25("address2")
+        )
+
+        coEvery { algo25Dao.getAllAsFlow() } returns entitiesFlow
+        coEvery { algo25Mapper(entitiesFlow.value[0]) } returns expectedAccounts[0]
+        coEvery { algo25Mapper(entitiesFlow.value[1]) } returns expectedAccounts[1]
+
+        val testObserver = sut.getAllAsFlow().test()
+        entitiesFlow.update { emptyList() }
+
+        testObserver.assertValueHistory(expectedAccounts, emptyList())
+    }
 
     @Test
     fun `EXPECT all accounts WHEN getAll is invoked`() = runTest {
@@ -60,18 +84,49 @@ class Algo25AccountRepositoryImplTest {
         assertEquals(expectedReturnedList, localAccounts)
     }
 
-//    @Test
-//    fun `EXPECT account WHEN account was registered before`() = runTest {
-//        coEvery { algo25Mapper(Algo25Entity("address", "encryptedSecretKey".toByteArray())) }
-//            .returns(LocalAccount.Algo25("address", byteArrayOf(1, 2, 3)))
-//        coEvery { algo25Dao.get("address") } returns Algo25Entity("address", "encryptedSecretKey".toByteArray())
-//
-//        val localAccount = sut.getAccount("address")
-//
-//        val expectedAccount = LocalAccount.Algo25("address", byteArrayOf(1, 2, 3))
-//        coVerify(exactly = 1) { algo25Dao.get("address") }
-//        assertEquals(expectedAccount, localAccount)
-//    }
+    @Test
+    fun `EXPECT account WHEN getAccount is invoked`() = runTest {
+        val entity = Algo25Entity("address", "encryptedSecretKey".toByteArray())
+        coEvery { algo25Dao.get("address") } returns entity
+        coEvery { algo25Mapper(entity) } returns LocalAccount.Algo25("address")
+
+        val localAccount = sut.getAccount("address")
+
+        val expectedAccount = LocalAccount.Algo25("address")
+        coVerify { algo25Dao.get("address") }
+        assertEquals(expectedAccount, localAccount)
+    }
+
+    @Test
+    fun `EXPECT null WHEN getAccount is invoked with a non-existent address`() = runTest {
+        coEvery { algo25Dao.get("non_existent_address") } returns null
+
+        val result = sut.getAccount("non_existent_address")
+
+        coVerify { algo25Dao.get("non_existent_address") }
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `EXPECT account count as flow WHEN getAccountCountAsFlow is invoked`() = runTest {
+        val expectedCountFlow = MutableStateFlow(5)
+        coEvery { algo25Dao.getTableSizeAsFlow() } returns expectedCountFlow
+
+        val testObserver = sut.getAccountCountAsFlow().test()
+        expectedCountFlow.update { 10 }
+
+        testObserver.assertValueHistory(5, 10)
+    }
+
+    @Test
+    fun `EXPECT all addresses WHEN getAllAddresses is invoked`() = runTest {
+        val addresses = listOf("address1", "address2", "address3")
+        coEvery { algo25Dao.getAllAddresses() } returns addresses
+
+        val result = sut.getAllAddresses()
+
+        assertEquals(addresses, result)
+    }
 
     @Test
     fun `EXPECT account to be added to database WHEN addAccount is invoked`() = runTest {
@@ -87,7 +142,7 @@ class Algo25AccountRepositoryImplTest {
     }
 
     @Test
-    fun `EXPECT account to be deleted from database  WHEN deleteAccount is invoked`() = runTest {
+    fun `EXPECT account to be deleted from database WHEN deleteAccount is invoked`() = runTest {
         val address = "address"
         coEvery { algo25Dao.delete(address) } returns Unit
 
@@ -106,24 +161,24 @@ class Algo25AccountRepositoryImplTest {
     }
 
     @Test
-    fun `EXPECT all accounts as flow WHEN getAllAsFlow is invoked`() {
-        val entities = listOf(
-            Algo25Entity("encryptedAddress1", "encryptedSecretKey1".toByteArray()),
-            Algo25Entity("encryptedAddress2", "encryptedSecretKey2".toByteArray())
-        )
-        val localAccounts = listOf(
-            LocalAccount.Algo25("address1"),
-            LocalAccount.Algo25("address2")
-        )
-        coEvery { algo25Dao.getAllAsFlow() } returns flowOf(entities)
-        coEvery { algo25Mapper(entities[0]) } returns localAccounts[0]
-        coEvery { algo25Mapper(entities[1]) } returns localAccounts[1]
+    fun `EXPECT secret key WHEN getSecretKey is invoked`() = runTest {
+        val encryptedSK = "encryptedSecretKey".toByteArray()
+        val decryptedSK = byteArrayOf(1, 2, 3)
+        coEvery { algo25Dao.get("address") } returns Algo25Entity("address", encryptedSK)
+        coEvery { aesPlatformManager.decryptByteArray(encryptedSK) } returns decryptedSK
 
-        val flow = sut.getAllAsFlow()
+        val result = sut.getSecretKey("address")
 
-        runTest {
-            val returnedList = flow.toList()
-            assertEquals(listOf(localAccounts), returnedList)
-        }
+        assertEquals(decryptedSK, result)
+    }
+
+    @Test
+    fun `EXPECT null WHEN getSecretKey is invoked with a non-existent address`() = runTest {
+        coEvery { algo25Dao.get("non_existent_address") } returns null
+
+        val result = sut.getSecretKey("non_existent_address")
+
+        coVerify { algo25Dao.get("non_existent_address") }
+        assertEquals(null, result)
     }
 }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/local/data/repository/HdKeyAccountRepositoryImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/local/data/repository/HdKeyAccountRepositoryImplTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.local.data.repository
+
+import com.algorand.wallet.account.local.data.database.dao.HdKeyDao
+import com.algorand.wallet.account.local.data.database.model.HdKeyEntity
+import com.algorand.wallet.account.local.data.mapper.entity.HdKeyEntityMapper
+import com.algorand.wallet.account.local.data.mapper.model.HdKeyMapper
+import com.algorand.wallet.account.local.domain.model.LocalAccount
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HdKeyAccountRepositoryImplTest {
+
+    private val hdKeyDao: HdKeyDao = mockk()
+    private val hdKeyEntityMapper: HdKeyEntityMapper = mockk()
+    private val hdKeyMapper: HdKeyMapper = mockk()
+    private val sut = HdKeyAccountRepositoryImpl(
+        hdKeyDao,
+        hdKeyEntityMapper,
+        hdKeyMapper
+    )
+
+    @Test
+    fun `EXPECT all accounts as flow WHEN getAllAsFlow is invoked`() = runTest {
+        val entities = listOf(
+            HdKeyEntity("address1", byteArrayOf(1), byteArrayOf(2), 1, 0, 0, 0, 1),
+            HdKeyEntity("address2", byteArrayOf(3), byteArrayOf(4), 2, 0, 0, 1, 1)
+        )
+        val expectedAccounts = listOf(
+            LocalAccount.HdKey("address1", byteArrayOf(1), 1, 0, 0, 0, 1),
+            LocalAccount.HdKey("address2", byteArrayOf(3), 2, 0, 0, 1, 1)
+        )
+
+        coEvery { hdKeyDao.getAllAsFlow() } returns flowOf(entities)
+        coEvery { hdKeyMapper(entities[0]) } returns expectedAccounts[0]
+        coEvery { hdKeyMapper(entities[1]) } returns expectedAccounts[1]
+
+        val result = sut.getAllAsFlow().toList().first()
+
+        coVerify { hdKeyDao.getAllAsFlow() }
+        assertEquals(expectedAccounts, result)
+    }
+
+    @Test
+    fun `EXPECT account count as flow WHEN getAccountCountAsFlow is invoked`() = runTest {
+        val expectedCount = 3
+        coEvery { hdKeyDao.getTableSizeAsFlow() } returns flowOf(expectedCount)
+
+        val flow = sut.getAccountCountAsFlow()
+        val result = flow.toList()
+
+        assertEquals(listOf(expectedCount), result)
+    }
+
+    @Test
+    fun `EXPECT all accounts WHEN getAll is invoked`() = runTest {
+        val entities = listOf(
+            HdKeyEntity("address1", byteArrayOf(1), byteArrayOf(2), 1, 0, 0, 0, 1),
+            HdKeyEntity("address2", byteArrayOf(3), byteArrayOf(4), 2, 0, 0, 1, 1)
+        )
+        val expectedAccounts = listOf(
+            LocalAccount.HdKey("address1", byteArrayOf(1), 1, 0, 0, 0, 1),
+            LocalAccount.HdKey("address2", byteArrayOf(3), 2, 0, 0, 1, 1)
+        )
+
+        coEvery { hdKeyDao.getAll() } returns entities
+        coEvery { hdKeyMapper(entities[0]) } returns expectedAccounts[0]
+        coEvery { hdKeyMapper(entities[1]) } returns expectedAccounts[1]
+
+        val result = sut.getAll()
+
+        coVerify { hdKeyDao.getAll() }
+        assertEquals(expectedAccounts, result)
+    }
+
+    @Test
+    fun `EXPECT all addresses WHEN getAllAddresses is invoked`() = runTest {
+        val addresses = listOf("address1", "address2")
+        coEvery { hdKeyDao.getAllAddresses() } returns addresses
+
+        val result = sut.getAllAddresses()
+
+        assertEquals(addresses, result)
+    }
+
+    @Test
+    fun `EXPECT account WHEN getAccount is invoked`() = runTest {
+        val entity = HdKeyEntity("address1", byteArrayOf(1), byteArrayOf(2), 1, 0, 0, 0, 1)
+        val expectedAccount = LocalAccount.HdKey("address1", byteArrayOf(1), 1, 0, 0, 0, 1)
+
+        coEvery { hdKeyDao.get("address1") } returns entity
+        coEvery { hdKeyMapper(entity) } returns expectedAccount
+
+        val result = sut.getAccount("address1")
+
+        coVerify { hdKeyDao.get("address1") }
+        assertEquals(expectedAccount, result)
+    }
+
+    @Test
+    fun `EXPECT null WHEN getAccount is invoked with a non-existent address`() = runTest {
+        coEvery { hdKeyDao.get("non_existent_address") } returns null
+
+        val result = sut.getAccount("non_existent_address")
+
+        coVerify { hdKeyDao.get("non_existent_address") }
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `EXPECT account to be added WHEN addAccount is invoked`() = runTest {
+        val privateKey = byteArrayOf(5, 6, 7)
+        val account = LocalAccount.HdKey("address", byteArrayOf(8), 1, 0, 0, 0, 1)
+        val entity = HdKeyEntity("address", byteArrayOf(8), privateKey, 1, 0, 0, 0, 1)
+
+        coEvery { hdKeyEntityMapper(account, privateKey) } returns entity
+        coEvery { hdKeyDao.insert(entity) } returns Unit
+
+        sut.addAccount(account, privateKey)
+
+        coVerify { hdKeyDao.insert(entity) }
+    }
+
+    @Test
+    fun `EXPECT account to be deleted WHEN deleteAccount is invoked`() = runTest {
+        coEvery { hdKeyDao.delete("address") } returns Unit
+
+        sut.deleteAccount("address")
+
+        coVerify { hdKeyDao.delete("address") }
+    }
+
+    @Test
+    fun `EXPECT all accounts to be deleted WHEN deleteAllAccounts is invoked`() = runTest {
+        coEvery { hdKeyDao.clearAll() } returns Unit
+
+        sut.deleteAllAccounts()
+
+        coVerify { hdKeyDao.clearAll() }
+    }
+}

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/local/data/repository/LedgerBleAccountRepositoryImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/local/data/repository/LedgerBleAccountRepositoryImplTest.kt
@@ -13,6 +13,7 @@
 package com.algorand.wallet.account.local.data.repository
 
 import com.algorand.test.peraFixture
+import com.algorand.test.test
 import com.algorand.wallet.account.local.data.database.dao.LedgerBleDao
 import com.algorand.wallet.account.local.data.database.model.LedgerBleEntity
 import com.algorand.wallet.account.local.data.mapper.entity.LedgerBleEntityMapper
@@ -21,8 +22,10 @@ import com.algorand.wallet.account.local.domain.model.LocalAccount
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -52,22 +55,52 @@ class LedgerBleAccountRepositoryImplTest {
         assertEquals(expectedReturnedList, localAccounts)
     }
 
-//    @Test
-//    fun `EXPECT account WHEN account was registered before`() = runTest {
-//        coEvery { ledgerBleMapper(LEDGER_BLE_1_ENTITY) } returns LEDGER_BLE_1
-//        coEvery { ledgerBleDao.get(LEDGER_BLE_1_ENTITY.algoAddress) } returns LEDGER_BLE_1_ENTITY
-//        coEvery { LEDGER_BLE_1.address } returns LEDGER_BLE_1_ENTITY.algoAddress
-//
-//        val localAccount = sut.getAccount(LEDGER_BLE_1.address)
-//
-//        coVerify { ledgerBleMapper(LEDGER_BLE_1_ENTITY) }
-//        assertEquals(LEDGER_BLE_1, localAccount)
-//    }
+    @Test
+    fun `EXPECT account WHEN getAccount is invoked`() = runTest {
+        coEvery { ledgerBleDao.get(LEDGER_BLE_1_ENTITY.algoAddress) } returns LEDGER_BLE_1_ENTITY
+        coEvery { ledgerBleMapper(LEDGER_BLE_1_ENTITY) } returns LEDGER_BLE_1
+
+        val localAccount = sut.getAccount(LEDGER_BLE_1_ENTITY.algoAddress)
+
+        coVerify { ledgerBleDao.get(LEDGER_BLE_1_ENTITY.algoAddress) }
+        assertEquals(LEDGER_BLE_1, localAccount)
+    }
 
     @Test
-    fun `EXPECT account to be added to database  WHEN addAccount is invoked`() = runTest {
-        coEvery { ledgerBleDao.insert(LEDGER_BLE_1_ENTITY) } returns Unit
+    fun `EXPECT null WHEN getAccount is invoked with a non-existent address`() = runTest {
+        coEvery { ledgerBleDao.get("non_existent_address") } returns null
+
+        val result = sut.getAccount("non_existent_address")
+
+        coVerify { ledgerBleDao.get("non_existent_address") }
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `EXPECT account count as flow WHEN getAccountCountAsFlow is invoked`() = runTest {
+        val expectedCountFlow = MutableStateFlow(3)
+        coEvery { ledgerBleDao.getTableSizeAsFlow() } returns expectedCountFlow
+
+        val testObserver = sut.getAccountCountAsFlow().test()
+        expectedCountFlow.update { 5 }
+
+        testObserver.assertValueHistory(3, 5)
+    }
+
+    @Test
+    fun `EXPECT all addresses WHEN getAllAddresses is invoked`() = runTest {
+        val addresses = listOf("address1", "address2")
+        coEvery { ledgerBleDao.getAllAddresses() } returns addresses
+
+        val result = sut.getAllAddresses()
+
+        assertEquals(addresses, result)
+    }
+
+    @Test
+    fun `EXPECT account to be added to database WHEN addAccount is invoked`() = runTest {
         coEvery { ledgerBleEntityMapper(LEDGER_BLE_1) } returns LEDGER_BLE_1_ENTITY
+        coEvery { ledgerBleDao.insert(LEDGER_BLE_1_ENTITY) } returns Unit
 
         sut.addAccount(LEDGER_BLE_1)
 
@@ -75,7 +108,7 @@ class LedgerBleAccountRepositoryImplTest {
     }
 
     @Test
-    fun `EXPECT account to be deleted WHEN deleteAccount is invoked`() = runTest {
+    fun `EXPECT account to be deleted from database WHEN deleteAccount is invoked`() = runTest {
         coEvery { ledgerBleDao.delete("address") } returns Unit
 
         sut.deleteAccount("address")
@@ -84,7 +117,7 @@ class LedgerBleAccountRepositoryImplTest {
     }
 
     @Test
-    fun `EXPECT all accounts to be deleted WHEN deleteAllAccounts is invoked`() = runTest {
+    fun `EXPECT all accounts to be deleted from database WHEN deleteAllAccounts is invoked`() = runTest {
         coEvery { ledgerBleDao.clearAll() } returns Unit
 
         sut.deleteAllAccounts()
@@ -93,17 +126,26 @@ class LedgerBleAccountRepositoryImplTest {
     }
 
     @Test
-    fun `EXPECT all accounts WHEN getAllAsFlow is invoked`() = runTest {
-        val entities = listOf(LEDGER_BLE_1_ENTITY, LEDGER_BLE_2_ENTITY)
-        coEvery { ledgerBleDao.getAllAsFlow() } returns flowOf(entities)
-        coEvery { ledgerBleMapper(LEDGER_BLE_1_ENTITY) } returns LEDGER_BLE_1
-        coEvery { ledgerBleMapper(LEDGER_BLE_2_ENTITY) } returns LEDGER_BLE_2
+    fun `EXPECT all accounts as flow WHEN getAllAsFlow is invoked`() = runTest {
+        val entitiesFlow = MutableStateFlow(
+            listOf(
+                LEDGER_BLE_1_ENTITY,
+                LEDGER_BLE_2_ENTITY
+            )
+        )
+        val expectedAccounts = listOf(
+            LEDGER_BLE_1,
+            LEDGER_BLE_2
+        )
 
-        val localAccounts = sut.getAllAsFlow().toList().first()
+        coEvery { ledgerBleDao.getAllAsFlow() } returns entitiesFlow
+        coEvery { ledgerBleMapper(LEDGER_BLE_1_ENTITY) } returns expectedAccounts[0]
+        coEvery { ledgerBleMapper(LEDGER_BLE_2_ENTITY) } returns expectedAccounts[1]
 
-        val expectedReturnedList = listOf(LEDGER_BLE_1, LEDGER_BLE_2)
-        coVerify { ledgerBleDao.getAllAsFlow() }
-        assertEquals(expectedReturnedList, localAccounts)
+        val testObserver = sut.getAllAsFlow().test()
+        entitiesFlow.update { emptyList() }
+
+        testObserver.assertValueHistory(expectedAccounts, emptyList())
     }
 
     companion object {

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/local/data/repository/NoAuthAccountRepositoryImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/local/data/repository/NoAuthAccountRepositoryImplTest.kt
@@ -12,6 +12,7 @@
 
 package com.algorand.wallet.account.local.data.repository
 
+import com.algorand.test.test
 import com.algorand.wallet.account.local.data.database.dao.NoAuthDao
 import com.algorand.wallet.account.local.data.database.model.NoAuthEntity
 import com.algorand.wallet.account.local.data.mapper.entity.NoAuthEntityMapper
@@ -20,8 +21,8 @@ import com.algorand.wallet.account.local.domain.model.LocalAccount
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -52,40 +53,70 @@ class NoAuthAccountRepositoryImplTest {
     }
 
     @Test
-    fun `EXPECT account WHEN account was registered before`() = runTest {
-        coEvery { noAuthMapper(NoAuthEntity("unencrypted_address")) } returns LocalAccount.NoAuth("unencrypted_address")
-        coEvery { noAuthDao.get("unencrypted_address") } returns NoAuthEntity("unencrypted_address")
+    fun `EXPECT account WHEN getAccount is invoked`() = runTest {
+        coEvery { noAuthDao.get("address1") } returns NoAuthEntity("address1")
+        coEvery { noAuthMapper(NoAuthEntity("address1")) } returns LocalAccount.NoAuth("address1")
 
-        val localAccount = sut.getAccount("unencrypted_address")
+        val localAccount = sut.getAccount("address1")
 
-        val expectedAccount = LocalAccount.NoAuth("unencrypted_address")
-        coVerify { noAuthDao.get("unencrypted_address") }
-        assertEquals(expectedAccount, localAccount)
+        coVerify { noAuthDao.get("address1") }
+        assertEquals(LocalAccount.NoAuth("address1"), localAccount)
+    }
+
+    @Test
+    fun `EXPECT null WHEN getAccount is invoked with a non-existent address`() = runTest {
+        coEvery { noAuthDao.get("non_existent_address") } returns null
+
+        val result = sut.getAccount("non_existent_address")
+
+        coVerify { noAuthDao.get("non_existent_address") }
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `EXPECT account count as flow WHEN getAccountCountAsFlow is invoked`() = runTest {
+        val expectedCountFlow = MutableStateFlow(3)
+        coEvery { noAuthDao.getTableSizeAsFlow() } returns expectedCountFlow
+
+        val testObserver = sut.getAccountCountAsFlow().test()
+        expectedCountFlow.update { 5 }
+
+        testObserver.assertValueHistory(3, 5)
+    }
+
+    @Test
+    fun `EXPECT all addresses WHEN getAllAddresses is invoked`() = runTest {
+        val addresses = listOf("address1", "address2")
+        coEvery { noAuthDao.getAllAddresses() } returns addresses
+
+        val result = sut.getAllAddresses()
+
+        assertEquals(addresses, result)
     }
 
     @Test
     fun `EXPECT account to be added to database WHEN addAccount is invoked`() = runTest {
         val account = LocalAccount.NoAuth("address")
-        val ledgerUsbEntity = NoAuthEntity("unencrypted_address")
-        coEvery { noAuthEntityMapper(account) } returns ledgerUsbEntity
-        coEvery { noAuthDao.insert(ledgerUsbEntity) } returns Unit
+        val entity = NoAuthEntity("address")
+        coEvery { noAuthEntityMapper(account) } returns entity
+        coEvery { noAuthDao.insert(entity) } returns Unit
 
         sut.addAccount(account)
 
-        coVerify { noAuthDao.insert(ledgerUsbEntity) }
+        coVerify { noAuthDao.insert(entity) }
     }
 
     @Test
-    fun `EXPECT account to be deleted WHEN deleteAccount is invoked`() = runTest {
-        coEvery { noAuthDao.delete("unencrypted_address") } returns Unit
+    fun `EXPECT account to be deleted from database WHEN deleteAccount is invoked`() = runTest {
+        coEvery { noAuthDao.delete("address") } returns Unit
 
-        sut.deleteAccount("unencrypted_address")
+        sut.deleteAccount("address")
 
-        coVerify { noAuthDao.delete("unencrypted_address") }
+        coVerify { noAuthDao.delete("address") }
     }
 
     @Test
-    fun `EXPECT all accounts to be deleted WHEN deleteAllAccounts is invoked`() = runTest {
+    fun `EXPECT all accounts to be deleted from database WHEN deleteAllAccounts is invoked`() = runTest {
         coEvery { noAuthDao.clearAll() } returns Unit
 
         sut.deleteAllAccounts()
@@ -94,16 +125,43 @@ class NoAuthAccountRepositoryImplTest {
     }
 
     @Test
-    fun `EXPECT all accounts WHEN getAllAsFlow is invoked`() = runTest {
-        val entities = listOf(NoAuthEntity("address1"), NoAuthEntity("address2"))
-        coEvery { noAuthDao.getAllAsFlow() } returns flowOf(entities)
-        coEvery { noAuthMapper(entities[0]) } returns LocalAccount.NoAuth("address1")
-        coEvery { noAuthMapper(entities[1]) } returns LocalAccount.NoAuth("address2")
+    fun `EXPECT all accounts as flow WHEN getAllAsFlow is invoked`() = runTest {
+        val entitiesFlow = MutableStateFlow(
+            listOf(
+                NoAuthEntity("address1"),
+                NoAuthEntity("address2")
+            )
+        )
+        val expectedAccounts = listOf(
+            LocalAccount.NoAuth("address1"),
+            LocalAccount.NoAuth("address2")
+        )
 
-        val localAccounts = sut.getAllAsFlow().toList().first()
+        coEvery { noAuthDao.getAllAsFlow() } returns entitiesFlow
+        coEvery { noAuthMapper(entitiesFlow.value[0]) } returns expectedAccounts[0]
+        coEvery { noAuthMapper(entitiesFlow.value[1]) } returns expectedAccounts[1]
 
-        val expectedReturnedList = listOf(LocalAccount.NoAuth("address1"), LocalAccount.NoAuth("address2"))
-        coVerify { noAuthDao.getAllAsFlow() }
-        assertEquals(expectedReturnedList, localAccounts)
+        val testObserver = sut.getAllAsFlow().test()
+        entitiesFlow.update { emptyList() }
+
+        testObserver.assertValueHistory(expectedAccounts, emptyList())
+    }
+
+    @Test
+    fun `EXPECT true WHEN isAddressExists returns true`() = runTest {
+        coEvery { noAuthDao.isAddressExists("address1") } returns true
+
+        val result = sut.isAddressExists("address1")
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `EXPECT false WHEN isAddressExists returns false`() = runTest {
+        coEvery { noAuthDao.isAddressExists("address1") } returns false
+
+        val result = sut.isAddressExists("address1")
+
+        assertEquals(false, result)
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
- getRekeyedAccountAddresses function removed from app module and added to the common sdk

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1627

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
