### PR TITLE
PERA-1816 :: Map firebase token result flow into shared flow in main vie…

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/MainActivity.kt
+++ b/app/src/main/kotlin/com/algorand/android/MainActivity.kt
@@ -58,7 +58,6 @@ import com.algorand.android.models.WalletConnectRequest.WalletConnectTransaction
 import com.algorand.android.modules.assetinbox.assetinboxoneaccount.ui.model.AssetInboxOneAccountNavArgs
 import com.algorand.android.modules.autolockmanager.ui.AutoLockManager
 import com.algorand.android.modules.deeplink.ui.DeeplinkHandler
-import com.algorand.android.modules.firebase.token.FirebaseTokenManager
 import com.algorand.android.modules.firebase.token.model.FirebaseTokenResult
 import com.algorand.android.modules.keyreg.ui.model.KeyRegTransactionDetail
 import com.algorand.android.modules.perawebview.ui.BasePeraWebViewFragment
@@ -172,9 +171,6 @@ class MainActivity :
 
     @Inject
     lateinit var firebaseAnalytics: FirebaseAnalytics
-
-    @Inject
-    lateinit var firebaseTokenManager: FirebaseTokenManager
 
     @Inject
     lateinit var inAppReviewManager: InAppReviewManager
@@ -587,7 +583,7 @@ class MainActivity :
         )
 
         collectLatestOnLifecycle(
-            flow = firebaseTokenManager.firebaseTokenResultFlow,
+            flow = mainViewModel.firebaseTokenResultFlow,
             collection = firebaseTokenResultCollector
         )
 

--- a/app/src/main/kotlin/com/algorand/android/MainViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/MainViewModel.kt
@@ -29,6 +29,8 @@ import com.algorand.android.modules.appopencount.domain.usecase.IncreaseAppOpeni
 import com.algorand.android.modules.autolockmanager.ui.AutoLockManager
 import com.algorand.android.modules.autolockmanager.ui.usecase.AutoLockManagerUseCase
 import com.algorand.android.modules.deeplink.ui.DeeplinkHandler
+import com.algorand.android.modules.firebase.token.FirebaseTokenManager
+import com.algorand.android.modules.firebase.token.model.FirebaseTokenResult
 import com.algorand.android.modules.pendingintentkeeper.ui.PendingIntentKeeper
 import com.algorand.android.modules.swap.utils.SwapNavigationDestinationHelper
 import com.algorand.android.modules.tutorialdialog.domain.usecase.TutorialUseCase
@@ -62,8 +64,11 @@ import kotlin.properties.Delegates
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 
 @Suppress("LongParameterList")
@@ -92,6 +97,7 @@ class MainViewModel @Inject constructor(
     private val autoLockManager: AutoLockManager,
     private val autoLockSuggestionManager: AutoLockSuggestionManager,
     private val androidEncryptionManager: AndroidEncryptionManager,
+    firebaseTokenManager: FirebaseTokenManager,
     getAppCacheStatusFlow: GetAppCacheStatusFlow
 ) : BaseViewModel(), EventViewModel<MainViewModel.ViewEvent> by eventDelegate {
 
@@ -105,6 +111,9 @@ class MainViewModel @Inject constructor(
             handlePendingIntent(true)
         }
     }
+
+    val firebaseTokenResultFlow: SharedFlow<FirebaseTokenResult> = firebaseTokenManager.firebaseTokenResultFlow
+        .shareIn(viewModelScope, started = SharingStarted.Lazily)
 
     private val _swapNavigationResultFlow = MutableStateFlow<Event<NavDirections>?>(null)
     private val _activeNodeFlow = MutableStateFlow<Node?>(null)

--- a/app/src/main/kotlin/com/algorand/android/modules/firebase/token/model/FirebaseTokenResult.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/firebase/token/model/FirebaseTokenResult.kt
@@ -14,9 +14,9 @@ package com.algorand.android.modules.firebase.token.model
 
 sealed class FirebaseTokenResult {
 
-    object TokenLoading : FirebaseTokenResult()
+    data object TokenLoading : FirebaseTokenResult()
 
-    object TokenLoaded : FirebaseTokenResult()
+    data object TokenLoaded : FirebaseTokenResult()
 
-    object TokenFailed : FirebaseTokenResult()
+    data object TokenFailed : FirebaseTokenResult()
 }


### PR DESCRIPTION
…wmodel

# Pull Request Template

## Description
FirebaseTokenResultFlow is a StateFlow, which was being observed when every time app is in foreground. Mapped it to SharedFlow in MainViewModel, so that when app is in foreground, it doesn't observe values that was emitted before subscription.  

## Related Issues
Closes https://algorandfoundation.atlassian.net/browse/PERA-1816

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?


https://github.com/user-attachments/assets/9f217678-68af-4eac-bde8-8a6120aad060

