### PR TITLE
PERA-2034 :: Use AccountLite to populate some account listing screens

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/accountselection/usecase/AccountSelectionUiUseCases.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/accountselection/usecase/AccountSelectionUiUseCases.kt
@@ -14,19 +14,19 @@ package com.algorand.android.modules.accountcore.ui.accountselection.usecase
 
 import com.algorand.android.models.BaseAccountSelectionListItem
 import com.algorand.android.modules.accountcore.ui.model.BaseItemConfiguration
-import com.algorand.wallet.account.detail.domain.model.AccountDetail
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import com.algorand.wallet.account.detail.domain.model.AccountType
 
 fun interface CreateLoadedAccountConfiguration {
     suspend operator fun invoke(
-        accountDetail: AccountDetail,
+        accountLite: AccountLite,
         showHoldings: Boolean,
         selectedCurrencySymbol: String
     ): BaseItemConfiguration.AccountItemConfiguration
 }
 
 fun interface CreateNotLoadedAccountConfiguration {
-    suspend operator fun invoke(address: String): BaseItemConfiguration.AccountItemConfiguration
+    suspend operator fun invoke(accountLite: AccountLite): BaseItemConfiguration.AccountItemConfiguration
 }
 
 fun interface GetAccountSelectionAccountItems {

--- a/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/accountselection/usecase/CreateLoadedAccountConfigurationUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/accountselection/usecase/CreateLoadedAccountConfigurationUseCase.kt
@@ -12,30 +12,27 @@
 
 package com.algorand.android.modules.accountcore.ui.accountselection.usecase
 
-import com.algorand.android.modules.accountcore.domain.usecase.GetAccountTotalValue
 import com.algorand.android.modules.accountcore.ui.mapper.AccountItemConfigurationMapper
 import com.algorand.android.modules.accountcore.ui.model.BaseItemConfiguration
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountDisplayName
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreview
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import com.algorand.android.utils.formatAsCurrency
-import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import javax.inject.Inject
 
 internal class CreateLoadedAccountConfigurationUseCase @Inject constructor(
-    private val getAccountTotalValue: GetAccountTotalValue,
     private val accountItemConfigurationMapper: AccountItemConfigurationMapper,
     private val getAccountDisplayName: GetAccountDisplayName,
     private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview
 ) : CreateLoadedAccountConfiguration {
 
     override suspend fun invoke(
-        accountDetail: AccountDetail,
+        accountLite: AccountLite,
         showHoldings: Boolean,
         selectedCurrencySymbol: String
     ): BaseItemConfiguration.AccountItemConfiguration {
-        val primaryAccountValue = getAccountTotalValue(accountDetail.address, includeAlgo = true).primaryAccountValue
         val accountPrimaryValueText = if (showHoldings) {
-            primaryAccountValue.formatAsCurrency(
+            accountLite.cachedInfo?.primaryAccountValue?.formatAsCurrency(
                 symbol = selectedCurrencySymbol,
                 isCompact = true,
                 isFiat = true
@@ -43,13 +40,14 @@ internal class CreateLoadedAccountConfigurationUseCase @Inject constructor(
         } else {
             null
         }
+
         return accountItemConfigurationMapper(
-            accountAddress = accountDetail.address,
-            accountDisplayName = getAccountDisplayName(accountDetail.address),
-            accountIconDrawablePreview = getAccountIconDrawablePreview(accountDetail.address),
+            accountAddress = accountLite.address,
+            accountDisplayName = getAccountDisplayName(accountLite),
+            accountIconDrawablePreview = getAccountIconDrawablePreview(accountLite),
             accountPrimaryValueText = accountPrimaryValueText,
-            accountPrimaryValue = primaryAccountValue,
-            accountType = accountDetail.accountType
+            accountPrimaryValue = accountLite.cachedInfo?.primaryAccountValue,
+            accountType = accountLite.cachedInfo?.type
         )
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/accountselection/usecase/CreateNotLoadedAccountConfigurationUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/accountselection/usecase/CreateNotLoadedAccountConfigurationUseCase.kt
@@ -16,6 +16,7 @@ import com.algorand.android.modules.accountcore.ui.mapper.AccountItemConfigurati
 import com.algorand.android.modules.accountcore.ui.model.BaseItemConfiguration
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountDisplayName
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreview
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import javax.inject.Inject
 
 internal class CreateNotLoadedAccountConfigurationUseCase @Inject constructor(
@@ -24,13 +25,13 @@ internal class CreateNotLoadedAccountConfigurationUseCase @Inject constructor(
     private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview
 ) : CreateNotLoadedAccountConfiguration {
 
-    override suspend fun invoke(address: String): BaseItemConfiguration.AccountItemConfiguration {
+    override suspend fun invoke(accountLite: AccountLite): BaseItemConfiguration.AccountItemConfiguration {
         return accountItemConfigurationMapper(
-            accountAddress = address,
-            accountDisplayName = getAccountDisplayName(address),
-            accountIconDrawablePreview = getAccountIconDrawablePreview(address),
+            accountAddress = accountLite.address,
+            accountDisplayName = getAccountDisplayName(accountLite),
+            accountIconDrawablePreview = getAccountIconDrawablePreview(accountLite),
             showWarningIcon = true,
-            accountType = null
+            accountType = accountLite.cachedInfo?.type
         )
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/accountselection/usecase/GetAccountSelectionAccountItemsUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/accountselection/usecase/GetAccountSelectionAccountItemsUseCase.kt
@@ -35,7 +35,7 @@ internal class GetAccountSelectionAccountItemsUseCase @Inject constructor(
         val sortedAccountListItems = getSortedAccountsByPreference(
             onLoadedAccountConfiguration = {
                 createLoadedAccountConfiguration(
-                    accountDetail = this,
+                    accountLite = this,
                     showHoldings = showHoldings,
                     selectedCurrencySymbol = selectedCurrencySymbol
                 )

--- a/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/usecase/GetAccountDisplayName.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/usecase/GetAccountDisplayName.kt
@@ -1,6 +1,7 @@
 package com.algorand.android.modules.accountcore.ui.usecase
 
 import com.algorand.android.modules.accountcore.ui.model.AccountDisplayName
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import com.algorand.wallet.account.detail.domain.model.AccountType
 
@@ -10,4 +11,6 @@ interface GetAccountDisplayName {
     suspend operator fun invoke(address: String, name: String?, type: AccountType?): AccountDisplayName
 
     suspend operator fun invoke(accountDetail: AccountDetail): AccountDisplayName
+
+    suspend operator fun invoke(accountLite: AccountLite): AccountDisplayName
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/usecase/GetAccountDisplayNameUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/usecase/GetAccountDisplayNameUseCase.kt
@@ -15,6 +15,7 @@ package com.algorand.android.modules.accountcore.ui.usecase
 import android.content.res.Resources
 import com.algorand.android.R
 import com.algorand.android.modules.accountcore.ui.model.AccountDisplayName
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import com.algorand.android.utils.toShortenedAddress
 import com.algorand.wallet.account.custom.domain.usecase.GetAccountCustomInfoOrNull
 import com.algorand.wallet.account.detail.domain.model.AccountDetail
@@ -81,6 +82,17 @@ internal class GetAccountDisplayNameUseCase @Inject constructor(
                 accountAddress = address,
                 primaryDisplayName = getPrimaryName(address, customAccountInfo?.customName, nameService),
                 secondaryDisplayName = getSecondaryName(address, customAccountInfo?.customName, nameService)
+            )
+        }
+    }
+
+    override suspend fun invoke(accountLite: AccountLite): AccountDisplayName {
+        val nameService = getAccountNameService(accountLite.address)
+        return with(accountLite) {
+            AccountDisplayName(
+                accountAddress = address,
+                primaryDisplayName = getPrimaryName(address, customName, nameService),
+                secondaryDisplayName = getSecondaryName(address, customName, nameService)
             )
         }
     }

--- a/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/usecase/GetAccountIconDrawablePreview.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/usecase/GetAccountIconDrawablePreview.kt
@@ -13,9 +13,11 @@
 package com.algorand.android.modules.accountcore.ui.usecase
 
 import com.algorand.android.modules.accounticon.ui.model.AccountIconDrawablePreview
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import com.algorand.wallet.account.detail.domain.model.AccountDetail
 
 interface GetAccountIconDrawablePreview {
     suspend operator fun invoke(address: String): AccountIconDrawablePreview
     suspend operator fun invoke(accountDetail: AccountDetail): AccountIconDrawablePreview
+    suspend operator fun invoke(accountLite: AccountLite): AccountIconDrawablePreview
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/usecase/GetAccountIconDrawablePreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountcore/ui/usecase/GetAccountIconDrawablePreviewUseCase.kt
@@ -16,6 +16,7 @@ import com.algorand.android.R
 import com.algorand.android.models.AccountIconResource
 import com.algorand.android.modules.accountcore.ui.usecase.AccountIconDrawablePreviews.getRekeyedDrawable
 import com.algorand.android.modules.accounticon.ui.model.AccountIconDrawablePreview
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import com.algorand.wallet.account.detail.domain.model.AccountRegistrationType
 import com.algorand.wallet.account.detail.domain.model.AccountType
@@ -27,32 +28,47 @@ import javax.inject.Inject
 internal class GetAccountIconDrawablePreviewUseCase @Inject constructor(
     private val getAccountDetail: GetAccountDetail,
     private val getAccountRegistrationType: GetAccountRegistrationType,
-    private val getAccountRekeyAdminAddress: GetAccountRekeyAdminAddress
+    private val getAccountRekeyAdminAddress: GetAccountRekeyAdminAddress,
+    private val getAccountIconDrawablePreviewByType: GetAccountIconDrawablePreviewByType
 ) : GetAccountIconDrawablePreview {
 
     override suspend fun invoke(address: String): AccountIconDrawablePreview {
         val accountDetail = getAccountDetail(address)
-        return getAccountIconDrawablePreview(accountDetail)
+        return getAccountIconDrawablePreview(address, accountDetail.accountType, rekeyAuthAddress = null)
     }
 
     override suspend fun invoke(accountDetail: AccountDetail): AccountIconDrawablePreview {
-        return getAccountIconDrawablePreview(accountDetail)
+        return getAccountIconDrawablePreview(accountDetail.address, accountDetail.accountType, rekeyAuthAddress = null)
     }
 
-    private suspend fun getAccountIconDrawablePreview(accountDetail: AccountDetail): AccountIconDrawablePreview {
-        return when (accountDetail.accountType) {
+    override suspend fun invoke(accountLite: AccountLite): AccountIconDrawablePreview {
+        return with(accountLite) {
+            if (cachedInfo == null) {
+                getAccountIconDrawablePreviewByType(registrationType)
+            } else {
+                getAccountIconDrawablePreview(address, cachedInfo.type, cachedInfo.rekeyAuthAddress)
+            }
+        }
+    }
+
+    private suspend fun getAccountIconDrawablePreview(
+        address: String,
+        accountType: AccountType?,
+        rekeyAuthAddress: String?
+    ): AccountIconDrawablePreview {
+        return when (accountType) {
             AccountType.Algo25 -> AccountIconDrawablePreviews.getAlgo25Drawable()
             AccountType.HdKey -> AccountIconDrawablePreviews.getHdKeyDrawable()
             AccountType.LedgerBle -> AccountIconDrawablePreviews.getLedgerBleDrawable()
             AccountType.NoAuth -> AccountIconDrawablePreviews.getNoAuthDrawable()
             AccountType.Rekeyed -> getRekeyedDrawable()
-            AccountType.RekeyedAuth -> getRekeyedAuthDrawable(accountDetail.address)
+            AccountType.RekeyedAuth -> getRekeyedAuthDrawable(address, rekeyAuthAddress)
             null -> AccountIconDrawablePreviews.getDefaultIconDrawablePreview()
         }
     }
 
-    private suspend fun getRekeyedAuthDrawable(address: String): AccountIconDrawablePreview {
-        val rekeyAdminAddress = getAccountRekeyAdminAddress(address) ?: return getRekeyedDrawable()
+    private suspend fun getRekeyedAuthDrawable(address: String, rekeyAuthAddress: String?): AccountIconDrawablePreview {
+        val rekeyAdminAddress = rekeyAuthAddress ?: getAccountRekeyAdminAddress(address) ?: return getRekeyedDrawable()
         val rekeyAdminType = getAccountRegistrationType(rekeyAdminAddress)
         val backgroundColorResId = when (rekeyAdminType) {
             AccountRegistrationType.Algo25 -> AccountIconResource.STANDARD.backgroundColorResId

--- a/app/src/main/kotlin/com/algorand/android/modules/accounts/lite/di/AccountLiteAppModule.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accounts/lite/di/AccountLiteAppModule.kt
@@ -14,6 +14,8 @@ package com.algorand.android.modules.accounts.lite.di
 
 import com.algorand.android.modules.accounts.lite.domain.manager.AccountLiteManager
 import com.algorand.android.modules.accounts.lite.domain.manager.AccountLiteManagerImpl
+import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheData
+import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheDataUseCase
 import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheFlow
 import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLitesFlow
 import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLitesFlowUseCase
@@ -38,4 +40,7 @@ internal object AccountLiteAppModule {
     fun provideGetAccountLiteCacheFlow(accountLiteManager: AccountLiteManager): GetAccountLiteCacheFlow {
         return GetAccountLiteCacheFlow(accountLiteManager::localAccountLitesFlow)
     }
+
+    @Provides
+    fun provideGetAccountLiteCacheData(useCase: GetAccountLiteCacheDataUseCase): GetAccountLiteCacheData = useCase
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/accounts/lite/domain/model/AccountLite.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accounts/lite/domain/model/AccountLite.kt
@@ -16,6 +16,7 @@ import com.algorand.android.modules.parity.domain.model.AlgoAmountValue
 import com.algorand.wallet.account.detail.domain.model.AccountRegistrationType
 import com.algorand.wallet.account.detail.domain.model.AccountType
 import java.math.BigDecimal
+import java.math.BigInteger
 
 data class AccountLite(
     val address: String,
@@ -31,6 +32,8 @@ data class AccountLite(
         val algoAmountValue: AlgoAmountValue,
         val primaryAccountValue: BigDecimal,
         val secondaryAccountValue: BigDecimal,
-        val assetCount: Int
+        val assetCount: Int,
+        val minRequiredBalance: BigInteger,
+        val rekeyAuthAddress: String?
     )
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/accounts/lite/domain/usecase/AccountLiteUseCases.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accounts/lite/domain/usecase/AccountLiteUseCases.kt
@@ -25,3 +25,7 @@ fun interface GetAccountLitesFlow {
 fun interface GetAccountLiteCacheFlow {
     operator fun invoke(): StateFlow<AccountLiteCacheStatus>
 }
+
+fun interface GetAccountLiteCacheData {
+    operator fun invoke(): AccountLiteCacheStatus.Data?
+}

--- a/app/src/main/kotlin/com/algorand/android/modules/accounts/lite/domain/usecase/GetAccountLiteCacheDataUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accounts/lite/domain/usecase/GetAccountLiteCacheDataUseCase.kt
@@ -1,0 +1,14 @@
+package com.algorand.android.modules.accounts.lite.domain.usecase
+
+import com.algorand.android.modules.accounts.lite.domain.manager.AccountLiteManager
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLiteCacheStatus
+import javax.inject.Inject
+
+internal class GetAccountLiteCacheDataUseCase @Inject constructor(
+    private val accountLiteManager: AccountLiteManager
+) : GetAccountLiteCacheData {
+
+    override fun invoke(): AccountLiteCacheStatus.Data? {
+        return accountLiteManager.localAccountLitesFlow.value as? AccountLiteCacheStatus.Data
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/modules/accounts/lite/domain/usecase/GetAccountLitesFlowUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accounts/lite/domain/usecase/GetAccountLitesFlowUseCase.kt
@@ -136,7 +136,9 @@ internal class GetAccountLitesFlowUseCase @Inject constructor(
             algoAmountValue = algoAmountValue,
             primaryAccountValue = primaryAccountValue,
             secondaryAccountValue = secondaryAccountValue,
-            assetCount = accountPayload.assetHoldingLiteInformation.size
+            assetCount = accountPayload.assetHoldingLiteInformation.size,
+            minRequiredBalance = accountPayload.accountInfoLiteInformation.minRequiredBalance,
+            rekeyAuthAddress = rekeyAuthAddress
         )
     }
 

--- a/app/src/main/kotlin/com/algorand/android/modules/accountselection/ui/usecase/AddAssetAccountSelectionPreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountselection/ui/usecase/AddAssetAccountSelectionPreviewUseCase.kt
@@ -39,7 +39,7 @@ class AddAssetAccountSelectionPreviewUseCase @Inject constructor(
             excludedAccountTypes = null,
             onLoadedAccountConfiguration = {
                 createLoadedAccountConfiguration(
-                    accountDetail = this,
+                    accountLite = this,
                     showHoldings = true,
                     selectedCurrencySymbol = selectedCurrencySymbol
                 )

--- a/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransaction.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransaction.kt
@@ -13,15 +13,15 @@
 package com.algorand.android.modules.accountsorting.ui.domain.usecase
 
 import com.algorand.android.modules.accountcore.ui.model.BaseItemConfiguration
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import com.algorand.android.modules.accountsorting.ui.domain.model.BaseAccountAndAssetListItem
-import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import com.algorand.wallet.account.detail.domain.model.AccountType
 
 interface GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransaction {
     suspend operator fun invoke(
         accountFilterAssetId: Long?,
         excludedAccountTypes: List<AccountType>? = null,
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): List<BaseAccountAndAssetListItem.AccountListItem>
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/GetFilteredSortedAccountListWhichNotBackedUp.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/GetFilteredSortedAccountListWhichNotBackedUp.kt
@@ -13,13 +13,13 @@
 package com.algorand.android.modules.accountsorting.ui.domain.usecase
 
 import com.algorand.android.modules.accountcore.ui.model.BaseItemConfiguration
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import com.algorand.android.modules.accountsorting.ui.domain.model.BaseAccountAndAssetListItem
-import com.algorand.wallet.account.detail.domain.model.AccountDetail
 
 interface GetFilteredSortedAccountListWhichNotBackedUp {
 
     suspend operator fun invoke(
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): List<BaseAccountAndAssetListItem.AccountListItem>
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/GetSortedAccountsByPreference.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/GetSortedAccountsByPreference.kt
@@ -13,23 +13,23 @@
 package com.algorand.android.modules.accountsorting.ui.domain.usecase
 
 import com.algorand.android.modules.accountcore.ui.model.BaseItemConfiguration
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import com.algorand.android.modules.accountsorting.domain.model.AccountSortingTypeIdentifier
 import com.algorand.android.modules.accountsorting.ui.domain.model.AccountAndAssetListItem
-import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import com.algorand.wallet.account.detail.domain.model.AccountType
 
 interface GetSortedAccountsByPreference {
 
     suspend operator fun invoke(
         excludedAccountTypes: List<AccountType>? = null,
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): List<AccountAndAssetListItem.AccountListItem>
 
     suspend operator fun invoke(
         sortingIdentifier: AccountSortingTypeIdentifier,
         excludedAccountTypes: List<AccountType>? = null,
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): List<AccountAndAssetListItem.AccountListItem>
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/implementation/GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransactionUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/implementation/GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransactionUseCase.kt
@@ -13,22 +13,22 @@
 package com.algorand.android.modules.accountsorting.ui.domain.usecase.implementation
 
 import com.algorand.android.modules.accountcore.ui.model.BaseItemConfiguration
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
+import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheData
 import com.algorand.android.modules.accountsorting.domain.usecase.GetSortedLocalAccounts
 import com.algorand.android.modules.accountsorting.ui.domain.mapper.BaseAccountAndAssetListItemMapper
 import com.algorand.android.modules.accountsorting.ui.domain.model.BaseAccountAndAssetListItem
 import com.algorand.android.modules.accountsorting.ui.domain.usecase.GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransaction
 import com.algorand.android.modules.accountsorting.ui.domain.util.ItemConfigurationHelper
-import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import com.algorand.wallet.account.detail.domain.model.AccountType
 import com.algorand.wallet.account.detail.domain.model.AccountType.Companion.canSignTransaction
-import com.algorand.wallet.account.detail.domain.usecase.GetAccountsDetails
 import com.algorand.wallet.account.info.domain.usecase.IsAssetOwnedByAccount
 import com.algorand.wallet.asset.domain.util.AssetConstants.ALGO_ID
 import javax.inject.Inject
 
 internal class GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransactionUseCase @Inject constructor(
     private val getSortedLocalAccounts: GetSortedLocalAccounts,
-    private val getAccountsDetails: GetAccountsDetails,
+    private val getAccountLiteCacheData: GetAccountLiteCacheData,
     private val baseAccountAndAssetListItemMapper: BaseAccountAndAssetListItemMapper,
     private val isAssetOwnedByAccount: IsAssetOwnedByAccount
 ) : GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransaction {
@@ -36,17 +36,17 @@ internal class GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransactio
     override suspend operator fun invoke(
         accountFilterAssetId: Long?,
         excludedAccountTypes: List<AccountType>?,
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): List<BaseAccountAndAssetListItem.AccountListItem> {
-        val accountsDetails = getAccountsDetails()
+        val accountLites = getAccountLiteCacheData()?.accountLites.orEmpty()
         return getSortedLocalAccounts().mapNotNull { account ->
-            val accountDetail = accountsDetails.find { it.address == account.address } ?: return@mapNotNull null
-            val isAccountTypeValid = isAccountTypeValid(excludedAccountTypes, accountDetail.accountType)
-            if (isAccountTypeValid && accountDetail.accountType?.canSignTransaction() == true) {
-                val isAssetIdValid = isAssetIdValid(accountDetail, accountFilterAssetId)
+            val accountLite = accountLites[account.address] ?: return@mapNotNull null
+            val isAccountTypeValid = isAccountTypeValid(excludedAccountTypes, accountLite.cachedInfo?.type)
+            if (isAccountTypeValid && accountLite.cachedInfo?.type?.canSignTransaction() == true) {
+                val isAssetIdValid = isAssetIdValid(accountLite.address, accountFilterAssetId)
                 if (isAssetIdValid) {
-                    getAccountListItem(accountDetail, onLoadedAccountConfiguration, onFailedAccountConfiguration)
+                    getAccountListItem(accountLite, onLoadedAccountConfiguration, onFailedAccountConfiguration)
                 } else {
                     null
                 }
@@ -57,13 +57,12 @@ internal class GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransactio
     }
 
     private suspend fun getAccountListItem(
-        accountDetail: AccountDetail,
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        accountLite: AccountLite,
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): BaseAccountAndAssetListItem.AccountListItem? {
         val accountItemConfiguration = ItemConfigurationHelper.configureListItem(
-            accountDetail = accountDetail,
-            accountAddress = accountDetail.address,
+            accountLite = accountLite,
             onLoadedAccountConfiguration = onLoadedAccountConfiguration,
             onFailedAccountConfiguration = onFailedAccountConfiguration
         ) ?: return null
@@ -76,9 +75,8 @@ internal class GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransactio
         return accountType !in excludedAccountTypes
     }
 
-    private suspend fun isAssetIdValid(accountDetail: AccountDetail?, filteredAssetId: Long?): Boolean {
+    private suspend fun isAssetIdValid(address: String, filteredAssetId: Long?): Boolean {
         if (filteredAssetId == null || filteredAssetId == ALGO_ID) return true
-        if (accountDetail?.address == null) return false
-        return isAssetOwnedByAccount(accountDetail.address, filteredAssetId)
+        return isAssetOwnedByAccount(address, filteredAssetId)
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/implementation/GetFilteredSortedAccountListWhichNotBackedUpUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/implementation/GetFilteredSortedAccountListWhichNotBackedUpUseCase.kt
@@ -13,38 +13,34 @@
 package com.algorand.android.modules.accountsorting.ui.domain.usecase.implementation
 
 import com.algorand.android.modules.accountcore.ui.model.BaseItemConfiguration
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
+import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheData
 import com.algorand.android.modules.accountsorting.domain.usecase.GetSortedLocalAccounts
 import com.algorand.android.modules.accountsorting.ui.domain.mapper.BaseAccountAndAssetListItemMapper
 import com.algorand.android.modules.accountsorting.ui.domain.model.BaseAccountAndAssetListItem
 import com.algorand.android.modules.accountsorting.ui.domain.usecase.GetFilteredSortedAccountListWhichNotBackedUp
 import com.algorand.android.modules.accountsorting.ui.domain.util.ItemConfigurationHelper.configureListItem
-import com.algorand.wallet.account.custom.domain.usecase.GetBackedUpAccounts
-import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import com.algorand.wallet.account.detail.domain.model.AccountType.Companion.canSignTransaction
-import com.algorand.wallet.account.detail.domain.usecase.GetAccountsDetails
 import javax.inject.Inject
 
 internal class GetFilteredSortedAccountListWhichNotBackedUpUseCase @Inject constructor(
     private val getSortedLocalAccounts: GetSortedLocalAccounts,
-    private val getBackedUpAccounts: GetBackedUpAccounts,
-    private val getAccountsDetails: GetAccountsDetails,
     private val baseAccountAndAssetListItemMapper: BaseAccountAndAssetListItemMapper,
+    private val getAccountLiteCacheData: GetAccountLiteCacheData
 ) : GetFilteredSortedAccountListWhichNotBackedUp {
 
     override suspend fun invoke(
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): List<BaseAccountAndAssetListItem.AccountListItem> {
-        val backedUpAccounts = getBackedUpAccounts()
-        val accountsDetail = getAccountsDetails()
+        val accountLites = getAccountLiteCacheData()?.accountLites
         return getSortedLocalAccounts().mapIndexedNotNull { _, account ->
-            val accountDetail = accountsDetail.find { it.address == account.address } ?: return@mapIndexedNotNull null
-            val isBackedUp = backedUpAccounts.contains(account.address)
-            val canSignTransaction = accountDetail.accountType?.canSignTransaction() == true
+            val accountLite = accountLites?.get(account.address) ?: return@mapIndexedNotNull null
+            val isBackedUp = accountLite.isBackedUp
+            val canSignTransaction = accountLite.cachedInfo?.type?.canSignTransaction() == true
             if (canSignTransaction && !isBackedUp) {
                 val accountItemConfiguration = configureListItem(
-                    accountDetail = accountDetail,
-                    accountAddress = account.address,
+                    accountLite = accountLite,
                     onLoadedAccountConfiguration = onLoadedAccountConfiguration,
                     onFailedAccountConfiguration = onFailedAccountConfiguration
                 ) ?: return@mapIndexedNotNull null

--- a/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/implementation/GetSortedAccountsByPreferenceUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/usecase/implementation/GetSortedAccountsByPreferenceUseCase.kt
@@ -13,6 +13,8 @@
 package com.algorand.android.modules.accountsorting.ui.domain.usecase.implementation
 
 import com.algorand.android.modules.accountcore.ui.model.BaseItemConfiguration
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
+import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheData
 import com.algorand.android.modules.accountsorting.domain.model.AccountSortingTypeIdentifier
 import com.algorand.android.modules.accountsorting.domain.usecase.GetSortedLocalAccounts
 import com.algorand.android.modules.accountsorting.ui.domain.mapper.AccountAndAssetAccountListItemMapper
@@ -20,22 +22,20 @@ import com.algorand.android.modules.accountsorting.ui.domain.model.AccountAndAss
 import com.algorand.android.modules.accountsorting.ui.domain.usecase.GetSortedAccountsByPreference
 import com.algorand.android.modules.accountsorting.ui.domain.usecase.SortAccountsBySortingPreference
 import com.algorand.android.modules.accountsorting.ui.domain.util.ItemConfigurationHelper
-import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import com.algorand.wallet.account.detail.domain.model.AccountType
-import com.algorand.wallet.account.detail.domain.usecase.GetAccountDetail
 import javax.inject.Inject
 
 internal class GetSortedAccountsByPreferenceUseCase @Inject constructor(
     private val getSortedLocalAccounts: GetSortedLocalAccounts,
-    private val getAccountDetail: GetAccountDetail,
     private val accountAndAssetAccountListItemMapper: AccountAndAssetAccountListItemMapper,
-    private val sortAccountsBySortingPreference: SortAccountsBySortingPreference
+    private val sortAccountsBySortingPreference: SortAccountsBySortingPreference,
+    private val getAccountLiteCacheData: GetAccountLiteCacheData
 ) : GetSortedAccountsByPreference {
 
     override suspend fun invoke(
         excludedAccountTypes: List<AccountType>?,
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): List<AccountAndAssetListItem.AccountListItem> {
         val accountListItems = getAccountListItems(
             excludedAccountTypes = excludedAccountTypes,
@@ -48,8 +48,8 @@ internal class GetSortedAccountsByPreferenceUseCase @Inject constructor(
     override suspend fun invoke(
         sortingIdentifier: AccountSortingTypeIdentifier,
         excludedAccountTypes: List<AccountType>?,
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): List<AccountAndAssetListItem.AccountListItem> {
         val accountListItems = getAccountListItems(
             excludedAccountTypes = excludedAccountTypes,
@@ -61,17 +61,17 @@ internal class GetSortedAccountsByPreferenceUseCase @Inject constructor(
 
     private suspend fun getAccountListItems(
         excludedAccountTypes: List<AccountType>?,
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): List<AccountAndAssetListItem.AccountListItem> {
+        val accountLites = getAccountLiteCacheData()?.accountLites
         val localAccounts = getSortedLocalAccounts()
         return localAccounts.mapIndexedNotNull { _, account ->
-            val accountDetail = getAccountDetail(account.address)
-            val isAccountTypeValid = isAccountTypeValid(excludedAccountTypes, accountDetail.accountType)
+            val accountLite = accountLites?.get(account.address) ?: return@mapIndexedNotNull null
+            val isAccountTypeValid = isAccountTypeValid(excludedAccountTypes, accountLite.cachedInfo?.type)
             if (isAccountTypeValid) {
                 val accountItemConfiguration = ItemConfigurationHelper.configureListItem(
-                    accountDetail = accountDetail,
-                    accountAddress = account.address,
+                    accountLite = accountLite,
                     onLoadedAccountConfiguration = onLoadedAccountConfiguration,
                     onFailedAccountConfiguration = onFailedAccountConfiguration
                 ) ?: return@mapIndexedNotNull null

--- a/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/util/ItemConfigurationHelper.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountsorting/ui/domain/util/ItemConfigurationHelper.kt
@@ -13,20 +13,19 @@
 package com.algorand.android.modules.accountsorting.ui.domain.util
 
 import com.algorand.android.modules.accountcore.ui.model.BaseItemConfiguration
-import com.algorand.wallet.account.detail.domain.model.AccountDetail
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 
 internal object ItemConfigurationHelper {
 
     suspend fun configureListItem(
-        accountDetail: AccountDetail,
-        accountAddress: String,
-        onLoadedAccountConfiguration: suspend AccountDetail.() -> BaseItemConfiguration.AccountItemConfiguration,
-        onFailedAccountConfiguration: suspend String.() -> BaseItemConfiguration.AccountItemConfiguration?
+        accountLite: AccountLite,
+        onLoadedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration,
+        onFailedAccountConfiguration: suspend AccountLite.() -> BaseItemConfiguration.AccountItemConfiguration?
     ): BaseItemConfiguration.AccountItemConfiguration? {
-        return if (accountDetail.accountType != null) {
-            onLoadedAccountConfiguration(accountDetail)
+        return if (accountLite.cachedInfo != null) {
+            onLoadedAccountConfiguration(accountLite)
         } else {
-            onFailedAccountConfiguration.invoke((accountAddress))
+            onFailedAccountConfiguration.invoke(accountLite)
         }
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/asb/importbackup/accountselection/ui/usecase/AsbImportAccountSelectionPreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/asb/importbackup/accountselection/ui/usecase/AsbImportAccountSelectionPreviewUseCase.kt
@@ -18,11 +18,8 @@ import com.algorand.android.models.AccountCreation
 import com.algorand.android.models.AccountIconResource
 import com.algorand.android.models.ScreenState
 import com.algorand.android.models.ui.AccountAssetItemButtonState.CHECKED
-import com.algorand.android.modules.accountcore.ui.mapper.AccountItemConfigurationMapper
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountDisplayName
-import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreview
 import com.algorand.android.modules.accounticon.ui.model.AccountIconDrawablePreview
-import com.algorand.android.modules.accountsorting.ui.domain.usecase.GetSortedAccountsByPreference
 import com.algorand.android.modules.asb.importbackup.accountrestoreresult.ui.model.AsbImportRestoreResultNavArg
 import com.algorand.android.modules.asb.importbackup.accountrestoreresult.ui.usecase.CreateAsbImportedAddresses
 import com.algorand.android.modules.asb.importbackup.accountselection.ui.mapper.AsbImportAccountSelectionPreviewMapper
@@ -53,16 +50,7 @@ class AsbImportAccountSelectionPreviewUseCase @Inject constructor(
     private val getAccountDisplayName: GetAccountDisplayName,
     private val aesPlatformManager: AESPlatformManager,
     private val createAsbImportedAddresses: CreateAsbImportedAddresses,
-    getSortedAccountsByPreference: GetSortedAccountsByPreference,
-    accountItemConfigurationMapper: AccountItemConfigurationMapper,
-    getAccountIconDrawablePreview: GetAccountIconDrawablePreview
-) : BaseMultipleAccountSelectionPreviewUseCase(
-    multipleAccountSelectionListItemMapper,
-    getSortedAccountsByPreference,
-    accountItemConfigurationMapper,
-    getAccountDisplayName,
-    getAccountIconDrawablePreview
-) {
+) : BaseMultipleAccountSelectionPreviewUseCase(multipleAccountSelectionListItemMapper) {
     fun getInitialPreview(): AsbImportAccountSelectionPreview {
         val titleItem = createTitleItem(textResId = R.string.choose_accounts_n_to_restore)
         return asbImportAccountSelectionPreviewMapper.mapToAsbImportAccountSelectionPreview(

--- a/app/src/main/kotlin/com/algorand/android/modules/basemultipleaccountselection/ui/usecase/BaseMultipleAccountSelectionPreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/basemultipleaccountselection/ui/usecase/BaseMultipleAccountSelectionPreviewUseCase.kt
@@ -17,20 +17,11 @@ import androidx.annotation.StringRes
 import com.algorand.android.customviews.TriStatesCheckBox
 import com.algorand.android.models.ui.AccountAssetItemButtonState.CHECKED
 import com.algorand.android.models.ui.AccountAssetItemButtonState.UNCHECKED
-import com.algorand.android.modules.accountcore.ui.mapper.AccountItemConfigurationMapper
-import com.algorand.android.modules.accountcore.ui.usecase.GetAccountDisplayName
-import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreview
-import com.algorand.android.modules.accountsorting.ui.domain.usecase.GetSortedAccountsByPreference
 import com.algorand.android.modules.basemultipleaccountselection.ui.mapper.MultipleAccountSelectionListItemMapper
 import com.algorand.android.modules.basemultipleaccountselection.ui.model.MultipleAccountSelectionListItem
-import com.algorand.wallet.account.detail.domain.model.AccountType
 
 open class BaseMultipleAccountSelectionPreviewUseCase(
-    private val multipleAccountSelectionListItemMapper: MultipleAccountSelectionListItemMapper,
-    private val getSortedAccountsByPreference: GetSortedAccountsByPreference,
-    private val accountItemConfigurationMapper: AccountItemConfigurationMapper,
-    private val getAccountDisplayName: GetAccountDisplayName,
-    private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview
+    private val multipleAccountSelectionListItemMapper: MultipleAccountSelectionListItemMapper
 ) {
 
     protected fun getSelectedAccountAddressList(
@@ -123,38 +114,5 @@ open class BaseMultipleAccountSelectionPreviewUseCase(
             accountCount = accountCount,
             checkboxState = checkboxState
         )
-    }
-
-    protected suspend fun createAccountItemList(
-        excludedAccountTypes: List<AccountType>
-    ): List<MultipleAccountSelectionListItem.AccountItem> {
-        return getSortedAccountsByPreference(
-            excludedAccountTypes = excludedAccountTypes,
-            onLoadedAccountConfiguration = {
-                accountItemConfigurationMapper(
-                    accountAddress = address,
-                    accountDisplayName = getAccountDisplayName(address),
-                    accountIconDrawablePreview = getAccountIconDrawablePreview(address),
-                    accountType = accountType,
-                    showWarningIcon = true
-                )
-            },
-            onFailedAccountConfiguration = {
-                accountItemConfigurationMapper(
-                    accountDisplayName = getAccountDisplayName(this),
-                    accountAddress = this,
-                    accountType = null,
-                    accountIconDrawablePreview = getAccountIconDrawablePreview(this),
-                )
-            }
-        ).mapNotNull { accountListItem ->
-            with(accountListItem.itemConfiguration) {
-                multipleAccountSelectionListItemMapper.mapToAccountItem(
-                    accountDisplayName = accountDisplayName ?: return@mapNotNull null,
-                    accountIconDrawablePreview = accountIconDrawablePreview ?: return@mapNotNull null,
-                    accountViewButtonState = CHECKED
-                )
-            }
-        }
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/sorting/accountsorting/ui/usecase/AccountSortingPreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/sorting/accountsorting/ui/usecase/AccountSortingPreviewUseCase.kt
@@ -14,7 +14,6 @@ package com.algorand.android.modules.sorting.accountsorting.ui.usecase
 
 import com.algorand.android.R
 import com.algorand.android.models.ButtonConfiguration
-import com.algorand.android.modules.accountcore.domain.usecase.GetAccountTotalValue
 import com.algorand.android.modules.accountcore.ui.mapper.AccountItemConfigurationMapper
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountDisplayName
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreview
@@ -36,13 +35,12 @@ open class AccountSortingPreviewUseCase @Inject constructor(
     private val sortingTypeCreator: SortingTypeCreator,
     private val sortingPreviewMapper: SortingPreviewMapper,
     private val getAccountDisplayName: GetAccountDisplayName,
-    private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview,
     private val getSortedAccountsByPreference: GetSortedAccountsByPreference,
-    private val getAccountTotalValue: GetAccountTotalValue,
     private val accountItemConfigurationMapper: AccountItemConfigurationMapper,
     private val setAccountOrderIndex: SetAccountOrderIndex,
     private val saveAccountSortPreference: SaveAccountSortPreference,
-    private val getAccountSortingTypeIdentifier: GetAccountSortingTypeIdentifier
+    private val getAccountSortingTypeIdentifier: GetAccountSortingTypeIdentifier,
+    private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview
 ) {
 
     fun getInitialSortingPreview(): AccountSortingPreview {
@@ -130,13 +128,12 @@ open class AccountSortingPreviewUseCase @Inject constructor(
         val accountListItems = getSortedAccountsByPreference(
             sortingIdentifier = sortingIdentifier,
             onLoadedAccountConfiguration = {
-                val accountValue = getAccountTotalValue(address, true)
                 accountItemConfigurationMapper(
                     accountAddress = address,
-                    accountDisplayName = getAccountDisplayName(address),
-                    accountIconDrawablePreview = getAccountIconDrawablePreview(address),
-                    accountType = accountType,
-                    accountPrimaryValue = accountValue.primaryAccountValue,
+                    accountDisplayName = getAccountDisplayName(this),
+                    accountIconDrawablePreview = getAccountIconDrawablePreview(this),
+                    accountType = cachedInfo?.type,
+                    accountPrimaryValue = cachedInfo?.primaryAccountValue,
                     dragButtonConfiguration = ButtonConfiguration(
                         iconDrawableResId = R.drawable.ic_reorder,
                         iconTintResId = R.color.text_gray_lighter,
@@ -146,7 +143,7 @@ open class AccountSortingPreviewUseCase @Inject constructor(
                 )
             }, onFailedAccountConfiguration = {
                 accountItemConfigurationMapper(
-                    accountAddress = this,
+                    accountAddress = address,
                     accountDisplayName = getAccountDisplayName(this),
                     accountIconDrawablePreview = getAccountIconDrawablePreview(this),
                     showWarningIcon = true

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/connectionrequest/ui/usecase/WalletConnectConnectionPreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/connectionrequest/ui/usecase/WalletConnectConnectionPreviewUseCase.kt
@@ -15,12 +15,11 @@ package com.algorand.android.modules.walletconnect.connectionrequest.ui.usecase
 import com.algorand.android.R
 import com.algorand.android.models.ui.AccountAssetItemButtonState.CHECKED
 import com.algorand.android.models.ui.AccountAssetItemButtonState.UNCHECKED
-import com.algorand.android.modules.accountcore.ui.accountselection.usecase.CreateLoadedAccountConfiguration
-import com.algorand.android.modules.accountcore.ui.accountselection.usecase.CreateNotLoadedAccountConfiguration
-import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreview
-import com.algorand.android.modules.accountsorting.ui.domain.model.BaseAccountAndAssetListItem
-import com.algorand.android.modules.accountsorting.ui.domain.usecase.GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransaction
-import com.algorand.android.modules.currency.domain.usecase.GetPrimaryCurrencySymbol
+import com.algorand.android.modules.accountcore.ui.usecase.GetAccountDisplayName
+import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreviewByType
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLiteCacheStatus
+import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheFlow
 import com.algorand.android.modules.walletconnect.connectionrequest.domain.usecase.WCDomainScammerStateUseCase
 import com.algorand.android.modules.walletconnect.connectionrequest.ui.mapper.BaseWalletConnectConnectionItemMapper
 import com.algorand.android.modules.walletconnect.connectionrequest.ui.mapper.WCSessionRequestResultMapper
@@ -32,6 +31,7 @@ import com.algorand.android.modules.walletconnect.connectionrequest.ui.model.Wal
 import com.algorand.android.modules.walletconnect.domain.model.WalletConnectBlockchain
 import com.algorand.android.modules.walletconnect.ui.model.WalletConnectSessionProposal
 import com.algorand.android.utils.Event
+import com.algorand.wallet.account.detail.domain.model.AccountType.Companion.canSignTransaction
 import javax.inject.Inject
 
 @SuppressWarnings("LongParameterList")
@@ -40,32 +40,17 @@ class WalletConnectConnectionPreviewUseCase @Inject constructor(
     private val walletConnectConnectionPreviewMapper: WalletConnectConnectionPreviewMapper,
     private val wcSessionRequestResultMapper: WCSessionRequestResultMapper,
     private val walletConnectNetworkItemMapper: WalletConnectNetworkItemMapper,
-    private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview,
     private val wcDomainScammerStateUseCase: WCDomainScammerStateUseCase,
-    private val getAuthFilteredSortedAccounts: GetFilteredSortedAccountListItemsByAssetIdsWhichCanSignTransaction,
-    private val createLoadedAccountConfiguration: CreateLoadedAccountConfiguration,
-    private val createNotLoadedAccountConfiguration: CreateNotLoadedAccountConfiguration,
-    private val getPrimaryCurrencySymbol: GetPrimaryCurrencySymbol
+    private val getAccountLiteCacheFlow: GetAccountLiteCacheFlow,
+    private val getAccountIconDrawablePreviewByType: GetAccountIconDrawablePreviewByType,
+    private val getAccountDisplayName: GetAccountDisplayName
 ) {
 
     suspend fun getWalletConnectConnectionPreview(
         sessionProposal: WalletConnectSessionProposal
     ): WalletConnectConnectionPreview {
-        val sortedAccountList = createSortedAccountList()
-        val isThereOnlyOneAccount = sortedAccountList.count() == 1
-        val preSelectedButtonState = if (isThereOnlyOneAccount) CHECKED else UNCHECKED
 
-        val accountItems = sortedAccountList.map { accountListItem ->
-            baseWalletConnectConnectionItemMapper.mapToAccountItem(
-                accountAddress = accountListItem.itemConfiguration.accountAddress,
-                accountIconDrawablePreview = getAccountIconDrawablePreview(
-                    address = accountListItem.itemConfiguration.accountAddress
-                ),
-                accountDisplayName = accountListItem.itemConfiguration.accountDisplayName,
-                buttonState = preSelectedButtonState,
-                isChecked = isThereOnlyOneAccount
-            )
-        }
+        val accountItems = getAccountItems()
 
         val dAppInfoItem = baseWalletConnectConnectionItemMapper.mapToDappInfoItem(
             name = sessionProposal.peerMeta.name,
@@ -117,20 +102,34 @@ class WalletConnectConnectionPreviewUseCase @Inject constructor(
         )
     }
 
-    private suspend fun createSortedAccountList(): List<BaseAccountAndAssetListItem.AccountListItem> {
-        return getAuthFilteredSortedAccounts(
-            accountFilterAssetId = null,
-            onLoadedAccountConfiguration = {
-                createLoadedAccountConfiguration(
-                    accountDetail = this,
-                    showHoldings = true,
-                    selectedCurrencySymbol = getPrimaryCurrencySymbol().orEmpty()
-                )
-            },
-            onFailedAccountConfiguration = {
-                createNotLoadedAccountConfiguration(address = this)
+    private suspend fun getAccountItems(): List<BaseWalletConnectConnectionItem.AccountItem> {
+        val sortedAccountList = createSortedAccountList()
+        val isThereOnlyOneAccount = sortedAccountList.count() == 1
+        val preSelectedButtonState = if (isThereOnlyOneAccount) CHECKED else UNCHECKED
+
+        return sortedAccountList.map { accountLite ->
+            val iconDrawablePreview = if (accountLite.cachedInfo?.type != null) {
+                getAccountIconDrawablePreviewByType(accountLite.cachedInfo.type)
+            } else {
+                getAccountIconDrawablePreviewByType(accountLite.registrationType)
             }
-        )
+            with(accountLite) {
+                baseWalletConnectConnectionItemMapper.mapToAccountItem(
+                    accountAddress = address,
+                    accountIconDrawablePreview = iconDrawablePreview,
+                    accountDisplayName = getAccountDisplayName(address, customName, cachedInfo?.type),
+                    buttonState = preSelectedButtonState,
+                    isChecked = isThereOnlyOneAccount
+                )
+            }
+        }
+    }
+
+    private fun createSortedAccountList(): Collection<AccountLite> {
+        return (getAccountLiteCacheFlow().value as? AccountLiteCacheStatus.Data)?.accountLites
+            ?.filter { it.value.cachedInfo?.type?.canSignTransaction() == true }
+            ?.values
+            .orEmpty()
     }
 
     fun updatePreviewStateAccordingToAccountSelection(

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/connectionrequest/ui/usecase/WalletConnectConnectionPreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/connectionrequest/ui/usecase/WalletConnectConnectionPreviewUseCase.kt
@@ -16,10 +16,9 @@ import com.algorand.android.R
 import com.algorand.android.models.ui.AccountAssetItemButtonState.CHECKED
 import com.algorand.android.models.ui.AccountAssetItemButtonState.UNCHECKED
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountDisplayName
-import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreviewByType
+import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreview
 import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
-import com.algorand.android.modules.accounts.lite.domain.model.AccountLiteCacheStatus
-import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheFlow
+import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheData
 import com.algorand.android.modules.walletconnect.connectionrequest.domain.usecase.WCDomainScammerStateUseCase
 import com.algorand.android.modules.walletconnect.connectionrequest.ui.mapper.BaseWalletConnectConnectionItemMapper
 import com.algorand.android.modules.walletconnect.connectionrequest.ui.mapper.WCSessionRequestResultMapper
@@ -41,8 +40,8 @@ class WalletConnectConnectionPreviewUseCase @Inject constructor(
     private val wcSessionRequestResultMapper: WCSessionRequestResultMapper,
     private val walletConnectNetworkItemMapper: WalletConnectNetworkItemMapper,
     private val wcDomainScammerStateUseCase: WCDomainScammerStateUseCase,
-    private val getAccountLiteCacheFlow: GetAccountLiteCacheFlow,
-    private val getAccountIconDrawablePreviewByType: GetAccountIconDrawablePreviewByType,
+    private val getAccountLiteCacheData: GetAccountLiteCacheData,
+    private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview,
     private val getAccountDisplayName: GetAccountDisplayName
 ) {
 
@@ -108,16 +107,11 @@ class WalletConnectConnectionPreviewUseCase @Inject constructor(
         val preSelectedButtonState = if (isThereOnlyOneAccount) CHECKED else UNCHECKED
 
         return sortedAccountList.map { accountLite ->
-            val iconDrawablePreview = if (accountLite.cachedInfo?.type != null) {
-                getAccountIconDrawablePreviewByType(accountLite.cachedInfo.type)
-            } else {
-                getAccountIconDrawablePreviewByType(accountLite.registrationType)
-            }
             with(accountLite) {
                 baseWalletConnectConnectionItemMapper.mapToAccountItem(
                     accountAddress = address,
-                    accountIconDrawablePreview = iconDrawablePreview,
-                    accountDisplayName = getAccountDisplayName(address, customName, cachedInfo?.type),
+                    accountIconDrawablePreview = getAccountIconDrawablePreview(this),
+                    accountDisplayName = getAccountDisplayName(this),
                     buttonState = preSelectedButtonState,
                     isChecked = isThereOnlyOneAccount
                 )
@@ -126,7 +120,7 @@ class WalletConnectConnectionPreviewUseCase @Inject constructor(
     }
 
     private fun createSortedAccountList(): Collection<AccountLite> {
-        return (getAccountLiteCacheFlow().value as? AccountLiteCacheStatus.Data)?.accountLites
+        return getAccountLiteCacheData()?.accountLites
             ?.filter { it.value.cachedInfo?.type?.canSignTransaction() == true }
             ?.values
             .orEmpty()

--- a/app/src/main/kotlin/com/algorand/android/ui/common/warningconfirmation/accountselection/usecase/BackupAccountSelectionPreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/common/warningconfirmation/accountselection/usecase/BackupAccountSelectionPreviewUseCase.kt
@@ -37,7 +37,7 @@ class BackupAccountSelectionPreviewUseCase @Inject constructor(
         val sortedAccountListItems = getFilteredSortedAccountListWhichNotBackedUp(
             onLoadedAccountConfiguration = {
                 createLoadedAccountConfiguration(
-                    accountDetail = this,
+                    accountLite = this,
                     showHoldings = true,
                     selectedCurrencySymbol = selectedCurrencySymbol
                 )

--- a/app/src/main/kotlin/com/algorand/android/ui/notificationfilter/NotificationFilterViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/notificationfilter/NotificationFilterViewModel.kt
@@ -16,7 +16,6 @@ import android.content.SharedPreferences
 import androidx.lifecycle.viewModelScope
 import com.algorand.android.core.BaseViewModel
 import com.algorand.android.database.NotificationFilterDao
-import com.algorand.android.modules.accountcore.domain.usecase.GetAccountTotalValue
 import com.algorand.android.modules.accountcore.ui.mapper.AccountItemConfigurationMapper
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountDisplayName
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreview
@@ -37,11 +36,10 @@ class NotificationFilterViewModel @Inject constructor(
     private val sharedPref: SharedPreferences,
     private val notificationFilterDao: NotificationFilterDao,
     private val getAccountDisplayName: GetAccountDisplayName,
-    private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview,
-    private val getAccountTotalValue: GetAccountTotalValue,
     private val getSortedAccountsByPreference: GetSortedAccountsByPreference,
     private val accountItemConfigurationMapper: AccountItemConfigurationMapper,
     private val notificationRepository: NotificationRepository,
+    private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview
 ) : BaseViewModel() {
 
     val notificationFilterOperation = MutableStateFlow<Resource<Unit>?>(null)
@@ -54,15 +52,15 @@ class NotificationFilterViewModel @Inject constructor(
                     onLoadedAccountConfiguration = {
                         accountItemConfigurationMapper(
                             accountAddress = address,
-                            accountDisplayName = getAccountDisplayName(address),
-                            accountType = accountType,
-                            accountIconDrawablePreview = getAccountIconDrawablePreview(address),
-                            accountPrimaryValue = getAccountTotalValue(address, true).primaryAccountValue,
+                            accountDisplayName = getAccountDisplayName(this),
+                            accountType = cachedInfo?.type,
+                            accountIconDrawablePreview = getAccountIconDrawablePreview(this),
+                            accountPrimaryValue = cachedInfo?.primaryAccountValue,
                         )
                     },
                     onFailedAccountConfiguration = {
                         accountItemConfigurationMapper(
-                            accountAddress = this,
+                            accountAddress = address,
                             accountDisplayName = getAccountDisplayName(this),
                             accountType = null,
                             accountIconDrawablePreview = getAccountIconDrawablePreview(this),

--- a/app/src/main/kotlin/com/algorand/android/ui/settings/usecase/DeveloperSettingsPreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/settings/usecase/DeveloperSettingsPreviewUseCase.kt
@@ -12,41 +12,17 @@
 
 package com.algorand.android.ui.settings.usecase
 
-import com.algorand.android.modules.accountcore.domain.usecase.GetAccountTotalValue
-import com.algorand.android.modules.accountcore.ui.mapper.AccountItemConfigurationMapper
-import com.algorand.android.modules.accountcore.ui.usecase.GetAccountDisplayName
-import com.algorand.android.modules.accountsorting.ui.domain.usecase.GetSortedAccountsByPreference
+import com.algorand.android.modules.accountsorting.domain.usecase.GetSortedLocalAccounts
 import com.algorand.android.usecase.GetIsActiveNodeTestnetUseCase
 import javax.inject.Inject
 
 class DeveloperSettingsPreviewUseCase @Inject constructor(
-    private val accountItemConfigurationMapper: AccountItemConfigurationMapper,
-    private val getSortedAccountsByPreference: GetSortedAccountsByPreference,
-    private val getAccountDisplayName: GetAccountDisplayName,
-    private val getAccountTotalValue: GetAccountTotalValue,
-    private val isActiveNodeTestnetUseCase: GetIsActiveNodeTestnetUseCase
+    private val isActiveNodeTestnetUseCase: GetIsActiveNodeTestnetUseCase,
+    private val getSortedLocalAccounts: GetSortedLocalAccounts
 ) {
 
     suspend fun getFirstAccountAddress(): String? {
-        val sortedAccountListItem = getSortedAccountsByPreference(
-            onLoadedAccountConfiguration = {
-                val accountValue = getAccountTotalValue(address, includeAlgo = true)
-                accountItemConfigurationMapper(
-                    accountAddress = address,
-                    accountDisplayName = getAccountDisplayName(address),
-                    accountType = accountType,
-                    accountPrimaryValue = accountValue.primaryAccountValue
-                )
-            },
-            onFailedAccountConfiguration = {
-                accountItemConfigurationMapper(
-                    accountAddress = this,
-                    accountDisplayName = getAccountDisplayName(this),
-                    accountType = null
-                )
-            }
-        )
-        return sortedAccountListItem.firstOrNull()?.itemConfiguration?.accountAddress
+        return getSortedLocalAccounts().firstOrNull()?.address
     }
 
     fun isConnectedToTestnet(): Boolean {

--- a/common-sdk/schemas/com.algorand.wallet.foundation.database.PeraDatabase/1.json
+++ b/common-sdk/schemas/com.algorand.wallet.foundation.database.PeraDatabase/1.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "958a3c215a97f2e685212d057acc3590",
+    "identityHash": "1a357e5ace97773ae5b296c2c2af3928",
     "entities": [
       {
         "tableName": "account_information",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`algo_address` TEXT NOT NULL, `algo_amount` TEXT NOT NULL, `opted_in_apps_count` INTEGER NOT NULL, `apps_total_extra_pages` INTEGER NOT NULL, `auth_algo_address` TEXT, `created_at_round` INTEGER, `last_fetched_round` INTEGER NOT NULL, `total_created_apps_count` INTEGER NOT NULL, `total_created_assets_count` INTEGER NOT NULL, `app_state_schema_num_byte_slice` INTEGER, `app_state_schema_num_uint` INTEGER, PRIMARY KEY(`algo_address`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`algo_address` TEXT NOT NULL, `algo_amount` TEXT NOT NULL, `opted_in_apps_count` INTEGER NOT NULL, `apps_total_extra_pages` INTEGER NOT NULL, `auth_algo_address` TEXT, `created_at_round` INTEGER, `last_fetched_round` INTEGER NOT NULL, `total_created_apps_count` INTEGER NOT NULL, `total_created_assets_count` INTEGER NOT NULL, `app_state_schema_num_byte_slice` INTEGER, `app_state_schema_num_uint` INTEGER, `min_required_balance` TEXT NOT NULL, PRIMARY KEY(`algo_address`))",
         "fields": [
           {
             "fieldPath": "algoAddress",
@@ -69,6 +69,12 @@
             "fieldPath": "appStateSchemaUint",
             "columnName": "app_state_schema_num_uint",
             "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "minRequiredBalance",
+            "columnName": "min_required_balance",
+            "affinity": "TEXT",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -503,7 +509,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '958a3c215a97f2e685212d057acc3590')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1a357e5ace97773ae5b296c2c2af3928')"
     ]
   }
 }

--- a/common-sdk/schemas/com.algorand.wallet.foundation.database.PeraDatabase/2.json
+++ b/common-sdk/schemas/com.algorand.wallet.foundation.database.PeraDatabase/2.json
@@ -1,0 +1,515 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "1a357e5ace97773ae5b296c2c2af3928",
+    "entities": [
+      {
+        "tableName": "account_information",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`algo_address` TEXT NOT NULL, `algo_amount` TEXT NOT NULL, `opted_in_apps_count` INTEGER NOT NULL, `apps_total_extra_pages` INTEGER NOT NULL, `auth_algo_address` TEXT, `created_at_round` INTEGER, `last_fetched_round` INTEGER NOT NULL, `total_created_apps_count` INTEGER NOT NULL, `total_created_assets_count` INTEGER NOT NULL, `app_state_schema_num_byte_slice` INTEGER, `app_state_schema_num_uint` INTEGER, `min_required_balance` TEXT NOT NULL, PRIMARY KEY(`algo_address`))",
+        "fields": [
+          {
+            "fieldPath": "algoAddress",
+            "columnName": "algo_address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "algoAmount",
+            "columnName": "algo_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optedInAppsCount",
+            "columnName": "opted_in_apps_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appsTotalExtraPages",
+            "columnName": "apps_total_extra_pages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authAlgoAddress",
+            "columnName": "auth_algo_address",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAtRound",
+            "columnName": "created_at_round",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastFetchedRound",
+            "columnName": "last_fetched_round",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalCreatedAppsCount",
+            "columnName": "total_created_apps_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalCreatedAssetsCount",
+            "columnName": "total_created_assets_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appStateNumByteSlice",
+            "columnName": "app_state_schema_num_byte_slice",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "appStateSchemaUint",
+            "columnName": "app_state_schema_num_uint",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "minRequiredBalance",
+            "columnName": "min_required_balance",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "algo_address"
+          ]
+        }
+      },
+      {
+        "tableName": "asset_holding_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `algo_address` TEXT NOT NULL, `asset_id` INTEGER NOT NULL, `amount` TEXT NOT NULL, `is_deleted` INTEGER NOT NULL, `is_frozen` INTEGER NOT NULL, `opted_in_at_round` INTEGER, `opted_out_at_round` INTEGER, `asset_status` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "algoAddress",
+            "columnName": "algo_address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFrozen",
+            "columnName": "is_frozen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optedInAtRound",
+            "columnName": "opted_in_at_round",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "optedOutAtRound",
+            "columnName": "opted_out_at_round",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "assetStatusEntity",
+            "columnName": "asset_status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_asset_holding_table_algo_address_asset_id",
+            "unique": true,
+            "columnNames": [
+              "algo_address",
+              "asset_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_asset_holding_table_algo_address_asset_id` ON `${TABLE_NAME}` (`algo_address`, `asset_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "asset_detail",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` INTEGER NOT NULL, `name` TEXT, `unit_name` TEXT, `decimals` INTEGER NOT NULL, `usd_value` TEXT, `max_supply` TEXT NOT NULL, `explorer_url` TEXT, `project_url` TEXT, `project_name` TEXT, `logo_svg_url` TEXT, `logo_url` TEXT, `discord_url` TEXT, `telegram_url` TEXT, `twitter_username` TEXT, `description` TEXT, `url` TEXT, `total_supply` TEXT, `last_24_hours_algo_price_change_percentage` TEXT, `available_on_discover_mobile` INTEGER NOT NULL, `asset_creator_id` INTEGER, `asset_creator_address` TEXT, `is_verified_asset_creator` INTEGER, `verification_tier` TEXT NOT NULL, PRIMARY KEY(`asset_id`))",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unitName",
+            "columnName": "unit_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "decimals",
+            "columnName": "decimals",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usdValue",
+            "columnName": "usd_value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxSupply",
+            "columnName": "max_supply",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explorerUrl",
+            "columnName": "explorer_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "projectUrl",
+            "columnName": "project_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "projectName",
+            "columnName": "project_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "logoSvgUrl",
+            "columnName": "logo_svg_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logo_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "discordUrl",
+            "columnName": "discord_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "telegramUrl",
+            "columnName": "telegram_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "twitterUsername",
+            "columnName": "twitter_username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalSupply",
+            "columnName": "total_supply",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "last24HoursAlgoPriceChangePercentage",
+            "columnName": "last_24_hours_algo_price_change_percentage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "availableOnDiscoverMobile",
+            "columnName": "available_on_discover_mobile",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetCreatorId",
+            "columnName": "asset_creator_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "assetCreatorAddress",
+            "columnName": "asset_creator_address",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isVerifiedAssetCreator",
+            "columnName": "is_verified_asset_creator",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "verificationTier",
+            "columnName": "verification_tier",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id"
+          ]
+        }
+      },
+      {
+        "tableName": "collectible",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `collectible_asset_id` INTEGER NOT NULL, `standard_type` TEXT, `media_type` TEXT, `primary_image_url` TEXT, `title` TEXT, `description` TEXT, `collection_id` INTEGER, `collection_name` TEXT, `collection_description` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectibleAssetId",
+            "columnName": "collectible_asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "standardType",
+            "columnName": "standard_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryImageUrl",
+            "columnName": "primary_image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collection_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "collectionName",
+            "columnName": "collection_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "collectionDescription",
+            "columnName": "collection_description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collectible_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `collectible_asset_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `download_url` TEXT, `preview_url` TEXT, `media_type_extension` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectibleAssetId",
+            "columnName": "collectible_asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "previewUrl",
+            "columnName": "preview_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaTypeExtension",
+            "columnName": "media_type_extension",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collectible_trait",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `collectible_asset_id` INTEGER NOT NULL, `display_name` TEXT, `display_value` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectibleAssetId",
+            "columnName": "collectible_asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayValue",
+            "columnName": "display_value",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "custom_account_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`algo_address` TEXT NOT NULL, `custom_name` TEXT, `order_index` INTEGER NOT NULL, `is_backed_up` INTEGER NOT NULL, PRIMARY KEY(`algo_address`))",
+        "fields": [
+          {
+            "fieldPath": "algoAddress",
+            "columnName": "algo_address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "order_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBackedUp",
+            "columnName": "is_backed_up",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "algo_address"
+          ]
+        }
+      },
+      {
+        "tableName": "custom_hd_seed_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seed_id` INTEGER NOT NULL, `entropy_custom_name` TEXT NOT NULL, `order_index` INTEGER NOT NULL, `is_backed_up` INTEGER NOT NULL, PRIMARY KEY(`seed_id`))",
+        "fields": [
+          {
+            "fieldPath": "seedId",
+            "columnName": "seed_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entropyCustomName",
+            "columnName": "entropy_custom_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "order_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBackedUp",
+            "columnName": "is_backed_up",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seed_id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1a357e5ace97773ae5b296c2c2af3928')"
+    ]
+  }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/core/domain/usecase/GetAccountMinBalanceUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/core/domain/usecase/GetAccountMinBalanceUseCase.kt
@@ -13,15 +13,21 @@
 package com.algorand.wallet.account.core.domain.usecase
 
 import com.algorand.wallet.account.info.domain.model.AccountInformation
+import com.algorand.wallet.account.info.domain.repository.AccountInformationRepository
 import com.algorand.wallet.account.info.domain.usecase.GetAccountInformation
 import java.math.BigInteger
 import javax.inject.Inject
 
 internal class GetAccountMinBalanceUseCase @Inject constructor(
-    private val getAccountInformation: GetAccountInformation
+    private val getAccountInformation: GetAccountInformation,
+    private val accountInformationRepository: AccountInformationRepository
 ) : GetAccountMinBalance {
 
     override suspend fun invoke(accountAddress: String): BigInteger {
+        val cachedRequiredMinBalance = accountInformationRepository.getCachedAccountMinRequiredBalance(accountAddress)
+        if (cachedRequiredMinBalance != null) {
+            return cachedRequiredMinBalance
+        }
         val accountInformation = getAccountInformation(accountAddress) ?: return BigInteger.ZERO
         return invoke(accountInformation)
     }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/dao/AccountInformationDao.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/dao/AccountInformationDao.kt
@@ -69,6 +69,9 @@ internal interface AccountInformationDao {
     @Query("SELECT algo_amount FROM account_information WHERE :address = algo_address")
     suspend fun getAccountAlgoBalance(address: String): BigInteger?
 
-    @Query("SELECT algo_address, auth_algo_address, algo_amount FROM account_information WHERE algo_address IN (:addresses)")
+    @Query("SELECT algo_address, auth_algo_address, algo_amount, min_required_balance FROM account_information WHERE algo_address IN (:addresses)")
     fun getAccountLiteInformationFlow(addresses: List<String>): Flow<List<AccountLiteInformationDao>>
+
+    @Query("SELECT min_required_balance FROM account_information WHERE :address = algo_address")
+    suspend fun getMinRequiredBalance(address: String): BigInteger?
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/model/AccountInformationEntity.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/model/AccountInformationEntity.kt
@@ -51,5 +51,8 @@ internal data class AccountInformationEntity(
     val appStateNumByteSlice: Long?,
 
     @ColumnInfo(name = "app_state_schema_num_uint")
-    val appStateSchemaUint: Long?
+    val appStateSchemaUint: Long?,
+
+    @ColumnInfo(name = "min_required_balance")
+    val minRequiredBalance: BigInteger
 )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/model/AccountLiteInformationDao.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/model/AccountLiteInformationDao.kt
@@ -21,5 +21,7 @@ internal data class AccountLiteInformationDao(
     @ColumnInfo(name = "auth_algo_address")
     val rekeyAuthAddress: String?,
     @ColumnInfo(name = "algo_amount")
-    val algoBalance: BigInteger
+    val algoBalance: BigInteger,
+    @ColumnInfo(name = "min_required_balance")
+    val minRequiredBalance: BigInteger
 )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/entity/AccountInformationEntityMapperImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/entity/AccountInformationEntityMapperImpl.kt
@@ -12,8 +12,9 @@
 
 package com.algorand.wallet.account.info.data.mapper.entity
 
-import com.algorand.wallet.account.info.data.model.AccountInformationResponse
 import com.algorand.wallet.account.info.data.database.model.AccountInformationEntity
+import com.algorand.wallet.account.info.data.model.AccountInformationResponse
+import java.math.BigInteger
 import javax.inject.Inject
 
 internal class AccountInformationEntityMapperImpl @Inject constructor() :
@@ -32,7 +33,8 @@ internal class AccountInformationEntityMapperImpl @Inject constructor() :
             appsTotalExtraPages = response.accountInformation.appsTotalExtraPages ?: 0,
             appStateNumByteSlice = response.accountInformation.appStateSchemaResponse?.numByteSlice,
             appStateSchemaUint = response.accountInformation.appStateSchemaResponse?.numUint,
-            createdAtRound = response.accountInformation.createdAtRound
+            createdAtRound = response.accountInformation.createdAtRound,
+            minRequiredBalance = response.accountInformation.minRequiredBalance ?: BigInteger.ZERO,
         )
     }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/model/AccountInformationResponseMapperImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/model/AccountInformationResponseMapperImpl.kt
@@ -33,7 +33,8 @@ internal class AccountInformationResponseMapperImpl @Inject constructor() :
                 totalAppsOptedIn = 0,
                 totalAssetsOptedIn = 0,
                 totalCreatedApps = 0,
-                totalCreatedAssets = 0
+                totalCreatedAssets = 0,
+                minRequiredBalance = null
             ),
             currentRound = 0
         )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/model/AccountInformationResponsePayloadResponse.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/model/AccountInformationResponsePayloadResponse.kt
@@ -13,6 +13,7 @@
 package com.algorand.wallet.account.info.data.model
 
 import com.google.gson.annotations.SerializedName
+import java.math.BigInteger
 
 internal data class AccountInformationResponsePayloadResponse(
     @SerializedName("address")
@@ -38,5 +39,7 @@ internal data class AccountInformationResponsePayloadResponse(
     @SerializedName("total-created-apps")
     val totalCreatedApps: Int? = null,
     @SerializedName("total-created-assets")
-    val totalCreatedAssets: Int? = null
+    val totalCreatedAssets: Int? = null,
+    @SerializedName("min-balance")
+    val minRequiredBalance: BigInteger?
 )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/repository/AccountInformationRepositoryImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/repository/AccountInformationRepositoryImpl.kt
@@ -204,7 +204,8 @@ internal class AccountInformationRepositoryImpl @Inject constructor(
                 accountLiteInformation.address to AccountLiteInformation(
                     address = accountLiteInformation.address,
                     rekeyAuthAddress = accountLiteInformation.rekeyAuthAddress,
-                    algoBalance = accountLiteInformation.algoBalance
+                    algoBalance = accountLiteInformation.algoBalance,
+                    minRequiredBalance = accountLiteInformation.minRequiredBalance
                 )
             }
         }
@@ -228,6 +229,10 @@ internal class AccountInformationRepositoryImpl @Inject constructor(
             }
             assetHoldingMap
         }
+    }
+
+    override suspend fun getCachedAccountMinRequiredBalance(address: String): BigInteger? {
+        return accountInformationDao.getMinRequiredBalance(address)
     }
 
     private suspend fun PeraResult<AccountInformationResponse>.mapToAccountInfo(): PeraResult<AccountInformation> {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/repository/AccountInformationRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/repository/AccountInformationRepository.kt
@@ -63,7 +63,7 @@ internal interface AccountInformationRepository {
     suspend fun getFailedAccountInformation(): List<String>
 
     suspend fun getRekeyAuthAddress(address: String): String?
-    
+
     suspend fun getFilteredRekeyedAccountCount(authAddress: String, algoAddresses: List<String>): Int
 
     suspend fun getAccountAlgoBalance(address: String): BigInteger?
@@ -71,4 +71,6 @@ internal interface AccountInformationRepository {
     fun getAccountsLiteInformationFlow(addresses: List<String>): Flow<Map<String, AccountLiteInformation?>>
 
     fun getAssetHoldingsLiteFlow(addresses: List<String>): Flow<Map<String, AssetHoldingLite>>
+
+    suspend fun getCachedAccountMinRequiredBalance(address: String): BigInteger?
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/lite/domain/model/AccountLiteInformation.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/lite/domain/model/AccountLiteInformation.kt
@@ -17,5 +17,6 @@ import java.math.BigInteger
 data class AccountLiteInformation(
     val address: String,
     val rekeyAuthAddress: String?,
-    val algoBalance: BigInteger
+    val algoBalance: BigInteger,
+    val minRequiredBalance: BigInteger
 )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/foundation/database/PeraDatabase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/foundation/database/PeraDatabase.kt
@@ -69,7 +69,7 @@ internal abstract class PeraDatabase : RoomDatabase() {
     abstract fun customHdSeedInfoDao(): CustomHdSeedInfoDao
 
     companion object {
-        const val DATABASE_VERSION = 1
+        const val DATABASE_VERSION = 2
         const val DATABASE_NAME = "pera_database"
     }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/foundation/database/PeraDatabaseModule.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/foundation/database/PeraDatabaseModule.kt
@@ -14,6 +14,7 @@ package com.algorand.wallet.foundation.database
 
 import android.content.Context
 import androidx.room.Room
+import com.algorand.wallet.foundation.database.migration.PeraDatabaseMigration1to2
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -34,6 +35,8 @@ internal object PeraDatabaseModule {
             context = context,
             klass = PeraDatabase::class.java,
             name = PeraDatabase.DATABASE_NAME
-        ).build()
+        )
+            .addMigrations(PeraDatabaseMigration1to2)
+            .build()
     }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/foundation/database/converters/BigIntegerTypeConverter.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/foundation/database/converters/BigIntegerTypeConverter.kt
@@ -12,7 +12,8 @@
 
 package com.algorand.wallet.foundation.database.converters
 
-import androidx.room.*
+import androidx.room.ProvidedTypeConverter
+import androidx.room.TypeConverter
 import java.math.BigInteger
 
 @ProvidedTypeConverter
@@ -24,7 +25,7 @@ internal object BigIntegerTypeConverter {
     }
 
     @TypeConverter
-    fun stringToBigInteger(value: String): BigInteger {
-        return value.toBigInteger()
+    fun stringToBigInteger(value: String): BigInteger? {
+        return value.toBigIntegerOrNull()
     }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/foundation/database/migration/PeraDatabaseMigration1to2.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/foundation/database/migration/PeraDatabaseMigration1to2.kt
@@ -1,0 +1,12 @@
+package com.algorand.wallet.foundation.database.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+internal object PeraDatabaseMigration1to2 : Migration(1, 2) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(
+            "ALTER TABLE account_information ADD COLUMN min_required_balance TEXT NOT NULL DEFAULT '0'"
+        )
+    }
+}

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/core/domain/usecase/GetAccountMinBalanceUseCaseTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/core/domain/usecase/GetAccountMinBalanceUseCaseTest.kt
@@ -14,6 +14,7 @@ package com.algorand.wallet.account.core.domain.usecase
 
 import com.algorand.wallet.account.info.domain.model.AccountInformation
 import com.algorand.wallet.account.info.domain.model.AppStateScheme
+import com.algorand.wallet.account.info.domain.repository.AccountInformationRepository
 import com.algorand.wallet.account.info.domain.usecase.GetAccountInformation
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -25,8 +26,20 @@ import org.junit.Test
 class GetAccountMinBalanceUseCaseTest {
 
     private val getAccountInformation: GetAccountInformation = mockk()
+    private val accountInformationRepository: AccountInformationRepository = mockk {
+        coEvery { getCachedAccountMinRequiredBalance(ADDRESS) } returns null
+    }
 
-    private val sut = GetAccountMinBalanceUseCase(getAccountInformation)
+    private val sut = GetAccountMinBalanceUseCase(getAccountInformation, accountInformationRepository)
+
+    @Test
+    fun `EXPECT cache min balance WHEN exist in cache`() = runTest {
+        coEvery { accountInformationRepository.getCachedAccountMinRequiredBalance(ADDRESS) } returns MIN_BALANCE
+
+        val result = sut(ADDRESS)
+
+        assertEquals(MIN_BALANCE, result)
+    }
 
     @Test
     fun `EXPECT zero WHEN account information is null`() = runTest {

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/entity/AccountInformationEntityMapperImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/entity/AccountInformationEntityMapperImplTest.kt
@@ -134,7 +134,8 @@ class AccountInformationEntityMapperImplTest {
             totalCreatedAssetsCount = 0,
             totalCreatedAppsCount = 0,
             appStateNumByteSlice = 21,
-            appStateSchemaUint = 12
+            appStateSchemaUint = 12,
+            minRequiredBalance = BigInteger.ZERO
         )
     }
 }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/entity/AccountInformationEntityMapperImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/entity/AccountInformationEntityMapperImplTest.kt
@@ -122,7 +122,7 @@ class AccountInformationEntityMapperImplTest {
         )
         private val ACCOUNT_INFORMATION_RESPONSE = AccountInformationResponse(
             accountInformation = ACCOUNT_INFORMATION_PAYLOAD,
-            currentRound = 9,
+            currentRound = 9
         )
 
         private val ACCOUNT_INFORMATION_ENTITY = AccountInformationEntity(

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/entity/AccountInformationEntityMapperImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/entity/AccountInformationEntityMapperImplTest.kt
@@ -82,7 +82,8 @@ class AccountInformationEntityMapperImplTest {
                 totalAppsOptedIn = null,
                 totalCreatedApps = null,
                 totalCreatedAssets = null,
-                appsTotalExtraPages = null
+                appsTotalExtraPages = null,
+                minRequiredBalance = BigInteger.ZERO
             ),
             currentRound = 9
         )
@@ -116,11 +117,12 @@ class AccountInformationEntityMapperImplTest {
             totalAppsOptedIn = 9,
             totalAssetsOptedIn = 4,
             totalCreatedAssets = 0,
-            totalCreatedApps = 0
+            totalCreatedApps = 0,
+            minRequiredBalance = BigInteger.ZERO
         )
         private val ACCOUNT_INFORMATION_RESPONSE = AccountInformationResponse(
             accountInformation = ACCOUNT_INFORMATION_PAYLOAD,
-            currentRound = 9
+            currentRound = 9,
         )
 
         private val ACCOUNT_INFORMATION_ENTITY = AccountInformationEntity(

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/model/AccountInformationMapperImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/model/AccountInformationMapperImplTest.kt
@@ -160,7 +160,8 @@ class AccountInformationMapperImplTest {
                 totalAppsOptedIn = 20,
                 totalAssetsOptedIn = 30,
                 totalCreatedApps = 40,
-                totalCreatedAssets = 50
+                totalCreatedAssets = 50,
+                minRequiredBalance = null
             ),
             currentRound = 0
         )

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/model/AccountInformationResponseMapperImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/data/mapper/model/AccountInformationResponseMapperImplTest.kt
@@ -43,7 +43,8 @@ class AccountInformationResponseMapperImplTest {
                 totalAppsOptedIn = 0,
                 totalAssetsOptedIn = 0,
                 totalCreatedApps = 0,
-                totalCreatedAssets = 0
+                totalCreatedAssets = 0,
+                minRequiredBalance = null
             ),
             currentRound = 0
         )


### PR DESCRIPTION
# Important Changes 
- Added `min_required_balance` field to AccountInformationEntity, and updated database schema accordingly. We used to calculate this field manually. I kept existing calculation to get correct balance if this field is null. 

## Description
Replaced some implementations  with new cache to optimize account listing/filtering

Affected flows:
- Receiver account selection
- Account sorting
- Notification filter
- Add asset account selection
- Wallet connect connection
- ASA profile account selection
- Bidali account selection
- Meld account selection
- Swap account selection
- Collectible receiver account selection
- Sender account selection

Some of these flows still need some optimization because of asset filtering, which is in progress in another ticket.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2034
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2045

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?

Address in the video has opted in 10103 assets;

```
"data": {
        "address": "3CZQTERKER2G5N7YMPBZKPPPNZVHSGC6OP5QNQFXAEPULFLQCLYW2AFWIU",
        "max-results": 10000,
        "total-apps-opted-in": 0,
        "total-assets-opted-in": 10103,
        "total-created-apps": 0,
        "total-created-assets": 0
    }
```

https://github.com/user-attachments/assets/50a482ae-0ecc-4e47-ab98-d927b2aed576


