### PR TITLE
PERA-1664 :: Asset flow common sdk changes into dev

### DIFF
--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/model/AssetStatusEntity.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/model/AssetStatusEntity.kt
@@ -15,6 +15,5 @@ package com.algorand.wallet.account.info.data.database.model
 internal enum class AssetStatusEntity {
     PENDING_FOR_REMOVAL,
     PENDING_FOR_ADDITION,
-    PENDING_FOR_SENDING,
     OWNED_BY_ACCOUNT
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/AssetHoldingEntityMapper.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/AssetHoldingEntityMapper.kt
@@ -17,7 +17,6 @@ import com.algorand.wallet.account.info.data.model.AssetHoldingResponse
 import com.algorand.wallet.account.info.domain.model.AssetStatus
 
 internal interface AssetHoldingEntityMapper {
-    operator fun invoke(address: String, response: AssetHoldingResponse): AssetHoldingEntity?
-    operator fun invoke(responses: List<Pair<String, AssetHoldingResponse>>): List<AssetHoldingEntity>
+    operator fun invoke(address: String, response: AssetHoldingResponse, status: AssetStatus): AssetHoldingEntity?
     operator fun invoke(address: String, assetId: Long, status: AssetStatus): AssetHoldingEntity
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/AssetHoldingEntityMapperImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/AssetHoldingEntityMapperImpl.kt
@@ -13,7 +13,6 @@
 package com.algorand.wallet.account.info.data.mapper
 
 import com.algorand.wallet.account.info.data.database.model.AssetHoldingEntity
-import com.algorand.wallet.account.info.data.database.model.AssetStatusEntity
 import com.algorand.wallet.account.info.data.model.AssetHoldingResponse
 import com.algorand.wallet.account.info.domain.model.AssetStatus
 import java.math.BigInteger
@@ -23,7 +22,7 @@ internal class AssetHoldingEntityMapperImpl @Inject constructor(
     private val assetStatusEntityMapper: AssetStatusEntityMapper
 ) : AssetHoldingEntityMapper {
 
-    override fun invoke(address: String, response: AssetHoldingResponse): AssetHoldingEntity? {
+    override fun invoke(address: String, response: AssetHoldingResponse, status: AssetStatus): AssetHoldingEntity? {
         return AssetHoldingEntity(
             algoAddress = address,
             assetId = response.assetId ?: return null,
@@ -32,14 +31,8 @@ internal class AssetHoldingEntityMapperImpl @Inject constructor(
             isFrozen = response.isFrozen ?: false,
             optedInAtRound = response.optedInAtRound,
             optedOutAtRound = response.optedOutAtRound,
-            assetStatusEntity = AssetStatusEntity.OWNED_BY_ACCOUNT
+            assetStatusEntity = assetStatusEntityMapper(status)
         )
-    }
-
-    override fun invoke(responses: List<Pair<String, AssetHoldingResponse>>): List<AssetHoldingEntity> {
-        return responses.mapNotNull { (address, assetHoldingResponse) ->
-            invoke(address, assetHoldingResponse)
-        }
     }
 
     override fun invoke(address: String, assetId: Long, status: AssetStatus): AssetHoldingEntity {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/AssetHoldingMapperImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/AssetHoldingMapperImpl.kt
@@ -54,7 +54,6 @@ internal class AssetHoldingMapperImpl @Inject constructor() : AssetHoldingMapper
         return when (entity) {
             AssetStatusEntity.PENDING_FOR_REMOVAL -> AssetStatus.PENDING_FOR_REMOVAL
             AssetStatusEntity.PENDING_FOR_ADDITION -> AssetStatus.PENDING_FOR_ADDITION
-            AssetStatusEntity.PENDING_FOR_SENDING -> AssetStatus.PENDING_FOR_SENDING
             AssetStatusEntity.OWNED_BY_ACCOUNT -> AssetStatus.OWNED_BY_ACCOUNT
         }
     }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/AssetStatusEntityMapperImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/AssetStatusEntityMapperImpl.kt
@@ -22,7 +22,6 @@ internal class AssetStatusEntityMapperImpl @Inject constructor() : AssetStatusEn
         return when (status) {
             AssetStatus.PENDING_FOR_REMOVAL -> AssetStatusEntity.PENDING_FOR_REMOVAL
             AssetStatus.PENDING_FOR_ADDITION -> AssetStatusEntity.PENDING_FOR_ADDITION
-            AssetStatus.PENDING_FOR_SENDING -> AssetStatusEntity.PENDING_FOR_SENDING
             AssetStatus.OWNED_BY_ACCOUNT -> AssetStatusEntity.OWNED_BY_ACCOUNT
         }
     }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/repository/AccountInformationCacheHelperImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/repository/AccountInformationCacheHelperImpl.kt
@@ -36,8 +36,10 @@ internal class AccountInformationCacheHelperImpl @Inject constructor(
     ): AccountInformation? {
         val entity = accountInformationEntityMapper(response)
         return if (entity != null) {
-            val assetHoldings =
-                assetHoldingCacheHelper.cacheAssetHolding(address, response.accountInformation?.allAssetHoldingList)
+            val assetHoldings = assetHoldingCacheHelper.cacheAssetHolding(
+                address,
+                response.accountInformation?.allAssetHoldingList.orEmpty()
+            )
             accountInformationErrorCache.remove(address)
             cacheAccountInformation(entity, assetHoldings)
         } else {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/repository/AssetHoldingCacheHelper.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/repository/AssetHoldingCacheHelper.kt
@@ -12,9 +12,9 @@
 
 package com.algorand.wallet.account.info.data.repository
 
-import com.algorand.wallet.account.info.domain.model.AssetHolding
 import com.algorand.wallet.account.info.data.model.AssetHoldingResponse
+import com.algorand.wallet.account.info.domain.model.AssetHolding
 
 internal interface AssetHoldingCacheHelper {
-    suspend fun cacheAssetHolding(address: String, assetHoldings: List<AssetHoldingResponse>?): List<AssetHolding>
+    suspend fun cacheAssetHolding(address: String, assetHoldings: List<AssetHoldingResponse>): List<AssetHolding>
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/repository/AssetHoldingCacheHelperImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/repository/AssetHoldingCacheHelperImpl.kt
@@ -14,33 +14,68 @@ package com.algorand.wallet.account.info.data.repository
 
 import com.algorand.wallet.account.info.data.database.dao.AssetHoldingDao
 import com.algorand.wallet.account.info.data.database.model.AssetHoldingEntity
+import com.algorand.wallet.account.info.data.database.model.AssetStatusEntity
 import com.algorand.wallet.account.info.data.mapper.AssetHoldingEntityMapper
 import com.algorand.wallet.account.info.data.mapper.AssetHoldingMapper
 import com.algorand.wallet.account.info.data.model.AssetHoldingResponse
 import com.algorand.wallet.account.info.domain.model.AssetHolding
+import com.algorand.wallet.account.info.domain.model.AssetStatus
 import javax.inject.Inject
 
 internal class AssetHoldingCacheHelperImpl @Inject constructor(
     private val assetHoldingDao: AssetHoldingDao,
     private val assetHoldingEntityMapper: AssetHoldingEntityMapper,
-    private val assetHoldingMapper: AssetHoldingMapper,
+    private val assetHoldingMapper: AssetHoldingMapper
 ) : AssetHoldingCacheHelper {
 
     override suspend fun cacheAssetHolding(
         address: String,
-        assetHoldings: List<AssetHoldingResponse>?
+        assetHoldings: List<AssetHoldingResponse>
     ): List<AssetHolding> {
-        val assetHoldingEntities = getAssetHoldingEntities(address, assetHoldings)
-        assetHoldingDao.updateAssetHoldings(address, assetHoldingEntities)
-        return assetHoldingMapper(assetHoldingEntities)
+        val updatedAssetHoldingEntities = getUpdatedAssetHoldings(address, assetHoldings)
+        assetHoldingDao.updateAssetHoldings(address, updatedAssetHoldingEntities)
+        return assetHoldingMapper(updatedAssetHoldingEntities)
     }
 
-    private fun getAssetHoldingEntities(
+    private suspend fun getUpdatedAssetHoldings(
         address: String,
-        assetHoldings: List<AssetHoldingResponse>?
+        assetHoldings: List<AssetHoldingResponse>
     ): List<AssetHoldingEntity> {
-        return assetHoldings?.mapNotNull {
-            assetHoldingEntityMapper(address, it)
-        }.orEmpty()
+        val updatedAssetHoldings = mutableListOf<AssetHoldingEntity>()
+        val cachedAssetHoldings = assetHoldingDao.getAssetsByAddress(address).toMutableList()
+
+        assetHoldings.forEach { response ->
+            val cachedAssetIndex = cachedAssetHoldings.indexOfFirst { it.assetId == response.assetId }
+
+            val isNewAsset = cachedAssetIndex == -1
+            if (isNewAsset) {
+                assetHoldingEntityMapper(address, response, AssetStatus.OWNED_BY_ACCOUNT)?.let {
+                    updatedAssetHoldings.add(it)
+                }
+                return@forEach
+            }
+
+            val cachedAsset = cachedAssetHoldings[cachedAssetIndex]
+            val updatedStatus = getUpdatedAssetStatus(cachedAsset.assetStatusEntity)
+            assetHoldingEntityMapper(address, response, updatedStatus)?.let {
+                updatedAssetHoldings.add(it)
+                cachedAssetHoldings.removeAt(cachedAssetIndex)
+            }
+        }
+
+        cachedAssetHoldings.forEach {
+            if (it.assetStatusEntity == AssetStatusEntity.PENDING_FOR_ADDITION) {
+                updatedAssetHoldings.add(it)
+            }
+        }
+        return updatedAssetHoldings
+    }
+
+    private fun getUpdatedAssetStatus(currentStatus: AssetStatusEntity): AssetStatus {
+        return when (currentStatus) {
+            AssetStatusEntity.PENDING_FOR_ADDITION -> AssetStatus.OWNED_BY_ACCOUNT
+            AssetStatusEntity.PENDING_FOR_REMOVAL -> AssetStatus.PENDING_FOR_REMOVAL
+            AssetStatusEntity.OWNED_BY_ACCOUNT -> AssetStatus.OWNED_BY_ACCOUNT
+        }
     }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/model/AssetStatus.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/model/AssetStatus.kt
@@ -15,7 +15,6 @@ package com.algorand.wallet.account.info.domain.model
 enum class AssetStatus {
     PENDING_FOR_REMOVAL,
     PENDING_FOR_ADDITION,
-    PENDING_FOR_SENDING,
     OWNED_BY_ACCOUNT;
 
     companion object {

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/AssetHoldingEntityMapperImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/AssetHoldingEntityMapperImplTest.kt
@@ -15,6 +15,7 @@ package com.algorand.wallet.account.info.data.mapper
 import com.algorand.wallet.account.info.data.database.model.AssetHoldingEntity
 import com.algorand.wallet.account.info.data.database.model.AssetStatusEntity
 import com.algorand.wallet.account.info.data.model.AssetHoldingResponse
+import com.algorand.wallet.account.info.domain.model.AssetStatus
 import java.math.BigInteger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -23,7 +24,9 @@ import org.mockito.kotlin.mock
 
 class AssetHoldingEntityMapperImplTest {
 
-    private val assetStatusEntityMapper: AssetStatusEntityMapper = mock()
+    private val assetStatusEntityMapper: AssetStatusEntityMapper = mock {
+        on { invoke(AssetStatus.OWNED_BY_ACCOUNT) }.thenReturn(AssetStatusEntity.OWNED_BY_ACCOUNT)
+    }
 
     private val sut = AssetHoldingEntityMapperImpl(assetStatusEntityMapper)
 
@@ -31,7 +34,7 @@ class AssetHoldingEntityMapperImplTest {
     fun `EXPECT null WHEN asset id is null`() {
         val response = RESPONSE.copy(assetId = null)
 
-        val result = sut(ADDRESS, response)
+        val result = sut(ADDRESS, response, ASSET_STATUS)
 
         assertNull(result)
     }
@@ -40,14 +43,14 @@ class AssetHoldingEntityMapperImplTest {
     fun `EXPECT null WHEN amount is null`() {
         val response = RESPONSE.copy(amount = null)
 
-        val result = sut(ADDRESS, response)
+        val result = sut(ADDRESS, response, ASSET_STATUS)
 
         assertNull(result)
     }
 
     @Test
     fun `EXPECT mapped entity WHEN response is valid`() {
-        val result = sut(ADDRESS, RESPONSE)
+        val result = sut(ADDRESS, RESPONSE, ASSET_STATUS)
 
         assertEquals(EXPECTED_ENTITY, result)
     }
@@ -59,13 +62,14 @@ class AssetHoldingEntityMapperImplTest {
             isFrozen = null
         )
 
-        val result = sut(ADDRESS, response)
+        val result = sut(ADDRESS, response, ASSET_STATUS)
 
         assertEquals(EXPECTED_ENTITY, result)
     }
 
     private companion object {
         const val ADDRESS = "address"
+        val ASSET_STATUS = AssetStatus.OWNED_BY_ACCOUNT
         val RESPONSE = AssetHoldingResponse(
             assetId = 1,
             amount = "10",

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/AssetHoldingMapperImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/AssetHoldingMapperImplTest.kt
@@ -97,20 +97,6 @@ class AssetHoldingMapperImplTest {
         assertEquals(expected, result)
     }
 
-    @Test
-    fun `EXPECT mapped object with pending sending asset status WHEN entity status is pending sending`() {
-        val entity = ASSET_HOLDING_ENTITY.copy(
-            assetStatusEntity = AssetStatusEntity.PENDING_FOR_SENDING
-        )
-
-        val result = sut(entity)
-
-        val expected = VALID_ASSET_HOLDING.copy(
-            status = AssetStatus.PENDING_FOR_SENDING
-        )
-        assertEquals(expected, result)
-    }
-
     private companion object {
         const val ADDRESS = "address"
 

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/repository/AssetHoldingCacheHelperImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/repository/AssetHoldingCacheHelperImplTest.kt
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.info.data.repository
+
+import com.algorand.test.peraFixture
+import com.algorand.wallet.account.info.data.database.dao.AssetHoldingDao
+import com.algorand.wallet.account.info.data.database.model.AssetHoldingEntity
+import com.algorand.wallet.account.info.data.database.model.AssetStatusEntity.OWNED_BY_ACCOUNT
+import com.algorand.wallet.account.info.data.database.model.AssetStatusEntity.PENDING_FOR_ADDITION
+import com.algorand.wallet.account.info.data.database.model.AssetStatusEntity.PENDING_FOR_REMOVAL
+import com.algorand.wallet.account.info.data.mapper.AssetHoldingEntityMapper
+import com.algorand.wallet.account.info.data.mapper.AssetHoldingMapper
+import com.algorand.wallet.account.info.data.model.AssetHoldingResponse
+import com.algorand.wallet.account.info.domain.model.AssetHolding
+import com.algorand.wallet.account.info.domain.model.AssetStatus
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AssetHoldingCacheHelperImplTest {
+
+    private val assetHoldingDao: AssetHoldingDao = mockk(relaxed = true)
+    private val assetHoldingEntityMapper: AssetHoldingEntityMapper = mockk()
+    private val assetHoldingMapper: AssetHoldingMapper = mockk()
+
+    private val sut = AssetHoldingCacheHelperImpl(assetHoldingDao, assetHoldingEntityMapper, assetHoldingMapper)
+
+    @Test
+    fun `EXPECT empty list and pending for removals to be removed WHEN response is empty`() = runTest {
+        coEvery { assetHoldingDao.getAssetsByAddress(ADDRESS) } returns listOf(PENDING_FOR_REMOVAL_ENTITY)
+        every { assetHoldingMapper(emptyList()) } returns emptyList()
+
+        val result = sut.cacheAssetHolding(ADDRESS, emptyList())
+
+        coVerify { assetHoldingDao.updateAssetHoldings(ADDRESS, emptyList()) }
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `EXPECT new asset to be cached WHEN response contains new asset`() = runTest {
+        coEvery { assetHoldingDao.getAssetsByAddress(ADDRESS) } returns emptyList()
+        every { assetHoldingEntityMapper(ADDRESS, OWNED_RESPONSE, AssetStatus.OWNED_BY_ACCOUNT) } returns OWNED_ENTITY
+        every { assetHoldingMapper(listOf(OWNED_ENTITY)) } returns listOf(OWNED_ASSET_HOLDING)
+
+        val result = sut.cacheAssetHolding(ADDRESS, listOf(OWNED_RESPONSE))
+
+        coVerify { assetHoldingDao.updateAssetHoldings(ADDRESS, listOf(OWNED_ENTITY)) }
+        val expected = listOf(OWNED_ASSET_HOLDING)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `EXPECT pending for removal to be removed WHEN response does not contain them`() = runTest {
+        val response = listOf(OWNED_RESPONSE)
+        val assetHoldings = listOf(OWNED_ENTITY, PENDING_FOR_REMOVAL_ENTITY)
+        coEvery { assetHoldingDao.getAssetsByAddress(ADDRESS) } returns assetHoldings
+        every { assetHoldingMapper.invoke(listOf(OWNED_ENTITY)) } returns listOf(OWNED_ASSET_HOLDING)
+        every { assetHoldingEntityMapper(ADDRESS, OWNED_RESPONSE, AssetStatus.OWNED_BY_ACCOUNT) } returns OWNED_ENTITY
+
+        val result = sut.cacheAssetHolding(ADDRESS, response)
+
+        coVerify { assetHoldingDao.updateAssetHoldings(ADDRESS, listOf(OWNED_ENTITY)) }
+        val expected = listOf(OWNED_ASSET_HOLDING)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `EXPECT pending for removal to be kept WHEN response still contains it`() = runTest {
+        val response = listOf(OWNED_RESPONSE, PENDING_FOR_REMOVAL_RESPONSE)
+        val assetHoldingEntities = listOf(OWNED_ENTITY, PENDING_FOR_REMOVAL_ENTITY)
+        val assetHoldings = listOf(OWNED_ASSET_HOLDING, PENDING_FOR_REMOVAL_ASSET_HOLDING)
+        coEvery { assetHoldingDao.getAssetsByAddress(ADDRESS) } returns assetHoldingEntities
+        every { assetHoldingMapper(assetHoldingEntities) } returns assetHoldings
+        every { assetHoldingEntityMapper(ADDRESS, OWNED_RESPONSE, AssetStatus.OWNED_BY_ACCOUNT) } returns OWNED_ENTITY
+        every {
+            assetHoldingEntityMapper(ADDRESS, PENDING_FOR_REMOVAL_RESPONSE, AssetStatus.PENDING_FOR_REMOVAL)
+        } returns PENDING_FOR_REMOVAL_ENTITY
+
+        val result = sut.cacheAssetHolding(ADDRESS, response)
+
+        coVerify { assetHoldingDao.updateAssetHoldings(ADDRESS, listOf(OWNED_ENTITY, PENDING_FOR_REMOVAL_ENTITY)) }
+        assertEquals(assetHoldings, result)
+    }
+
+    @Test
+    fun `EXPECT pending for addition to be cached as owned WHEN asset holding contains it`() = runTest {
+        val ownedResponse = peraFixture<AssetHoldingResponse>().copy(
+            assetId = PENDING_FOR_ADDITION_ENTITY.assetId,
+            amount = "0"
+        )
+        val ownedEntity = peraFixture<AssetHoldingEntity>().copy(
+            id = PENDING_FOR_ADDITION_ENTITY.id,
+            assetStatusEntity = OWNED_BY_ACCOUNT,
+            amount = BigInteger.ZERO,
+            algoAddress = ADDRESS
+        )
+        val assetHolding = peraFixture<AssetHolding>().copy(
+            assetId = PENDING_FOR_ADDITION_ENTITY.assetId,
+            status = AssetStatus.OWNED_BY_ACCOUNT,
+            amount = BigInteger.ZERO
+        )
+        coEvery { assetHoldingDao.getAssetsByAddress(ADDRESS) } returns listOf(PENDING_FOR_ADDITION_ENTITY)
+        every { assetHoldingMapper.invoke(listOf(ownedEntity)) } returns listOf(assetHolding)
+        every { assetHoldingEntityMapper(ADDRESS, ownedResponse, AssetStatus.OWNED_BY_ACCOUNT) } returns ownedEntity
+
+        val result = sut.cacheAssetHolding(ADDRESS, listOf(ownedResponse))
+
+        coVerify { assetHoldingDao.updateAssetHoldings(ADDRESS, listOf(ownedEntity)) }
+        val expected = listOf(assetHolding)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `EXPECT pending for addition to be cached as is WHEN asset holdings does not contain it`() = runTest {
+        val response = listOf(OWNED_RESPONSE)
+        val assetHoldings = listOf(OWNED_ENTITY, PENDING_FOR_ADDITION_ENTITY)
+        coEvery { assetHoldingDao.getAssetsByAddress(ADDRESS) } returns assetHoldings
+        every { assetHoldingMapper.invoke(listOf(OWNED_ENTITY, PENDING_FOR_ADDITION_ENTITY)) } returns listOf(
+            OWNED_ASSET_HOLDING,
+            PENDING_FOR_ADDITION_ASSET_HOLDING
+        )
+        every { assetHoldingEntityMapper(ADDRESS, OWNED_RESPONSE, AssetStatus.OWNED_BY_ACCOUNT) } returns OWNED_ENTITY
+
+        val result = sut.cacheAssetHolding(ADDRESS, response)
+
+        coVerify { assetHoldingDao.updateAssetHoldings(ADDRESS, listOf(OWNED_ENTITY, PENDING_FOR_ADDITION_ENTITY)) }
+        val expected = listOf(OWNED_ASSET_HOLDING, PENDING_FOR_ADDITION_ASSET_HOLDING)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `EXPECT new asset not to be cached WHEN mapping fails`() = runTest {
+        coEvery { assetHoldingDao.getAssetsByAddress(ADDRESS) } returns emptyList()
+        every { assetHoldingEntityMapper(ADDRESS, OWNED_RESPONSE, AssetStatus.OWNED_BY_ACCOUNT) } returns null
+        every { assetHoldingMapper(emptyList()) } returns emptyList()
+
+        val result = sut.cacheAssetHolding(ADDRESS, listOf(OWNED_RESPONSE))
+
+        coVerify { assetHoldingDao.updateAssetHoldings(ADDRESS, emptyList()) }
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `EXPECT cached asset not to be updated WHEN mapping fails`() = runTest {
+        coEvery { assetHoldingDao.getAssetsByAddress(ADDRESS) } returns listOf(OWNED_ENTITY)
+        every { assetHoldingEntityMapper(ADDRESS, OWNED_RESPONSE, AssetStatus.OWNED_BY_ACCOUNT) } returns null
+        every { assetHoldingMapper(emptyList()) } returns emptyList()
+
+        val result = sut.cacheAssetHolding(ADDRESS, listOf(OWNED_RESPONSE))
+
+        coVerify { assetHoldingDao.updateAssetHoldings(ADDRESS, emptyList()) }
+        assertTrue(result.isEmpty())
+    }
+
+    private companion object {
+        private const val ADDRESS = "ADDRESS"
+        private val OWNED_ENTITY = peraFixture<AssetHoldingEntity>().copy(
+            id = 1,
+            assetStatusEntity = OWNED_BY_ACCOUNT,
+            amount = BigInteger.ONE
+        )
+        private val PENDING_FOR_REMOVAL_ENTITY = peraFixture<AssetHoldingEntity>().copy(
+            id = 2,
+            assetStatusEntity = PENDING_FOR_REMOVAL,
+            amount = BigInteger.ONE
+        )
+        private val PENDING_FOR_ADDITION_ENTITY = peraFixture<AssetHoldingEntity>().copy(
+            id = 3,
+            assetStatusEntity = PENDING_FOR_ADDITION,
+            amount = BigInteger.ONE
+        )
+
+        private val OWNED_RESPONSE = peraFixture<AssetHoldingResponse>().copy(
+            assetId = OWNED_ENTITY.assetId,
+            amount = "10"
+        )
+        private val PENDING_FOR_REMOVAL_RESPONSE = peraFixture<AssetHoldingResponse>().copy(
+            assetId = PENDING_FOR_REMOVAL_ENTITY.assetId,
+            amount = "10"
+        )
+
+        private val OWNED_ASSET_HOLDING = peraFixture<AssetHolding>().copy(
+            assetId = OWNED_ENTITY.assetId,
+            status = AssetStatus.OWNED_BY_ACCOUNT,
+            amount = BigInteger.TEN
+        )
+        private val PENDING_FOR_REMOVAL_ASSET_HOLDING = peraFixture<AssetHolding>().copy(
+            assetId = PENDING_FOR_REMOVAL_ENTITY.assetId,
+            status = AssetStatus.PENDING_FOR_REMOVAL,
+            amount = BigInteger.TEN
+        )
+        private val PENDING_FOR_ADDITION_ASSET_HOLDING = peraFixture<AssetHolding>().copy(
+            assetId = PENDING_FOR_ADDITION_ENTITY.assetId,
+            status = AssetStatus.PENDING_FOR_ADDITION,
+            amount = BigInteger.TEN
+        )
+    }
+}


### PR DESCRIPTION
## Description
- Migrated remove asset flows into common-sdk
- Fixed asset cache updating issue; We used to update asset holdings directly which were causing us losing pending states

## Related Issues
- Closes: https://algorandfoundation.atlassian.net/browse/PERA-1664
- Related PRs - https://github.com/perawallet/pera-android/pull/155