### PR TITLE
PERA-1796 :: Fix max button on send asset screen

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/send/transferamount/AssetTransferAmountFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/send/transferamount/AssetTransferAmountFragment.kt
@@ -17,6 +17,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import com.algorand.android.R
 import com.algorand.android.SendAlgoNavigationDirections
 import com.algorand.android.assetsearch.ui.model.VerificationTierConfiguration
@@ -33,6 +34,9 @@ import com.algorand.android.models.ToolbarConfiguration
 import com.algorand.android.models.TransactionSignData
 import com.algorand.android.ui.common.warningconfirmation.BaseMaximumBalanceWarningBottomSheet
 import com.algorand.android.ui.send.shared.AddNoteBottomSheet
+import com.algorand.android.ui.send.transferamount.AssetTransferAmountViewModel.ViewEvent.GetMaximumAmountOfAsset
+import com.algorand.android.ui.send.transferamount.AssetTransferAmountViewModel.ViewEvent.NavigateBack
+import com.algorand.android.ui.send.transferamount.AssetTransferAmountViewModel.ViewEvent.ShowGenericError
 import com.algorand.android.utils.ALGO_SHORT_NAME
 import com.algorand.android.utils.AccountIconDrawable
 import com.algorand.android.utils.AssetName
@@ -115,6 +119,14 @@ class AssetTransferAmountFragment : TransactionSignBaseFragment(R.layout.fragmen
     private var lockedNote: String? by Delegates.observable(null) { _, _, newValue ->
         if (newValue.isNullOrEmpty()) {
             binding.addNoteButton.text = getString(R.string.show_note)
+        }
+    }
+
+    private val viewEventCollector: suspend (AssetTransferAmountViewModel.ViewEvent) -> Unit = {
+        when (it) {
+            is GetMaximumAmountOfAsset -> onGetMaximumAmountOfAsset(it.formattedMaximumAmount)
+            is ShowGenericError -> showGlobalError(getString(R.string.an_error_occured), tag = baseActivityTag)
+            is NavigateBack -> navBack()
         }
     }
 
@@ -266,6 +278,7 @@ class AssetTransferAmountFragment : TransactionSignBaseFragment(R.layout.fragmen
     }
 
     private fun initObservers() {
+        collectLatestOnLifecycle(assetTransferAmountViewModel.viewEvent, viewEventCollector, Lifecycle.State.CREATED)
         viewLifecycleOwner.collectLatestOnLifecycle(
             assetTransferAmountViewModel.assetTransferAmountPreviewFlow,
             assetTransferAmountPreview
@@ -277,8 +290,7 @@ class AssetTransferAmountFragment : TransactionSignBaseFragment(R.layout.fragmen
     }
 
     private fun onMaxButtonClick() {
-        val formattedMaximumAmount = assetTransferAmountViewModel.getMaximumAmountOfAsset()
-        binding.amountTextView.setAmount(formattedMaximumAmount)
+        assetTransferAmountViewModel.setMaximumAmountOfAsset()
     }
 
     private fun onAddButtonClick() {
@@ -389,5 +401,9 @@ class AssetTransferAmountFragment : TransactionSignBaseFragment(R.layout.fragmen
 
     private fun onAssetNotFound() {
         nav(SendAlgoNavigationDirections.actionSendAlgoNavigationPop())
+    }
+
+    private fun onGetMaximumAmountOfAsset(formattedMaximumAmount: String) {
+        binding.amountTextView.setAmount(formattedMaximumAmount)
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/send/transferamount/AssetTransferAmountViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/send/transferamount/AssetTransferAmountViewModel.kt
@@ -18,11 +18,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.algorand.android.models.AssetTransaction
 import com.algorand.android.models.AssetTransferAmountPreview
+import com.algorand.android.ui.send.transferamount.AssetTransferAmountViewModel.ViewEvent
 import com.algorand.android.usecase.AssetTransferAmountPreviewUseCase
 import com.algorand.android.usecase.AssetTransferAmountUseCase
 import com.algorand.android.utils.Event
 import com.algorand.android.utils.getOrElse
 import com.algorand.android.utils.getOrThrow
+import com.algorand.wallet.viewmodel.EventDelegate
+import com.algorand.wallet.viewmodel.EventViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -37,8 +40,9 @@ import kotlinx.coroutines.launch
 class AssetTransferAmountViewModel @Inject constructor(
     private val assetTransferAmountUseCase: AssetTransferAmountUseCase,
     private val assetTransferAmountPreviewUseCase: AssetTransferAmountPreviewUseCase,
+    private val eventDelegate: EventDelegate<ViewEvent>,
     savedStateHandle: SavedStateHandle
-) : ViewModel() {
+) : ViewModel(), EventViewModel<ViewEvent> by eventDelegate {
 
     var assetTransaction = savedStateHandle.getOrThrow<AssetTransaction>(ASSET_TRANSACTION_KEY)
         private set
@@ -83,8 +87,13 @@ class AssetTransferAmountViewModel @Inject constructor(
         }
     }
 
-    fun getMaximumAmountOfAsset(): String {
-        return with(assetTransaction) { assetTransferAmountUseCase.getMaximumAmountOfAsset(assetId, senderAddress) }
+    fun setMaximumAmountOfAsset() {
+        viewModelScope.launch(Dispatchers.IO) {
+            with(assetTransaction) {
+                val result = assetTransferAmountUseCase.getMaximumAmountOfAsset(assetId, senderAddress)
+                eventDelegate.sendEvent(ViewEvent.GetMaximumAmountOfAsset(result))
+            }
+        }
     }
 
     fun shouldShowTransactionTips(): Boolean {
@@ -128,6 +137,12 @@ class AssetTransferAmountViewModel @Inject constructor(
 
     fun isExpressSendWarningEnabled(isArc59Transaction: Boolean): Boolean {
         return assetTransferAmountUseCase.isExpressSendWarningEnabled(isArc59Transaction)
+    }
+
+    sealed interface ViewEvent {
+        data class GetMaximumAmountOfAsset(val formattedMaximumAmount: String) : ViewEvent
+        data object ShowGenericError : ViewEvent
+        data object NavigateBack : ViewEvent
     }
 
     companion object {

--- a/app/src/main/kotlin/com/algorand/android/usecase/AssetTransferAmountUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/usecase/AssetTransferAmountUseCase.kt
@@ -14,6 +14,7 @@
 package com.algorand.android.usecase
 
 import com.algorand.android.models.BaseAccountAssetData
+import com.algorand.android.modules.accountcore.domain.usecase.GetAccountBaseOwnedAssetData
 import com.algorand.android.modules.assetinbox.expresssend.domain.usecase.Arc59ExpressSendUseCase
 import com.algorand.android.utils.ALGO_DECIMALS
 import com.algorand.android.utils.formatAmount
@@ -22,6 +23,7 @@ import javax.inject.Inject
 class AssetTransferAmountUseCase @Inject constructor(
     private val transactionTipsUseCase: TransactionTipsUseCase,
     private val getBaseOwnedAssetDataUseCase: GetBaseOwnedAssetDataUseCase,
+    private val getAccountBaseOwnedAssetData: GetAccountBaseOwnedAssetData,
     private val arc59ExpressSendUseCase: Arc59ExpressSendUseCase
 ) {
 
@@ -29,8 +31,8 @@ class AssetTransferAmountUseCase @Inject constructor(
         return transactionTipsUseCase.shouldShowTransactionTips()
     }
 
-    fun getMaximumAmountOfAsset(assetId: Long, publicKey: String): String {
-        val assetDetail = getAccountAssetData(assetId, publicKey)
+    suspend fun getMaximumAmountOfAsset(assetId: Long, senderAddress: String): String {
+        val assetDetail = getAccountAssetData(assetId, senderAddress)
         return if (assetDetail?.isAlgo == true) {
             assetDetail.amount.formatAmount(ALGO_DECIMALS)
         } else {
@@ -38,8 +40,8 @@ class AssetTransferAmountUseCase @Inject constructor(
         }
     }
 
-    private fun getAccountAssetData(assetId: Long, publicKey: String): BaseAccountAssetData.BaseOwnedAssetData? {
-        return getBaseOwnedAssetDataUseCase.getBaseOwnedAssetData(assetId, publicKey)
+    private suspend fun getAccountAssetData(assetId: Long, address: String): BaseAccountAssetData.BaseOwnedAssetData? {
+        return getAccountBaseOwnedAssetData.invoke(address, assetId)
     }
 
     fun isExpressSendWarningEnabled(isArc59Transaction: Boolean): Boolean {

--- a/app/src/main/kotlin/com/algorand/android/usecase/AssetTransferAmountUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/usecase/AssetTransferAmountUseCase.kt
@@ -22,7 +22,6 @@ import javax.inject.Inject
 
 class AssetTransferAmountUseCase @Inject constructor(
     private val transactionTipsUseCase: TransactionTipsUseCase,
-    private val getBaseOwnedAssetDataUseCase: GetBaseOwnedAssetDataUseCase,
     private val getAccountBaseOwnedAssetData: GetAccountBaseOwnedAssetData,
     private val arc59ExpressSendUseCase: Arc59ExpressSendUseCase
 ) {


### PR DESCRIPTION
# Pull Request Template

## Description
- Fix max button on send asset screen

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-1796

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- I'm wondering if the algo max button should leave some for algo transaction fee and not literally the max?
- We can convert this fragment/viewmodel to states when we move UI to compose

Recording

[max.webm](https://github.com/user-attachments/assets/1dbd73c9-abfc-4fc7-aa55-3adc868a9ccc)

