### PR TITLE
Pera 1689 :: Create new IsAccountRekeyedToAnotherAccountUseCase and replace isAccountRekeyed function with it

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/modules/accounts/di/AccountsModule.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accounts/di/AccountsModule.kt
@@ -13,7 +13,6 @@
 package com.algorand.android.modules.accounts.di
 
 import com.algorand.android.modules.accounts.domain.usecase.GetAuthAddressOfAnAccount
-import com.algorand.android.modules.accounts.domain.usecase.IsSenderRekeyedToAnotherAccount
 import com.algorand.android.usecase.AccountDetailUseCase
 import dagger.Module
 import dagger.Provides
@@ -24,12 +23,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object AccountsModule {
-
-    @Provides
-    @Singleton
-    fun provideIsSenderRekeyedToAnotherAccount(
-        useCase: AccountDetailUseCase
-    ): IsSenderRekeyedToAnotherAccount = IsSenderRekeyedToAnotherAccount(useCase::isAccountRekeyed)
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/algorand/android/modules/assetinbox/detail/receivedetail/domain/usecase/CreateArc59ClaimTransactionUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/assetinbox/detail/receivedetail/domain/usecase/CreateArc59ClaimTransactionUseCase.kt
@@ -20,20 +20,24 @@ import com.algorand.android.models.TransactionParams
 import com.algorand.android.modules.assetinbox.detail.receivedetail.domain.model.Arc59ClaimTransactionPayload
 import com.algorand.android.modules.assetinbox.detail.receivedetail.domain.model.BaseArc59ClaimRejectTransaction.Arc59ClaimTransaction
 import com.algorand.android.repository.TransactionsRepository
-import com.algorand.android.usecase.AccountDetailUseCase
 import com.algorand.android.usecase.IsOnTestnetUseCase
 import com.algorand.android.utils.toSuggestedParams
+import com.algorand.wallet.account.detail.domain.usecase.IsAccountRekeyedToAnotherAccount
+import com.algorand.wallet.account.info.domain.usecase.IsAssetOwnedByAccount
+import com.algorand.wallet.account.info.domain.usecase.GetAccountRekeyAdminAddress
 import javax.inject.Inject
 
 class CreateArc59ClaimTransactionUseCase @Inject constructor(
-    private val accountDetailUseCase: AccountDetailUseCase,
     private val transactionsRepository: TransactionsRepository,
-    private val isOnTestnetUseCase: IsOnTestnetUseCase
+    private val isOnTestnetUseCase: IsOnTestnetUseCase,
+    private val getAccountRekeyAdminAddress: GetAccountRekeyAdminAddress,
+    private val isAccountRekeyedToAnotherAccount: IsAccountRekeyedToAnotherAccount,
+    private val isAssetOwnedByAccount: IsAssetOwnedByAccount
 ) : CreateArc59ClaimTransaction {
 
     override suspend fun invoke(payload: Arc59ClaimTransactionPayload): Result<List<Arc59ClaimTransaction>> {
-        val isAccountRekeyed = accountDetailUseCase.isAccountRekeyed(payload.receiverAddress)
-        val authAddress = accountDetailUseCase.getAuthAddress(payload.receiverAddress)
+        val authAddress = getAccountRekeyAdminAddress(payload.receiverAddress)
+        val isAccountRekeyed = isAccountRekeyedToAnotherAccount(payload.receiverAddress)
         return transactionsRepository.getTransactionParams().map { transactionParams ->
             createTransactions(payload, transactionParams).map { transactionByteArray ->
                 Arc59ClaimTransaction(
@@ -46,11 +50,7 @@ class CreateArc59ClaimTransactionUseCase @Inject constructor(
         }
     }
 
-    private fun isReceiverOptedInToAsset(address: String, assetId: Long): Boolean {
-        return accountDetailUseCase.getCachedAccountDetail(address)?.data?.accountInformation?.hasAsset(assetId) == true
-    }
-
-    private fun createTransactions(
+    private suspend fun createTransactions(
         payload: Arc59ClaimTransactionPayload,
         transactionParams: TransactionParams
     ): List<ByteArray> {
@@ -63,7 +63,7 @@ class CreateArc59ClaimTransactionUseCase @Inject constructor(
                 appID,
                 assetId,
                 transactionParams.toSuggestedParams(),
-                isReceiverOptedInToAsset(payload.receiverAddress, assetId),
+                isAssetOwnedByAccount(payload.receiverAddress, assetId),
                 payload.isClaimingAlgo
             )
         }

--- a/app/src/main/kotlin/com/algorand/android/modules/assetinbox/detail/receivedetail/domain/usecase/CreateArc59RejectTransactionUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/assetinbox/detail/receivedetail/domain/usecase/CreateArc59RejectTransactionUseCase.kt
@@ -20,20 +20,22 @@ import com.algorand.android.models.TransactionParams
 import com.algorand.android.modules.assetinbox.detail.receivedetail.domain.model.Arc59RejectTransactionPayload
 import com.algorand.android.modules.assetinbox.detail.receivedetail.domain.model.BaseArc59ClaimRejectTransaction.Arc59RejectTransaction
 import com.algorand.android.repository.TransactionsRepository
-import com.algorand.android.usecase.AccountDetailUseCase
 import com.algorand.android.usecase.IsOnTestnetUseCase
 import com.algorand.android.utils.toSuggestedParams
+import com.algorand.wallet.account.detail.domain.usecase.IsAccountRekeyedToAnotherAccount
+import com.algorand.wallet.account.info.domain.usecase.GetAccountRekeyAdminAddress
 import javax.inject.Inject
 
 class CreateArc59RejectTransactionUseCase @Inject constructor(
-    private val accountDetailUseCase: AccountDetailUseCase,
     private val transactionsRepository: TransactionsRepository,
-    private val isOnTestnetUseCase: IsOnTestnetUseCase
+    private val isOnTestnetUseCase: IsOnTestnetUseCase,
+    private val isAccountRekeyedToAnotherAccount: IsAccountRekeyedToAnotherAccount,
+    private val getAccountRekeyAdminAddress: GetAccountRekeyAdminAddress
 ) : CreateArc59RejectTransaction {
 
     override suspend fun invoke(payload: Arc59RejectTransactionPayload): Result<List<Arc59RejectTransaction>> {
-        val isAccountRekeyed = accountDetailUseCase.isAccountRekeyed(payload.receiverAddress)
-        val authAddress = accountDetailUseCase.getAuthAddress(payload.receiverAddress)
+        val isAccountRekeyed = isAccountRekeyedToAnotherAccount(payload.receiverAddress)
+        val authAddress = getAccountRekeyAdminAddress(payload.receiverAddress)
         return transactionsRepository.getTransactionParams().map { transactionParams ->
             createTransactions(payload, transactionParams).map { transactionByteArray ->
                 Arc59RejectTransaction(

--- a/app/src/main/kotlin/com/algorand/android/modules/assetinbox/send/domain/usecase/CreateArc59SendTransaction.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/assetinbox/send/domain/usecase/CreateArc59SendTransaction.kt
@@ -17,7 +17,7 @@ import com.algorand.android.modules.assetinbox.send.domain.model.Arc59SendTransa
 import com.algorand.android.modules.assetinbox.send.domain.model.Arc59TransactionPayload
 
 interface CreateArc59SendTransaction {
-    operator fun invoke(
+    suspend operator fun invoke(
         txnParams: TransactionParams,
         payload: Arc59TransactionPayload
     ): List<Arc59SendTransaction>?

--- a/app/src/main/kotlin/com/algorand/android/modules/assetinbox/send/domain/usecase/CreateArc59SendTransactionUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/assetinbox/send/domain/usecase/CreateArc59SendTransactionUseCase.kt
@@ -17,20 +17,25 @@ import com.algorand.android.BuildConfig
 import com.algorand.android.models.TransactionParams
 import com.algorand.android.modules.assetinbox.send.domain.model.Arc59SendTransaction
 import com.algorand.android.modules.assetinbox.send.domain.model.Arc59TransactionPayload
-import com.algorand.android.usecase.AccountDetailUseCase
 import com.algorand.android.usecase.IsOnTestnetUseCase
 import com.algorand.android.utils.toSuggestedParams
 import com.algorand.android.utils.toUint64
+import com.algorand.wallet.account.detail.domain.usecase.IsAccountRekeyedToAnotherAccount
+import com.algorand.wallet.account.info.domain.usecase.GetAccountRekeyAdminAddress
 import javax.inject.Inject
 
 class CreateArc59SendTransactionUseCase @Inject constructor(
-    private val accountDetailUseCase: AccountDetailUseCase,
-    private val isOnTestnetUseCase: IsOnTestnetUseCase
+    private val isOnTestnetUseCase: IsOnTestnetUseCase,
+    private val isAccountRekeyedToAnotherAccount: IsAccountRekeyedToAnotherAccount,
+    private val getAccountRekeyAdminAddress: GetAccountRekeyAdminAddress
 ) : CreateArc59SendTransaction {
 
-    override fun invoke(txnParams: TransactionParams, payload: Arc59TransactionPayload): List<Arc59SendTransaction> {
-        val senderAuthAddress = accountDetailUseCase.getAuthAddress(payload.senderAddress)
-        val isSenderRekeyedToAnotherAccount = accountDetailUseCase.isAccountRekeyed(payload.senderAddress)
+    override suspend fun invoke(
+        txnParams: TransactionParams,
+        payload: Arc59TransactionPayload
+    ): List<Arc59SendTransaction> {
+        val senderAuthAddress = getAccountRekeyAdminAddress(payload.senderAddress)
+        val isSenderRekeyedToAnotherAccount = isAccountRekeyedToAnotherAccount(payload.senderAddress)
         val transactions = txnParams.createTransactions(payload)
         return transactions.map { transactionByteArray ->
             Arc59SendTransaction(

--- a/app/src/main/kotlin/com/algorand/android/modules/assetinbox/send/domain/usecase/CreateArc59TransactionsUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/assetinbox/send/domain/usecase/CreateArc59TransactionsUseCase.kt
@@ -38,7 +38,7 @@ class CreateArc59TransactionsUseCase @Inject constructor(
         )
     }
 
-    private fun TransactionParams.createArc59Transactions(
+    private suspend fun TransactionParams.createArc59Transactions(
         payload: Arc59TransactionPayload
     ): Result<List<Arc59SendTransaction>> {
         val sendTransactions = createArc59SendTransaction(this, payload) ?: emptyList()

--- a/app/src/main/kotlin/com/algorand/android/modules/keyreg/domain/usecase/CreateKeyRegTransactionUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/keyreg/domain/usecase/CreateKeyRegTransactionUseCase.kt
@@ -17,7 +17,6 @@ import com.algorand.android.models.Result.Error
 import com.algorand.android.models.Result.Success
 import com.algorand.android.models.TransactionParams
 import com.algorand.android.modules.accounts.domain.usecase.GetAuthAddressOfAnAccount
-import com.algorand.android.modules.accounts.domain.usecase.IsSenderRekeyedToAnotherAccount
 import com.algorand.android.modules.algosdk.domain.model.OfflineKeyRegTransactionPayload
 import com.algorand.android.modules.algosdk.domain.model.OnlineKeyRegTransactionPayload
 import com.algorand.android.modules.algosdk.domain.usecase.BuildKeyRegOfflineTransaction
@@ -25,6 +24,7 @@ import com.algorand.android.modules.algosdk.domain.usecase.BuildKeyRegOnlineTran
 import com.algorand.android.modules.keyreg.domain.model.KeyRegTransaction
 import com.algorand.android.modules.keyreg.ui.model.KeyRegTransactionDetail
 import com.algorand.android.modules.transaction.domain.GetTransactionParams
+import com.algorand.wallet.account.detail.domain.usecase.IsAccountRekeyedToAnotherAccount
 import javax.inject.Inject
 
 fun interface CreateKeyRegTransaction {
@@ -32,7 +32,7 @@ fun interface CreateKeyRegTransaction {
 }
 
 internal class CreateKeyRegTransactionUseCase @Inject constructor(
-    private val isSenderRekeyedToAnotherAccount: IsSenderRekeyedToAnotherAccount,
+    private val isAccountRekeyedToAnotherAccount: IsAccountRekeyedToAnotherAccount,
     private val getAuthAddressOfAnAccount: GetAuthAddressOfAnAccount,
     private val getTransactionParams: GetTransactionParams,
     private val buildKeyRegOfflineTransaction: BuildKeyRegOfflineTransaction,
@@ -76,7 +76,7 @@ internal class CreateKeyRegTransactionUseCase @Inject constructor(
         }
     }
 
-    private fun createKeyRegTransactionResult(
+    private suspend fun createKeyRegTransactionResult(
         txnDetail: KeyRegTransactionDetail,
         txnByteArray: ByteArray
     ): KeyRegTransaction {
@@ -84,7 +84,7 @@ internal class CreateKeyRegTransactionUseCase @Inject constructor(
             transactionByteArray = txnByteArray,
             accountAddress = txnDetail.address,
             accountAuthAddress = getAuthAddressOfAnAccount(txnDetail.address),
-            isRekeyedToAnotherAccount = isSenderRekeyedToAnotherAccount(txnDetail.address)
+            isRekeyedToAnotherAccount = isAccountRekeyedToAnotherAccount(txnDetail.address)
         )
     }
 

--- a/app/src/main/kotlin/com/algorand/android/modules/swap/confirmswap/domain/usecase/CreateSwapQuoteTransactionsUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/swap/confirmswap/domain/usecase/CreateSwapQuoteTransactionsUseCase.kt
@@ -24,7 +24,7 @@ import com.algorand.android.modules.swap.confirmswap.domain.model.UnsignedSwapSi
 import com.algorand.android.usecase.NetworkSlugUseCase
 import com.algorand.android.utils.DataResource
 import com.algorand.android.utils.decodeBase64
-import com.algorand.wallet.account.info.domain.usecase.GetAccountRekeyAuthAddress
+import com.algorand.wallet.account.info.domain.usecase.GetAccountRekeyAdminAddress
 import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.flow.collectLatest
@@ -37,7 +37,7 @@ class CreateSwapQuoteTransactionsUseCase @Inject constructor(
     private val swapTransactionItemFactory: SwapTransactionItemFactory,
     private val networkSlugUseCase: NetworkSlugUseCase,
     private val parseTransactionMsgPackUseCase: ParseTransactionMsgPackUseCase,
-    private val getAccountRekeyAuthAddress: GetAccountRekeyAuthAddress
+    private val getAccountRekeyAdminAddress: GetAccountRekeyAdminAddress
 ) {
 
     suspend fun createQuoteTransactions(
@@ -111,7 +111,7 @@ class CreateSwapQuoteTransactionsUseCase @Inject constructor(
                     transactionListIndex = index,
                     transactionMsgPack = unsignedTransaction,
                     accountAddress = accountAddress,
-                    accountAuthAddress = getAccountRekeyAuthAddress(accountAddress),
+                    accountAuthAddress = getAccountRekeyAdminAddress(accountAddress),
                     rawTransaction = unsignedTransaction?.decodeBase64()
                         ?.run { parseTransactionMsgPackUseCase.parse(this) }
                 )

--- a/app/src/main/kotlin/com/algorand/android/usecase/AccountDetailUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/usecase/AccountDetailUseCase.kt
@@ -21,7 +21,6 @@ import com.algorand.android.models.AccountDetail
 import com.algorand.android.repository.AccountRepository
 import com.algorand.android.utils.CacheResult
 import com.algorand.android.utils.exceptions.AccountNotFoundException
-import com.algorand.android.utils.isRekeyedToAnotherAccount
 import com.algorand.android.utils.recordException
 import com.algorand.android.utils.toShortenedAddress
 import java.math.BigInteger
@@ -46,7 +45,7 @@ class AccountDetailUseCase @Inject constructor(
             .distinctUntilChanged()
     }
 
-    fun getCachedAccountDetails() = getAccountDetailCacheFlow().value.values
+    private fun getCachedAccountDetails() = getAccountDetailCacheFlow().value.values
 
     fun getCachedAccountDetail(publicKey: String): CacheResult<AccountDetail>? {
         return accountRepository.getCachedAccountDetail(publicKey)
@@ -101,7 +100,7 @@ class AccountDetailUseCase @Inject constructor(
         }
     }
 
-    fun isAuthAccountInDevice(accountAddress: String): Boolean {
+    private fun isAuthAccountInDevice(accountAddress: String): Boolean {
         val accountAuthAddress = getAuthAddress(accountAddress) ?: return false
         val authAccountDetail = getCachedAccountDetail(accountAuthAddress)?.data ?: return false
         return canAccountSignTransaction(authAccountDetail.account.address)
@@ -125,14 +124,6 @@ class AccountDetailUseCase @Inject constructor(
     fun getAuthAddress(publicKey: String): String? {
         val accountInformation = accountRepository.getCachedAccountDetail(publicKey)?.data?.accountInformation
         return accountInformation?.rekeyAdminAddress
-    }
-
-    fun isAccountRekeyed(publicKey: String): Boolean {
-        val authAddress = accountRepository.getCachedAccountDetail(publicKey)
-            ?.data
-            ?.accountInformation
-            ?.rekeyAdminAddress
-        return isRekeyedToAnotherAccount(authAddress, publicKey)
     }
 
     fun isThereAnyAccountWithPublicKey(publicKey: String): Boolean {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/di/AccountDetailModule.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/di/AccountDetailModule.kt
@@ -24,6 +24,8 @@ import com.algorand.wallet.account.detail.domain.usecase.GetAccountsDetails
 import com.algorand.wallet.account.detail.domain.usecase.GetAccountsDetailsUseCase
 import com.algorand.wallet.account.detail.domain.usecase.GetLocalRekeyedAccountCount
 import com.algorand.wallet.account.detail.domain.usecase.GetLocalRekeyedAccountCountUseCase
+import com.algorand.wallet.account.detail.domain.usecase.IsAccountRekeyedToAnotherAccount
+import com.algorand.wallet.account.detail.domain.usecase.IsAccountRekeyedToAnotherAccountUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -51,5 +53,12 @@ internal object AccountDetailModule {
     fun provideGetAccountDetail(useCase: GetAccountDetailUseCase): GetAccountDetail = useCase
 
     @Provides
-    fun provideGetRekeyedAccountCount(useCase: GetLocalRekeyedAccountCountUseCase): GetLocalRekeyedAccountCount = useCase
+    fun provideGetRekeyedAccountCount(
+        useCase: GetLocalRekeyedAccountCountUseCase
+    ): GetLocalRekeyedAccountCount = useCase
+
+    @Provides
+    fun provideIsAccountRekeyedToAnotherAccount(
+        useCase: IsAccountRekeyedToAnotherAccountUseCase
+    ): IsAccountRekeyedToAnotherAccount = useCase
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/usecase/AccountDetailUseCases.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/usecase/AccountDetailUseCases.kt
@@ -40,3 +40,7 @@ fun interface GetAccountsDetails {
 fun interface GetLocalRekeyedAccountCount {
     suspend operator fun invoke(authAddress: String): Int
 }
+
+fun interface IsAccountRekeyedToAnotherAccount {
+    suspend operator fun invoke(address: String): Boolean
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/usecase/IsAccountRekeyedToAnotherAccountUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/usecase/IsAccountRekeyedToAnotherAccountUseCase.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.detail.domain.usecase
+
+import com.algorand.wallet.account.info.domain.usecase.GetAccountRekeyAdminAddress
+import javax.inject.Inject
+
+internal class IsAccountRekeyedToAnotherAccountUseCase @Inject constructor(
+    private val getAccountRekeyAdminAddress: GetAccountRekeyAdminAddress
+) : IsAccountRekeyedToAnotherAccount {
+
+    override suspend fun invoke(address: String): Boolean {
+        val adminAddress = getAccountRekeyAdminAddress(address)
+        return !adminAddress.isNullOrBlank() && adminAddress != address
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/di/AccountInformationModule.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/di/AccountInformationModule.kt
@@ -54,7 +54,7 @@ import com.algorand.wallet.account.info.domain.usecase.GetAccountDetailCacheStat
 import com.algorand.wallet.account.info.domain.usecase.GetAccountDetailCacheStatusFlowUseCase
 import com.algorand.wallet.account.info.domain.usecase.GetAccountInformation
 import com.algorand.wallet.account.info.domain.usecase.GetAccountInformationFlow
-import com.algorand.wallet.account.info.domain.usecase.GetAccountRekeyAuthAddress
+import com.algorand.wallet.account.info.domain.usecase.GetAccountRekeyAdminAddress
 import com.algorand.wallet.account.info.domain.usecase.GetAllAccountInformationFlow
 import com.algorand.wallet.account.info.domain.usecase.GetAllAssetHoldingIds
 import com.algorand.wallet.account.info.domain.usecase.GetAllFailedCachedAccountAddresses
@@ -284,9 +284,9 @@ internal object AccountInformationModule {
     }
 
     @Provides
-    fun provideGetAccountRekeyAuthAddress(
+    fun provideGetAccountRekeyAdminAddress(
         repository: AccountInformationRepository
-    ): GetAccountRekeyAuthAddress = GetAccountRekeyAuthAddress(repository::getRekeyAuthAddress)
+    ): GetAccountRekeyAdminAddress = GetAccountRekeyAdminAddress(repository::getRekeyAuthAddress)
 
     @Provides
     fun provideGetAccountAssetHoldingsFlow(

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/AccountInformationUseCases.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/AccountInformationUseCases.kt
@@ -103,6 +103,6 @@ fun interface IsAccountCachedSuccessfully {
     suspend operator fun invoke(address: String): Boolean
 }
 
-fun interface GetAccountRekeyAuthAddress {
+fun interface GetAccountRekeyAdminAddress {
     suspend operator fun invoke(address: String): String?
 }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/detail/domain/usecase/IsAccountRekeyedToAnotherAccountUseCaseTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/detail/domain/usecase/IsAccountRekeyedToAnotherAccountUseCaseTest.kt
@@ -30,8 +30,9 @@ class IsAccountRekeyedToAnotherAccountUseCaseTest {
     fun `EXPECT false WHEN admin address is null`() = runTest {
         val address = "some-address"
         coEvery { getAccountRekeyAdminAddress(address) } returns null
+
         val result = sut.invoke(address)
-        coVerify { getAccountRekeyAdminAddress(address) }
+
         assertFalse(result)
     }
 
@@ -39,8 +40,9 @@ class IsAccountRekeyedToAnotherAccountUseCaseTest {
     fun `EXPECT false WHEN admin address is blank`() = runTest {
         val address = "some-address"
         coEvery { getAccountRekeyAdminAddress(address) } returns ""
+
         val result = sut.invoke(address)
-        coVerify { getAccountRekeyAdminAddress(address) }
+
         assertFalse(result)
     }
 
@@ -48,8 +50,9 @@ class IsAccountRekeyedToAnotherAccountUseCaseTest {
     fun `EXPECT false WHEN admin address is the same as the given address`() = runTest {
         val address = "some-address"
         coEvery { getAccountRekeyAdminAddress(address) } returns address
+
         val result = sut.invoke(address)
-        coVerify { getAccountRekeyAdminAddress(address) }
+
         assertFalse(result)
     }
 
@@ -58,8 +61,9 @@ class IsAccountRekeyedToAnotherAccountUseCaseTest {
         val address = "some-address"
         val adminAddress = "other-address"
         coEvery { getAccountRekeyAdminAddress(address) } returns adminAddress
+
         val result = sut.invoke(address)
-        coVerify { getAccountRekeyAdminAddress(address) }
+
         assertTrue(result)
     }
 }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/detail/domain/usecase/IsAccountRekeyedToAnotherAccountUseCaseTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/detail/domain/usecase/IsAccountRekeyedToAnotherAccountUseCaseTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.detail.domain.usecase
+
+import com.algorand.wallet.account.info.domain.usecase.GetAccountRekeyAdminAddress
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IsAccountRekeyedToAnotherAccountUseCaseTest {
+
+    private val getAccountRekeyAdminAddress: GetAccountRekeyAdminAddress = mockk()
+    private val sut = IsAccountRekeyedToAnotherAccountUseCase(getAccountRekeyAdminAddress)
+
+    @Test
+    fun `EXPECT false WHEN admin address is null`() = runTest {
+        val address = "some-address"
+        coEvery { getAccountRekeyAdminAddress(address) } returns null
+        val result = sut.invoke(address)
+        coVerify { getAccountRekeyAdminAddress(address) }
+        assertFalse(result)
+    }
+
+    @Test
+    fun `EXPECT false WHEN admin address is blank`() = runTest {
+        val address = "some-address"
+        coEvery { getAccountRekeyAdminAddress(address) } returns ""
+        val result = sut.invoke(address)
+        coVerify { getAccountRekeyAdminAddress(address) }
+        assertFalse(result)
+    }
+
+    @Test
+    fun `EXPECT false WHEN admin address is the same as the given address`() = runTest {
+        val address = "some-address"
+        coEvery { getAccountRekeyAdminAddress(address) } returns address
+        val result = sut.invoke(address)
+        coVerify { getAccountRekeyAdminAddress(address) }
+        assertFalse(result)
+    }
+
+    @Test
+    fun `EXPECT true WHEN admin address is different`() = runTest {
+        val address = "some-address"
+        val adminAddress = "other-address"
+        coEvery { getAccountRekeyAdminAddress(address) } returns adminAddress
+        val result = sut.invoke(address)
+        coVerify { getAccountRekeyAdminAddress(address) }
+        assertTrue(result)
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

Create new IsAccountRekeyedToAnotherAccountUseCase and replace isAccountRekeyed function with it.

- Affected Flows:
- Inbox Claim
- Inbox Reject
- Inbox Send
- Create keyreg transaction

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1689

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
