### PR TITLE
PERA-1877 :: Refresh settings screen when view is created

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/settings/SettingsFragment.kt
@@ -78,6 +78,7 @@ class SettingsFragment : DaggerBaseFragment(R.layout.fragment_settings),
         initDialogSavedStateListener()
         initObservers()
         initUi()
+        settingsViewModel.initSettingsPreviewFlow()
     }
 
     private fun initUi() {

--- a/app/src/main/kotlin/com/algorand/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/settings/SettingsViewModel.kt
@@ -35,17 +35,13 @@ class SettingsViewModel @Inject constructor(
     private val _settingsPreviewFlow = MutableStateFlow<SettingsPreview?>(null)
     val settingsPreviewFlow: StateFlow<SettingsPreview?> get() = _settingsPreviewFlow
 
-    init {
-        initSettingsPreviewFlow()
-    }
-
     fun deleteAllData(notificationManager: NotificationManager?, onDeletionCompleted: () -> Unit) {
         viewModelScope.launch {
             deleteAllDataUseCase.deleteAllData(notificationManager, onDeletionCompleted)
         }
     }
 
-    private fun initSettingsPreviewFlow() {
+    fun initSettingsPreviewFlow() {
         viewModelScope.launchIO {
             settingsPreviewUseCase.getSettingsPreviewFlow().collectLatest { preview ->
                 _settingsPreviewFlow.emit(preview)


### PR DESCRIPTION
# Pull Request Template

## Description
- Moved initialization into onViewCreated

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1877

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?


https://github.com/user-attachments/assets/d2f8e318-c86c-4b9b-b111-d4d9c56dbf17

