### PR TITLE
PERA-1863 :: Fix key returning 0s in account-refactor branch

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/usecase/AccountAdditionUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/usecase/AccountAdditionUseCase.kt
@@ -131,7 +131,7 @@ class AccountAdditionUseCase @Inject constructor(
             var secretKey = aesPlatformManager.decryptByteArray(type.encryptedSecretKey)
             addAlgo25Account(
                 address,
-                secretKey,
+                secretKey.copyOf(),
                 isBackedUp,
                 customName,
                 createAccount.orderIndex

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/core/domain/usecase/AddHdSeedUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/core/domain/usecase/AddHdSeedUseCase.kt
@@ -41,7 +41,7 @@ internal class AddHdSeedUseCase @Inject constructor(
             seed?.let {
                 val newSeedIdInDB = hdSeedRepository.addHdSeed(
                     seedId = 0, // Seed will be auto-generated, update name next step
-                    seed = it,
+                    seed = it.copyOf(),
                     entropy = entropy
                 ).toInt()
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/transaction/sdk/AlgoAccountSdkImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/transaction/sdk/AlgoAccountSdkImpl.kt
@@ -45,7 +45,7 @@ internal class AlgoAccountSdkImpl @Inject constructor(
             var secretKey = Sdk.generateSK()
             val output = Algo25Account(
                 address = Sdk.generateAddressFromSK(secretKey),
-                secretKey = secretKey
+                secretKey = secretKey.copyOf()
             )
             secretKey.clearFromMemory()
             output
@@ -60,7 +60,7 @@ internal class AlgoAccountSdkImpl @Inject constructor(
 
             val output = Algo25Account(
                 address = Sdk.generateAddressFromSK(secretKey),
-                secretKey = secretKey
+                secretKey = secretKey.copyOf()
             )
             secretKey.clearFromMemory()
             output

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/transaction/sdk/PeraBip39SdkImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/transaction/sdk/PeraBip39SdkImpl.kt
@@ -80,7 +80,7 @@ internal class PeraBip39SdkImpl @Inject constructor(
         // Produce the PK and turn it into an Algorand formatted address
         val algoAddress = Address(publicKey)
         var privateKey: ByteArray = xHDWalletAPI.deriveKey(
-            fromSeed(seed),
+            fromSeed(seed.copyOf()),
             getBIP44PathFromContext(keyContext, account, change, keyIndex),
             true
         )
@@ -88,8 +88,8 @@ internal class PeraBip39SdkImpl @Inject constructor(
         val output = HdKeyAccount(
             address = algoAddress.toString(),
             publicKey = publicKey,
-            privateKey = privateKey,
-            entropy = entropy,
+            privateKey = privateKey.copyOf(),
+            entropy = entropy.copyOf(),
             account = account.toInt(),
             change = change.toInt(),
             keyIndex = keyIndex.toInt(),


### PR DESCRIPTION
# Pull Request Template

## Description
- Fix key returning 0s in account-refactor branch

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1863

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Everywhere we are calling `clearFromMemory`, we need to remember to create a copy so it's a different reference or else it'll be 0 for secret key
