### PR TITLE
PERA-2114 :: Add support for AVM private key QR scheme for import and export

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/modules/deeplink/ui/DeeplinkHandler.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/deeplink/ui/DeeplinkHandler.kt
@@ -13,11 +13,11 @@
 package com.algorand.android.modules.deeplink.ui
 
 import android.util.Base64
-import android.util.Log
 import com.algorand.android.models.AssetAction
 import com.algorand.android.models.AssetTransaction
 import com.algorand.android.models.User
 import com.algorand.android.modules.webimport.common.data.model.WebImportQrCode
+import com.algorand.android.utils.decodeUrl
 import com.algorand.android.utils.toBigIntegerOrZero
 import com.algorand.android.utils.toShortenedAddress
 import com.algorand.wallet.algosdk.transaction.sdk.AlgoAccountSdk
@@ -26,8 +26,6 @@ import com.algorand.wallet.asset.domain.util.AssetConstants
 import com.algorand.wallet.deeplink.model.DeepLink
 import com.algorand.wallet.deeplink.model.NotificationGroupType
 import com.algorand.wallet.deeplink.parser.CreateDeepLink
-import com.algorand.wallet.encryption.domain.manager.Base64Manager
-import java.net.URLDecoder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -35,8 +33,7 @@ import javax.inject.Inject
 class DeeplinkHandler @Inject constructor(
     private val isAssetOptedInByAnyLocalAccount: IsAssetOptedInByAnyLocalAccount,
     private val createDeepLink: CreateDeepLink,
-    private val algoAccountSdk: AlgoAccountSdk,
-    private val base64Manager: Base64Manager
+    private val algoAccountSdk: AlgoAccountSdk
 ) {
 
     private var listener: Listener? = null
@@ -172,25 +169,17 @@ class DeeplinkHandler @Inject constructor(
 
     private fun handleAccountImportFromPrivateKeyDeepLink(deepLink: DeepLink.AccountImportFromPrivateKey): Boolean {
         val privateKeyBytes = try {
-            val urlDecodedKey = try {
-                URLDecoder.decode(deepLink.base64Key, "UTF-8")
-            } catch (e: Exception) {
-                Log.w("DeeplinkHandler", "Failed to URL-decode key: ${deepLink.base64Key}", e)
-                return triggerListener { it.onUndefinedDeepLink(DeepLink.Undefined(deepLink.toString())) ; true }
-            }
-            android.util.Base64.decode(urlDecodedKey, Base64.URL_SAFE or Base64.NO_PADDING)
+            val urlDecodedKey = deepLink.base64Key.decodeUrl()
+            Base64.decode(urlDecodedKey, Base64.URL_SAFE or Base64.NO_PADDING)
         } catch (e: Exception) {
-            Log.w("DeeplinkHandler", "Failed to decode base64 (URL_SAFE) private key: ${deepLink.base64Key}", e)
             return triggerListener { it.onUndefinedDeepLink(DeepLink.Undefined(deepLink.toString())) ; true }
         }
 
-        // AlgoAccountSdk handles the conversion and validation internally.
         val mnemonic = algoAccountSdk.getMnemonicFromAlgo25SecretKey(privateKeyBytes)
 
         return if (mnemonic != null) {
             triggerListener { it.onImportAccountDeepLink(mnemonic) }
         } else {
-            Log.w("DeeplinkHandler", "Failed to convert private key bytes to mnemonic (invalid key?). Key: ${deepLink.base64Key}")
             triggerListener { it.onUndefinedDeepLink(DeepLink.Undefined(deepLink.toString())) ; true }
         }
     }

--- a/app/src/main/kotlin/com/algorand/android/modules/deeplink/ui/DeeplinkHandler.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/deeplink/ui/DeeplinkHandler.kt
@@ -12,24 +12,31 @@
 
 package com.algorand.android.modules.deeplink.ui
 
+import android.util.Base64
+import android.util.Log
 import com.algorand.android.models.AssetAction
 import com.algorand.android.models.AssetTransaction
 import com.algorand.android.models.User
 import com.algorand.android.modules.webimport.common.data.model.WebImportQrCode
 import com.algorand.android.utils.toBigIntegerOrZero
 import com.algorand.android.utils.toShortenedAddress
+import com.algorand.wallet.algosdk.transaction.sdk.AlgoAccountSdk
 import com.algorand.wallet.account.info.domain.usecase.IsAssetOptedInByAnyLocalAccount
 import com.algorand.wallet.asset.domain.util.AssetConstants
 import com.algorand.wallet.deeplink.model.DeepLink
 import com.algorand.wallet.deeplink.model.NotificationGroupType
 import com.algorand.wallet.deeplink.parser.CreateDeepLink
+import com.algorand.wallet.encryption.domain.manager.Base64Manager
+import java.net.URLDecoder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class DeeplinkHandler @Inject constructor(
     private val isAssetOptedInByAnyLocalAccount: IsAssetOptedInByAnyLocalAccount,
-    private val createDeepLink: CreateDeepLink
+    private val createDeepLink: CreateDeepLink,
+    private val algoAccountSdk: AlgoAccountSdk,
+    private val base64Manager: Base64Manager
 ) {
 
     private var listener: Listener? = null
@@ -61,6 +68,7 @@ class DeeplinkHandler @Inject constructor(
             is DeepLink.AssetInbox -> handleAssetInboxDeepLink(deepLink)
             is DeepLink.Cards -> handleCardsDeepLink(deepLink)
             is DeepLink.Staking -> handleStakingDeepLink(deepLink)
+            is DeepLink.AccountImportFromPrivateKey -> handleAccountImportFromPrivateKeyDeepLink(deepLink)
         }
         if (!isDeeplinkHandled) listener?.onDeepLinkNotHandled(deepLink)
     }
@@ -159,6 +167,31 @@ class DeeplinkHandler @Inject constructor(
                 accountAddress = deepLink.address,
                 notificationGroupType = deepLink.notificationGroupType
             )
+        }
+    }
+
+    private fun handleAccountImportFromPrivateKeyDeepLink(deepLink: DeepLink.AccountImportFromPrivateKey): Boolean {
+        val privateKeyBytes = try {
+            val urlDecodedKey = try {
+                URLDecoder.decode(deepLink.base64Key, "UTF-8")
+            } catch (e: Exception) {
+                Log.w("DeeplinkHandler", "Failed to URL-decode key: ${deepLink.base64Key}", e)
+                return triggerListener { it.onUndefinedDeepLink(DeepLink.Undefined(deepLink.toString())) ; true }
+            }
+            android.util.Base64.decode(urlDecodedKey, Base64.URL_SAFE or Base64.NO_PADDING)
+        } catch (e: Exception) {
+            Log.w("DeeplinkHandler", "Failed to decode base64 (URL_SAFE) private key: ${deepLink.base64Key}", e)
+            return triggerListener { it.onUndefinedDeepLink(DeepLink.Undefined(deepLink.toString())) ; true }
+        }
+
+        // AlgoAccountSdk handles the conversion and validation internally.
+        val mnemonic = algoAccountSdk.getMnemonicFromAlgo25SecretKey(privateKeyBytes)
+
+        return if (mnemonic != null) {
+            triggerListener { it.onImportAccountDeepLink(mnemonic) }
+        } else {
+            Log.w("DeeplinkHandler", "Failed to convert private key bytes to mnemonic (invalid key?). Key: ${deepLink.base64Key}")
+            triggerListener { it.onUndefinedDeepLink(DeepLink.Undefined(deepLink.toString())) ; true }
         }
     }
 

--- a/app/src/main/kotlin/com/algorand/android/modules/viewpassphrase/view/ViewPassphraseFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/viewpassphrase/view/ViewPassphraseFragment.kt
@@ -12,11 +12,14 @@
 
 package com.algorand.android.modules.viewpassphrase.view
 
+import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.View
 import android.view.ViewTreeObserver
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
 import com.algorand.android.R
 import com.algorand.android.core.DaggerBaseFragment
 import com.algorand.android.databinding.FragmentViewPassphraseBinding
@@ -25,15 +28,18 @@ import com.algorand.android.models.ToolbarConfiguration
 import com.algorand.android.utils.disableScreenCapture
 import com.algorand.android.utils.enableScreenCapture
 import com.algorand.android.utils.extensions.collectLatestOnLifecycle
-import com.algorand.android.utils.extensions.show
 import com.algorand.android.utils.viewbinding.viewBinding
 import com.algorand.wallet.ui.accountdetail.viewpassphrase.ViewPassphraseViewModel
 import com.algorand.wallet.ui.accountdetail.viewpassphrase.ViewPassphraseViewModel.ViewEvent.NavigateBack
 import com.algorand.wallet.ui.accountdetail.viewpassphrase.ViewPassphraseViewModel.ViewEvent.ShowGenericError
+import com.algorand.wallet.ui.accountdetail.viewpassphrase.ViewPassphraseViewModel.ViewState
 import com.algorand.wallet.ui.accountdetail.viewpassphrase.ViewPassphraseViewModel.ViewState.Content
 import com.algorand.wallet.ui.accountdetail.viewpassphrase.ViewPassphraseViewModel.ViewState.Idle
 import com.algorand.wallet.ui.accountdetail.viewpassphrase.ViewPassphraseViewModel.ViewState.Loading
+import com.google.zxing.BarcodeFormat
+import com.journeyapps.barcodescanner.BarcodeEncoder
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class ViewPassphraseFragment : DaggerBaseFragment(R.layout.fragment_view_passphrase) {
@@ -56,7 +62,7 @@ class ViewPassphraseFragment : DaggerBaseFragment(R.layout.fragment_view_passphr
         isScreenCaptureEnablingAllowed = hasFocus
     }
 
-    private val viewStateCollector: suspend (ViewPassphraseViewModel.ViewState) -> Unit = {
+    private val viewStateCollector: suspend (ViewState) -> Unit = {
         updateViewState(it)
     }
 
@@ -71,11 +77,21 @@ class ViewPassphraseFragment : DaggerBaseFragment(R.layout.fragment_view_passphr
         super.onViewCreated(view, savedInstanceState)
         binding.viewPassphraseToolbar.configure(toolbarConfiguration)
         initObserver()
+        initListeners()
     }
 
     private fun initObserver() {
         collectLatestOnLifecycle(viewPassphraseViewModel.viewEvent, viewEventCollector, Lifecycle.State.CREATED)
         collectLatestOnLifecycle(viewPassphraseViewModel.state, viewStateCollector)
+    }
+
+    private fun initListeners() {
+        binding.displayModeRadioGroup.setOnCheckedChangeListener { _, checkedId ->
+            when (checkedId) {
+                R.id.mnemonicRadioButton -> showMnemonicView()
+                R.id.qrCodeRadioButton -> showQrCodeView()
+            }
+        }
     }
 
     override fun onResume() {
@@ -94,19 +110,93 @@ class ViewPassphraseFragment : DaggerBaseFragment(R.layout.fragment_view_passphr
         super.onStop()
     }
 
-    private fun updateViewState(state: ViewPassphraseViewModel.ViewState) {
+    private fun updateViewState(state: ViewState) {
+        binding.progressBar.isVisible = state is Loading
         when (state) {
-            Idle -> Unit
-            Loading -> binding.progressBar.show()
-            is Content -> showMnemonics(state.mnemonicWords)
+            is Idle -> { /* Reset UI elements? */ }
+            is Loading -> {
+                // Handled above, hide content views
+                binding.passphraseBoxView.visibility = View.INVISIBLE
+                binding.qrCodeImageView.visibility = View.INVISIBLE
+                binding.displayModeRadioGroup.visibility = View.INVISIBLE
+            }
+            is Content -> {
+                binding.displayModeRadioGroup.visibility = View.VISIBLE
+                binding.passphraseBoxView.setPassphrases(state.mnemonicWords)
+                binding.qrCodeRadioButton.isEnabled = state.isQrExportAvailable
+
+                // Ensure initial view is correct based on availability and current check state
+                if (!state.isQrExportAvailable) {
+                     binding.mnemonicRadioButton.isChecked = true // Force mnemonic if QR unavailable
+                     showMnemonicView() // Show mnemonic view explicitly
+                } else {
+                     // If content loaded, show view based on which radio button is checked
+                     if (binding.mnemonicRadioButton.isChecked) {
+                         showMnemonicView()
+                     } else if (binding.qrCodeRadioButton.isChecked) {
+                         showQrCodeView() // Will trigger URI generation if QR is selected
+                     }
+                }
+            }
         }
     }
 
-    private fun showMnemonics(mnemonicWords: List<String>) {
-        binding.progressBar.hide()
-        binding.passphraseBoxView.apply {
-            setPassphrases(mnemonicWords)
-            show()
+    private fun showMnemonicView() {
+        binding.passphraseBoxView.visibility = View.VISIBLE
+        binding.qrCodeImageView.visibility = View.GONE
+        binding.qrCodeImageView.setImageBitmap(null) // Clear QR if it was generated
+    }
+
+    private fun showQrCodeView() {
+        binding.passphraseBoxView.visibility = View.GONE
+        binding.qrCodeImageView.visibility = View.VISIBLE // Show the placeholder/loading view
+        binding.qrCodeImageView.setImageBitmap(null) // Clear previous QR or error icon
+
+        // Request URI generation from ViewModel
+        val address = requireArguments().getString(ACCOUNT_ADDRESS).orEmpty()
+        if (address.isNotEmpty()) {
+             viewPassphraseViewModel.requestAccountExportUri(address) { result ->
+                 // Ensure UI updates on main thread (lifecycleScope handles this)
+                 viewLifecycleOwner.lifecycleScope.launch {
+                     result.use(
+                         onSuccess = { uriString -> generateAndDisplayQrCode(uriString) },
+                         onFailed = { error, _ ->
+                             // Handle error - Show error icon or message
+                             binding.qrCodeImageView.setImageResource(R.drawable.ic_error) // Placeholder
+                             // Consider logging the actual error
+                             showGlobalError(getString(R.string.qr_code_generation_failed))
+                         }
+                     )
+                 }
+             }
+        } else {
+            // Handle case where address is missing (should not happen)
+            showGlobalError(getString(R.string.an_error_occured))
+            binding.qrCodeImageView.setImageResource(R.drawable.ic_error)
+        }
+    }
+
+    private fun generateAndDisplayQrCode(uriString: String) {
+        val qrSize = resources.getDimensionPixelSize(R.dimen.qr_code_size) // Use defined dimension
+        val qrBitmap = generateQrCodeBitmap(uriString, qrSize) // Using the utility function
+        if (qrBitmap != null) {
+            binding.qrCodeImageView.setImageBitmap(qrBitmap)
+        } else {
+            // Error handled during generation or show here
+            binding.qrCodeImageView.setImageResource(R.drawable.ic_error) // Placeholder error icon
+            showGlobalError(getString(R.string.qr_code_generation_failed))
+        }
+    }
+
+    /**
+     * Generates a QR code bitmap from the given data string.
+     */
+    private fun generateQrCodeBitmap(data: String, size: Int): Bitmap? {
+        return try {
+            val barcodeEncoder = BarcodeEncoder()
+            barcodeEncoder.encodeBitmap(data, BarcodeFormat.QR_CODE, size, size)
+        } catch (e: Exception) {
+            null // Return null on error, the caller handles showing a user message
         }
     }
 

--- a/app/src/main/res/layout/fragment_view_passphrase.xml
+++ b/app/src/main/res/layout/fragment_view_passphrase.xml
@@ -37,15 +37,54 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <RadioGroup
+        android:id="@+id/displayModeRadioGroup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center"
+        app:layout_constraintTop_toBottomOf="@id/viewPassphraseToolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp">
+
+        <RadioButton
+            android:id="@+id/mnemonicRadioButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/mnemonic"
+            android:checked="true"/>
+
+        <RadioButton
+            android:id="@+id/qrCodeRadioButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/qr_code"
+            android:layout_marginStart="16dp"
+            android:enabled="false"/>
+    </RadioGroup>
+
     <com.algorand.android.customviews.PassphrasesBoxView
         android:id="@+id/passphraseBoxView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/spacing_large"
         android:layout_marginTop="@dimen/spacing_large"
-        android:visibility="gone"
+        android:visibility="visible"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/viewPassphraseToolbar" />
+        app:layout_constraintTop_toBottomOf="@id/displayModeRadioGroup" />
+
+    <ImageView
+        android:id="@+id/qrCodeImageView"
+        android:layout_width="@dimen/qr_code_size"
+        android:layout_height="@dimen/qr_code_size"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="16dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/displayModeRadioGroup"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:contentDescription="@string/account_export_qr_code" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -201,4 +201,8 @@
     <dimen name="action_button_corner_radius">8dp</dimen>
 
     <dimen name="rekey_confirmation_bottom_padding">240dp</dimen>
+
+    <!-- QR Code -->
+    <dimen name="qr_code_size">250dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1493,4 +1493,12 @@
     </plurals>
 
     <string name="select_the_rekeyed_accounts_you">Select the rekeyed accounts you want to add to your wallet:</string>
+
+    <!-- Discover URL Viewer -->
+    <string name="open_in_browser">Open in Browser</string>
+
+    <!-- View Passphrase / Account Export -->
+    <string name="mnemonic">Mnemonic</string>
+    <string name="account_export_qr_code">Account Export QR Code</string>
+    <string name="qr_code_generation_failed">QR code generation failed.</string>
 </resources>

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/usecase/GenerateAccountExportUriUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/local/domain/usecase/GenerateAccountExportUriUseCase.kt
@@ -1,0 +1,69 @@
+package com.algorand.wallet.account.local.domain.usecase
+
+import android.util.Base64
+import android.util.Log
+import com.algorand.algosdk.sdk.Sdk
+import com.algorand.wallet.account.local.domain.model.AccountMnemonic
+import com.algorand.wallet.foundation.PeraResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.nio.charset.StandardCharsets
+import javax.inject.Inject
+
+class GenerateAccountExportUriUseCase @Inject constructor(
+    private val getLocalAccount: GetLocalAccount,
+    private val getAccountMnemonic: GetAccountMnemonic
+) {
+
+    // ExportError now extends Exception
+    sealed class ExportError(override val cause: Throwable? = null) : Exception() {
+        data class ExportUnavailableForAccountType(val accountType: AccountMnemonic.AccountType) : ExportError()
+        data class SdkError(override val cause: Throwable) : ExportError(cause = cause)
+        data class EncodingError(override val cause: Throwable) : ExportError(cause = cause)
+        data object AccountNotFound : ExportError()
+        data object MnemonicNotFound : ExportError()
+    }
+
+    suspend operator fun invoke(accountAddress: String): PeraResult<String> = withContext(Dispatchers.IO) {
+        getLocalAccount(accountAddress)
+            ?: return@withContext PeraResult.Error(ExportError.AccountNotFound)
+
+        val accountMnemonicResult = getAccountMnemonic(accountAddress)
+        val accountMnemonic = when (accountMnemonicResult) {
+            is PeraResult.Success -> accountMnemonicResult.data
+            is PeraResult.Error -> return@withContext PeraResult.Error(
+                ExportError.MnemonicNotFound
+            )
+        }
+
+        if (accountMnemonic.type != AccountMnemonic.AccountType.Algo25) {
+            return@withContext PeraResult.Error(ExportError.ExportUnavailableForAccountType(accountMnemonic.type))
+        }
+
+        try {
+            val mnemonicString = accountMnemonic.words.joinToString(" ")
+            val fullPrivateKeyBytes = Sdk.mnemonicToPrivateKey(mnemonicString)
+
+            // Handle error: private key generation failed or result is too short
+            if (fullPrivateKeyBytes == null || fullPrivateKeyBytes.size < 32) {
+                 return@withContext PeraResult.Error(ExportError.SdkError(IllegalArgumentException("Invalid private key generated")))
+            }
+
+            // Extract the first 32 bytes (seed)
+            val seedBytes = fullPrivateKeyBytes.copyOfRange(0, 32)
+
+            // Encode only the 32-byte seed
+            val base64Key = Base64.encodeToString(seedBytes, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+
+            // Construct URI
+            val uriString = "avm://account/import?privatekey=$base64Key"
+
+            PeraResult.Success(uriString)
+        } catch (e: Exception) {
+            when (e) {
+                is IllegalArgumentException -> PeraResult.Error(ExportError.SdkError(e))
+                else -> PeraResult.Error(ExportError.EncodingError(e))
+            }
+        }
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/builder/AccountImportFromPrivateKeyDeepLinkBuilder.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/builder/AccountImportFromPrivateKeyDeepLinkBuilder.kt
@@ -1,0 +1,45 @@
+package com.algorand.wallet.deeplink.builder
+
+import com.algorand.wallet.deeplink.model.DeepLink
+import com.algorand.wallet.deeplink.model.DeepLinkPayload
+import javax.inject.Inject
+
+internal class AccountImportFromPrivateKeyDeepLinkBuilder @Inject constructor() : DeepLinkBuilder {
+
+    override fun doesDeeplinkMeetTheRequirements(payload: DeepLinkPayload): Boolean {
+        // Ensure this payload is specifically for AccountImportFromPrivateKey
+        // and not conflicting with other potential deeplink types.
+        return with(payload) {
+            accountImportFromPrivateKey != null &&
+                accountAddress == null &&
+                walletConnectUrl == null &&
+                assetId == null &&
+                amount == null &&
+                note == null &&
+                xnote == null &&
+                mnemonic == null &&
+                label == null &&
+                transactionStatus == null &&
+                transactionId == null &&
+                url == null &&
+                webImportQrCode == null &&
+                notificationGroupType == null &&
+                fee == null &&
+                votekey == null &&
+                selkey == null &&
+                sprfkey == null &&
+                votefst == null &&
+                votelst == null &&
+                votekd == null &&
+                type == null &&
+                // host and path might be present from the URI parsing, but shouldn't define the link type here
+                // rawDeepLinkUri will always be present
+                true
+        }
+    }
+
+    override fun createDeepLink(payload: DeepLinkPayload): DeepLink {
+        // The doesDeeplinkMeetTheRequirements check ensures this is not null.
+        return payload.accountImportFromPrivateKey!!
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/di/DeepLinkModule.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/di/DeepLinkModule.kt
@@ -26,6 +26,7 @@ import com.algorand.wallet.deeplink.builder.NotificationDeepLinkBuilder
 import com.algorand.wallet.deeplink.builder.StakingDeepLinkBuilder
 import com.algorand.wallet.deeplink.builder.WalletConnectConnectionDeepLinkBuilder
 import com.algorand.wallet.deeplink.builder.WebImportQrCodeDeepLinkBuilder
+import com.algorand.wallet.deeplink.builder.AccountImportFromPrivateKeyDeepLinkBuilder
 import com.algorand.wallet.deeplink.parser.CreateDeepLink
 import com.algorand.wallet.deeplink.parser.CreateDeepLinkImpl
 import com.algorand.wallet.deeplink.parser.ParseDeepLinkPayload
@@ -39,6 +40,7 @@ import com.algorand.wallet.deeplink.parser.query.NotificationGroupTypeQueryParse
 import com.algorand.wallet.deeplink.parser.query.UrlQueryParser
 import com.algorand.wallet.deeplink.parser.query.WalletConnectUrlQueryParser
 import com.algorand.wallet.deeplink.parser.query.WebImportQrCodeQueryParser
+import com.algorand.wallet.deeplink.parser.query.AccountImportFromPrivateKeyQueryParser
 import com.algorand.wallet.encryption.domain.manager.Base64Manager
 import com.algorand.wallet.foundation.json.JsonSerializer
 import dagger.Module
@@ -51,6 +53,11 @@ import dagger.hilt.components.SingletonComponent
 internal object DeepLinkModule {
 
     @Provides
+    fun provideAccountImportFromPrivateKeyQueryParser(): AccountImportFromPrivateKeyQueryParser {
+        return AccountImportFromPrivateKeyQueryParser()
+    }
+
+    @Provides
     fun providePeraUriParser(impl: PeraUriParserImpl): PeraUriParser = impl
 
     @Provides
@@ -58,7 +65,8 @@ internal object DeepLinkModule {
         peraUriParser: PeraUriParser,
         algoSdkAddress: AlgoSdkAddress,
         jsonSerializer: JsonSerializer,
-        base64Manager: Base64Manager
+        base64Manager: Base64Manager,
+        accountImportFromPrivateKeyQueryParser: AccountImportFromPrivateKeyQueryParser
     ): ParseDeepLinkPayload {
         return ParseDeepLinkPayloadImpl(
             peraUriParser = peraUriParser,
@@ -68,8 +76,14 @@ internal object DeepLinkModule {
             webImportQrCodeQueryParser = WebImportQrCodeQueryParser(jsonSerializer),
             urlQueryParser = UrlQueryParser(base64Manager),
             mnemonicQueryParser = MnemonicQueryParser(jsonSerializer),
-            walletConnectUrlQueryParser = WalletConnectUrlQueryParser()
+            walletConnectUrlQueryParser = WalletConnectUrlQueryParser(),
+            accountImportFromPrivateKeyQueryParser = accountImportFromPrivateKeyQueryParser
         )
+    }
+
+    @Provides
+    fun provideAccountImportFromPrivateKeyDeepLinkBuilder(): AccountImportFromPrivateKeyDeepLinkBuilder {
+        return AccountImportFromPrivateKeyDeepLinkBuilder()
     }
 
     @Provides
@@ -90,7 +104,8 @@ internal object DeepLinkModule {
             assetInboxDeepLinkBuilder = AssetInboxDeepLinkBuilder(),
             keyRegTransactionDeepLinkBuilder = KeyRegTransactionDeepLinkBuilder(),
             cardsDeepLinkBuilder = CardsDeepLinkBuilder(),
-            stakingDeepLinkBuilder = StakingDeepLinkBuilder()
+            stakingDeepLinkBuilder = StakingDeepLinkBuilder(),
+            accountImportFromPrivateKeyDeepLinkBuilder = AccountImportFromPrivateKeyDeepLinkBuilder()
         )
     }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/model/DeepLink.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/model/DeepLink.kt
@@ -111,4 +111,8 @@ sealed interface DeepLink {
     ) : DeepLink
 
     data class Undefined(val url: String) : DeepLink
+
+    // Note: The 'name' parameter is currently parsed but not used in the final handling (Step 7).
+    // Future enhancement: Modify the account recovery flow to accept and utilize this name.
+    data class AccountImportFromPrivateKey(val name: String?, val base64Key: String) : DeepLink
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/model/DeepLinkPayload.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/model/DeepLinkPayload.kt
@@ -36,6 +36,7 @@ internal data class DeepLinkPayload(
     val type: String? = null,
     val host: String? = null,
     val path: String? = null,
+    val accountImportFromPrivateKey: DeepLink.AccountImportFromPrivateKey? = null,
     val rawDeepLinkUri: String,
 )
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/parser/CreateDeepLinkImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/parser/CreateDeepLinkImpl.kt
@@ -29,7 +29,8 @@ internal class CreateDeepLinkImpl(
     private val assetInboxDeepLinkBuilder: DeepLinkBuilder,
     private val keyRegTransactionDeepLinkBuilder: DeepLinkBuilder,
     private val cardsDeepLinkBuilder: DeepLinkBuilder,
-    private val stakingDeepLinkBuilder: DeepLinkBuilder
+    private val stakingDeepLinkBuilder: DeepLinkBuilder,
+    private val accountImportFromPrivateKeyDeepLinkBuilder: DeepLinkBuilder
 ) : CreateDeepLink {
 
     override fun invoke(url: String): DeepLink {
@@ -74,6 +75,9 @@ internal class CreateDeepLinkImpl(
             }
             stakingDeepLinkBuilder.doesDeeplinkMeetTheRequirements(payload) -> {
                 stakingDeepLinkBuilder.createDeepLink(payload)
+            }
+            accountImportFromPrivateKeyDeepLinkBuilder.doesDeeplinkMeetTheRequirements(payload) -> {
+                accountImportFromPrivateKeyDeepLinkBuilder.createDeepLink(payload)
             }
             else -> DeepLink.Undefined(url)
         }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/parser/ParseDeepLinkPayloadImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/parser/ParseDeepLinkPayloadImpl.kt
@@ -13,6 +13,7 @@
 package com.algorand.wallet.deeplink.parser
 
 import com.algorand.wallet.deeplink.model.DeepLinkPayload
+import com.algorand.wallet.deeplink.model.DeepLink
 import com.algorand.wallet.deeplink.model.NotificationGroupType
 import com.algorand.wallet.deeplink.model.WebImportQrCode
 import com.algorand.wallet.deeplink.parser.query.DeepLinkQueryParser
@@ -26,6 +27,7 @@ internal class ParseDeepLinkPayloadImpl(
     private val urlQueryParser: DeepLinkQueryParser<String?>,
     private val mnemonicQueryParser: DeepLinkQueryParser<String?>,
     private val walletConnectUrlQueryParser: DeepLinkQueryParser<String?>,
+    private val accountImportFromPrivateKeyQueryParser: DeepLinkQueryParser<DeepLink.AccountImportFromPrivateKey?>
 ) : ParseDeepLinkPayload {
 
     override fun invoke(url: String): DeepLinkPayload {
@@ -53,6 +55,7 @@ internal class ParseDeepLinkPayloadImpl(
             votekd = peraUri.getQueryParam(VOTEKD_QUERY_KEY),
             type = peraUri.getQueryParam(TYPE_QUERY_KEY),
             path = peraUri.getQueryParam(PATH_KEY),
+            accountImportFromPrivateKey = accountImportFromPrivateKeyQueryParser.parseQuery(peraUri),
             host = peraUri.host,
             rawDeepLinkUri = url
         )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/parser/query/AccountImportFromPrivateKeyQueryParser.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/parser/query/AccountImportFromPrivateKeyQueryParser.kt
@@ -1,0 +1,24 @@
+package com.algorand.wallet.deeplink.parser.query
+
+import com.algorand.wallet.deeplink.model.PeraUri
+import com.algorand.wallet.deeplink.model.DeepLink
+import javax.inject.Inject
+
+internal class AccountImportFromPrivateKeyQueryParser @Inject constructor() :
+    DeepLinkQueryParser<DeepLink.AccountImportFromPrivateKey?> {
+
+    override fun parseQuery(peraUri: PeraUri): DeepLink.AccountImportFromPrivateKey? {
+        if (peraUri.scheme != "avm" || peraUri.host != "account") {
+            return null
+        }
+
+        val name = peraUri.getQueryParam("name")
+        val key = peraUri.getQueryParam("privatekey")
+
+        return if (!key.isNullOrBlank()) {
+            DeepLink.AccountImportFromPrivateKey(name, key)
+        } else {
+            null
+        }
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/ui/accountdetail/viewpassphrase/ViewPassphraseViewModel.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/ui/accountdetail/viewpassphrase/ViewPassphraseViewModel.kt
@@ -15,7 +15,11 @@ package com.algorand.wallet.ui.accountdetail.viewpassphrase
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.algorand.wallet.account.local.domain.model.AccountMnemonic
+import com.algorand.wallet.account.local.domain.usecase.GenerateAccountExportUriUseCase
 import com.algorand.wallet.account.local.domain.usecase.GetAccountMnemonic
+import com.algorand.wallet.account.local.domain.usecase.GetLocalAccount
+import com.algorand.wallet.account.local.domain.model.LocalAccount
+import com.algorand.wallet.foundation.PeraResult
 import com.algorand.wallet.ui.accountdetail.viewpassphrase.ViewPassphraseViewModel.ViewEvent
 import com.algorand.wallet.ui.accountdetail.viewpassphrase.ViewPassphraseViewModel.ViewState
 import com.algorand.wallet.ui.accountdetail.viewpassphrase.ViewPassphraseViewModel.ViewState.Idle
@@ -30,6 +34,8 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class ViewPassphraseViewModel @Inject constructor(
     private val getAccountMnemonic: GetAccountMnemonic,
+    private val getLocalAccount: GetLocalAccount,
+    private val generateAccountExportUriUseCase: GenerateAccountExportUriUseCase,
     private val stateDelegate: StateDelegate<ViewState>,
     private val eventDelegate: EventDelegate<ViewEvent>
 ) : ViewModel(), StateViewModel<ViewState> by stateDelegate, EventViewModel<ViewEvent> by eventDelegate {
@@ -42,31 +48,59 @@ class ViewPassphraseViewModel @Inject constructor(
         stateDelegate.onState<Idle> {
             stateDelegate.updateState { ViewState.Loading }
             viewModelScope.launch {
-                getAccountMnemonic(accountAddress).use(
-                    onSuccess = ::displayMnemonic,
-                    onFailed = { _, _ -> displayError() }
-                )
+                val mnemonicResult = getAccountMnemonic(accountAddress)
+                val localAccount = getLocalAccount(accountAddress)
+
+                if (localAccount == null) {
+                    eventDelegate.sendEvent(ViewEvent.ShowGenericError)
+                    eventDelegate.sendEvent(ViewEvent.NavigateBack)
+                    return@launch
+                }
+
+                val mnemonic = when (mnemonicResult) {
+                    is PeraResult.Success -> mnemonicResult.data
+                    is PeraResult.Error -> {
+                        eventDelegate.sendEvent(ViewEvent.ShowGenericError)
+                        eventDelegate.sendEvent(ViewEvent.NavigateBack)
+                        return@launch
+                    }
+                }
+
+                val isQrAvailable = mnemonic.type == AccountMnemonic.AccountType.Algo25
+                val accountName = localAccount.algoAddress.shortenAddress()
+                stateDelegate.updateState {
+                    ViewState.Content(
+                        accountName = accountName,
+                        mnemonicWords = mnemonic.words,
+                        isQrExportAvailable = isQrAvailable
+                    )
+                }
             }
         }
     }
 
-    private fun displayMnemonic(mnemonic: AccountMnemonic) {
-        stateDelegate.updateState {
-            ViewState.Content(mnemonic.words)
+    fun requestAccountExportUri(accountAddress: String, resultCallback: (PeraResult<String>) -> Unit) {
+        viewModelScope.launch {
+            val result = generateAccountExportUriUseCase(accountAddress)
+            resultCallback(result)
         }
     }
 
-    private fun displayError() {
-        viewModelScope.launch {
-            eventDelegate.sendEvent(ViewEvent.ShowGenericError)
-            eventDelegate.sendEvent(ViewEvent.NavigateBack)
+    private fun String.shortenAddress(prefixLength: Int = 4, suffixLength: Int = 4): String {
+        if (this.length <= prefixLength + suffixLength) {
+            return this
         }
+        return "${this.take(prefixLength)}...${this.takeLast(suffixLength)}"
     }
 
     sealed interface ViewState {
         data object Idle : ViewState
         data object Loading : ViewState
-        data class Content(val mnemonicWords: List<String>) : ViewState
+        data class Content(
+            val accountName: String,
+            val mnemonicWords: List<String>,
+            val isQrExportAvailable: Boolean
+        ) : ViewState
     }
 
     sealed interface ViewEvent {


### PR DESCRIPTION
# Pull Request Template

## Description
- Add Deeplink support to import QR Codes URIs containing private keys using avm://account/import scheme supported by the Kibisis AVM Wallet
- Add a toggle to the Passphrase view to optionally view the private key as a QR Code supporting the avm scheme
- Enables accounts to be imported and exported between Kibisis and Pera via QR Code

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [ ] Have you documented any necessary changes in the project's documentation?
- [ ] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- The URI spec includes support for multiple private keys per URI, as well as account names. Neither is included in this implementation in order to reduce initial complexity.
- The URI format for private keys is: avm://account/import?name=<name>&privatekey=<url-safe-base64-encoded-private-key>
- Tracked internally as https://algorandfoundation.atlassian.net/browse/PERA-2114
