### PR TITLE
PERA-2024 :: Hide exchange fee in app UI

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/modules/swap/transactionsummary/ui/adapter/SwapFeesItemViewHolder.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/swap/transactionsummary/ui/adapter/SwapFeesItemViewHolder.kt
@@ -34,7 +34,8 @@ class SwapFeesItemViewHolder(
 
                 optInFeesGroup.isVisible = isOptInFeesVisible
                 peraFeesGroup.isVisible = isPeraFeeVisible
-                exchangeFeesGroup.isVisible = isExchangeFeesVisible
+                // hide UI element for now since FF has no exchange fees, we may show in future
+                exchangeFeesGroup.isVisible = false
             }
         }
     }

--- a/app/src/main/res/layout/bottom_sheet_swap_preview_summary.xml
+++ b/app/src/main/res/layout/bottom_sheet_swap_preview_summary.xml
@@ -223,6 +223,7 @@
         android:text="@string/exchange_fee"
         android:textAppearance="@style/TextAppearance.Body.Sans"
         android:textColor="@color/text_gray"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@id/exchangeFeeTextView"
         app:layout_constraintStart_toEndOf="@id/startGuideline"
         app:layout_constraintTop_toTopOf="@id/exchangeFeeTextView" />
@@ -233,6 +234,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacing_xlarge"
         android:textAppearance="@style/TextAppearance.Body.Sans"
+        android:visibility="gone"
         app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toStartOf="@id/endGuideline"
         app:layout_constraintHorizontal_bias="1"
@@ -244,6 +246,7 @@
         android:id="@+id/exchangeFeeBarrier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:visibility="gone"
         app:barrierDirection="bottom"
         app:constraint_referenced_ids="exchangeFeeLabelTextView, exchangeFeeTextView" />
 

--- a/app/src/main/res/layout/fragment_confirm_swap.xml
+++ b/app/src/main/res/layout/fragment_confirm_swap.xml
@@ -240,6 +240,7 @@
             android:id="@+id/minimumReceivedBarrier"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:visibility="gone"
             app:barrierDirection="top"
             app:constraint_referenced_ids="exchangeFeeLabelTextView, exchangeFeeTextView" />
 
@@ -252,6 +253,7 @@
             android:text="@string/exchange_fee"
             android:textAppearance="@style/TextAppearance.Footnote.Sans"
             android:textColor="@color/text_gray"
+            android:visibility="gone"
             app:drawableEndCompat="@drawable/ic_error"
             app:drawableTint="@color/text_gray_lighter"
             app:layout_constraintBottom_toBottomOf="@id/exchangeFeeTextView"
@@ -266,6 +268,7 @@
             android:layout_marginBottom="@dimen/spacing_normal"
             android:gravity="end"
             android:textAppearance="@style/TextAppearance.Footnote.Sans"
+            android:visibility="gone"
             app:layout_constrainedHeight="true"
             app:layout_constrainedWidth="true"
             app:layout_constraintBottom_toTopOf="@id/exchangeFeeBarrier"


### PR DESCRIPTION
# Pull Request Template

## Description
- Hide exchange fee in app UI

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2024

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- We need to hide exchange fee row in app UI right now due to folks finance not having support for it.  If i missed a spot, let me know.  I hid instead of removed since Joseph said we might bring it back one day

Sample

![Screenshot_1745359423](https://github.com/user-attachments/assets/d0d4c431-0ef3-46ab-a7c3-16b0d4588e06)

![Screenshot_1745360615](https://github.com/user-attachments/assets/0b06f661-ec41-4233-8d7e-60fab331a1f9)

