### PR TITLE
PERA-1948 :: fix migration issue due to missing generated key

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/encryption/domain/usecase/AndroidEncryptionManagerImpl.kt
+++ b/app/src/main/kotlin/com/algorand/android/encryption/domain/usecase/AndroidEncryptionManagerImpl.kt
@@ -124,7 +124,7 @@ internal class AndroidEncryptionManagerImpl @Inject constructor(
                 Log.d(TAG, "StrongBox key generated successfully")
             } catch (e: java.security.ProviderException) {
                 // Fall back to software-backed key
-                Log.e(TAG, "StrongBox not available, falling back to software-backed key", e)
+                Log.d(TAG, "StrongBox not available, falling back to software-backed key", e)
                 createKey(keyGenerator, KEY_ALIAS, useStrongBox = false)
                 saveStrongBoxUsedCheck.invoke(false)
                 Log.d(TAG, "Software-backed key generated successfully")

--- a/app/src/main/kotlin/com/algorand/android/modules/settings/domain/usecase/MigrateTo6xUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/settings/domain/usecase/MigrateTo6xUseCase.kt
@@ -12,6 +12,7 @@
 
 package com.algorand.android.modules.settings.domain.usecase
 
+import com.algorand.android.encryption.domain.usecase.AndroidEncryptionManager
 import com.algorand.android.models.Account
 import com.algorand.android.models.AccountCreation
 import com.algorand.android.usecase.AccountAdditionUseCase
@@ -24,6 +25,7 @@ import javax.inject.Inject
 
 class MigrateTo6xUseCase @Inject constructor(
     private val getLocalAccountsFromSharedPrefUseCase: GetLocalAccountsFromSharedPrefUseCase,
+    private val androidEncryptionManager: AndroidEncryptionManager,
     private val aesPlatformManager: AESPlatformManager,
     private val accountAdditionUseCase: AccountAdditionUseCase,
     private val peraExceptionLogger: PeraExceptionLogger
@@ -31,12 +33,12 @@ class MigrateTo6xUseCase @Inject constructor(
 
     suspend fun invoke(): PeraResult<Int> {
         return try {
+            androidEncryptionManager.initializeEncryptionManager()
+
             val localAccounts = getLocalAccountsFromSharedPrefUseCase.getLocalAccountsFromSharedPref()
             var migratedCount = 0
-
             localAccounts?.forEach { localAccount ->
                 val migrateAccount = createMigrationAccount(localAccount)
-
                 migrateAccount?.let {
                     accountAdditionUseCase.addNewAccount(it)
                     migratedCount++

--- a/app/src/main/kotlin/com/algorand/android/ui/settings/developersettings/DeveloperSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/settings/developersettings/DeveloperSettingsViewModel.kt
@@ -15,7 +15,6 @@ package com.algorand.android.ui.settings.developersettings
 import androidx.lifecycle.viewModelScope
 import com.algorand.android.core.BaseViewModel
 import com.algorand.android.ui.settings.usecase.DeveloperSettingsPreviewUseCase
-import com.algorand.android.usecase.GetLocalAccountsFromSharedPrefUseCase
 import com.algorand.wallet.remoteconfig.domain.usecase.ENABLE_ACCOUNT_DB_MIGRATION_VIEWER
 import com.algorand.wallet.remoteconfig.domain.usecase.IsFeatureToggleEnabled
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,7 +24,6 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class DeveloperSettingsViewModel @Inject constructor(
     private val developerSettingsPreviewUseCase: DeveloperSettingsPreviewUseCase,
-    private val getLocalAccountsFromSharedPrefUseCase: GetLocalAccountsFromSharedPrefUseCase,
     private val isFeatureToggleEnabled: IsFeatureToggleEnabled
 ) : BaseViewModel() {
 


### PR DESCRIPTION
# Pull Request Template

## Description
- Fix migration issue due to missing generated key dependency

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1948

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- This is a migration bug so create an account on dev branch (`v5.202507.1`) and then load up `v6.0.0` branch to upgrade. 
- `androidEncryptionManager.initializeEncryptionManager()` is in `MigrateTo6XUseCase.kt `and `MainViewModel.kt` has an instance too...where should we ideally put this line?  Or we can put it both places, I'm also find with that since the usecase is only used for migration
