### PR TITLE
PERA-1766 :: remove add pin step in onboarding flow

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/modules/onboarding/recoverypassphrase/nameregistration/RecoverAccountNameRegistrationFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/onboarding/recoverypassphrase/nameregistration/RecoverAccountNameRegistrationFragment.kt
@@ -28,7 +28,9 @@ class RecoverAccountNameRegistrationFragment : BaseNameRegistrationFragment() {
     override fun navToNextFragment() {
         nav(
             RecoverAccountNameRegistrationFragmentDirections
-                .actionRecoverAccountNameRegistrationFragmentToRecoverAccountResultInfoFragment()
+                .actionRecoverAccountNameRegistrationFragmentToHomeNavigation(
+                    showConfetti = true
+                )
         )
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/register/createaccount/name/CreateAccountNameRegistrationFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/register/createaccount/name/CreateAccountNameRegistrationFragment.kt
@@ -30,7 +30,9 @@ class CreateAccountNameRegistrationFragment : BaseNameRegistrationFragment() {
         nameRegistrationViewModel.logEvent(PeraEvent.ONBOARDING_NAME_WALLET_COMPLETE)
         nav(
             CreateAccountNameRegistrationFragmentDirections
-                .actionCreateAccountNameRegistrationFragmentToCreateAccountResultInfoFragment()
+                .actionCreateAccountNameRegistrationFragmentToHomeNavigation(
+                    showConfetti = true
+                )
         )
     }
 }

--- a/app/src/main/res/navigation/backup_passphrase_account_name_navigation.xml
+++ b/app/src/main/res/navigation/backup_passphrase_account_name_navigation.xml
@@ -33,6 +33,16 @@
             app:destination="@id/createAccountResultInfoFragment"
             app:popUpTo="@id/loginNavigation"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_createAccountNameRegistrationFragment_to_homeNavigation"
+            app:destination="@id/homeNavigation"
+            app:popUpTo="@id/loginNavigation"
+            app:popUpToInclusive="true">
+            <argument
+                android:name="showConfetti"
+                android:defaultValue="true"
+                app:argType="boolean" />
+        </action>
     </fragment>
 
     <fragment

--- a/app/src/main/res/navigation/home_navigation.xml
+++ b/app/src/main/res/navigation/home_navigation.xml
@@ -493,6 +493,10 @@
         android:name="com.algorand.android.modules.accounts.ui.AccountsFragment"
         android:label="fragment_accounts"
         tools:layout="@layout/fragment_accounts">
+        <argument
+            android:name="showConfetti"
+            android:defaultValue="false"
+            app:argType="boolean" />
         <action
             android:id="@+id/action_accountsFragment_to_removeAssetsFragment"
             app:destination="@id/removeAssetsFragment" />

--- a/app/src/main/res/navigation/recover_with_passphrase_navigation.xml
+++ b/app/src/main/res/navigation/recover_with_passphrase_navigation.xml
@@ -72,6 +72,16 @@
             app:destination="@id/recoverAccountResultInfoFragment"
             app:popUpTo="@id/loginNavigation"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_recoverAccountNameRegistrationFragment_to_homeNavigation"
+            app:destination="@id/homeNavigation"
+            app:popUpTo="@id/loginNavigation"
+            app:popUpToInclusive="true">
+            <argument
+                android:name="showConfetti"
+                android:defaultValue="true"
+                app:argType="boolean" />
+        </action>
     </fragment>
 
     <fragment


### PR DESCRIPTION
# Pull Request Template

## Description
- remove add pin step for create account and recovery flows (every time)

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1766

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- I left showConfetti param in navgraph since we'll still want it going into home account screen.  I can add back code showing it when I get lottie animation from Tahir
- you can still add pin in settings menu, this is just to remove it from onboarding flow

