### PR TITLE
PERA-2157 :: Call initialize when lifecycle state is created

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/CoreMainActivity.kt
+++ b/app/src/main/kotlin/com/algorand/android/CoreMainActivity.kt
@@ -22,6 +22,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.forEach
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.FragmentNavigator
@@ -48,6 +50,7 @@ import com.algorand.android.utils.showLightStatusBarIcons
 import com.algorand.android.utils.viewbinding.viewBinding
 import javax.inject.Inject
 import kotlin.properties.Delegates
+import kotlinx.coroutines.launch
 
 abstract class CoreMainActivity : BaseActivity() {
 
@@ -110,7 +113,15 @@ abstract class CoreMainActivity : BaseActivity() {
         if (savedInstanceState != null) {
             isBottomBarNavigationVisible = savedInstanceState.getBoolean(IS_BOTTOM_BAR_VISIBLE_KEY)
         }
-        coreMainViewModel.initialize()
+        initializeActivity()
+    }
+
+    private fun initializeActivity() {
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
+                coreMainViewModel.initialize()
+            }
+        }
     }
 
     private fun initObservers() {

--- a/app/src/main/kotlin/com/algorand/android/MainActivity.kt
+++ b/app/src/main/kotlin/com/algorand/android/MainActivity.kt
@@ -201,6 +201,7 @@ class MainActivity :
 
     private val appCacheStatusCollector: suspend (AppCacheStatus) -> Unit = {
         mainViewModel.isAssetSetupCompleted = it == AppCacheStatus.INITIALIZED
+        coreActionsTabBarViewModel.changeViewStateForFeatureFlag()
         binding.coreActionsTabBarView.setCoreActionButtonEnabled(it == AppCacheStatus.INITIALIZED)
     }
 
@@ -728,7 +729,6 @@ class MainActivity :
     private fun onNewNodeActivated() {
         hideProgress()
         mainViewModel.onNewNodeActivated(lifecycle)
-        coreActionsTabBarViewModel.changeViewStateForFeatureFlag()
     }
 
     private fun rejectScamSession(sessionProposal: WalletConnectSessionProposal) {


### PR DESCRIPTION
## Description
We collect when the lifecycle state is CREATED, but sometimes event is being triggered right before lifecycle state is set to CREATED, that's why it emits event but activity doesn't collect it.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2157

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?


