### PR TITLE
PERA-2075 Cancel active job before starting new one in AccountCacheManager

### DIFF
--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/manager/AccountCacheManagerImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/manager/AccountCacheManagerImpl.kt
@@ -50,7 +50,8 @@ internal class AccountCacheManagerImpl @Inject constructor(
     }
 
     private val localAccountCollector: suspend (Int) -> Unit = { accountCount ->
-        if (accountCount > 0) cacheManager.startJob() else cacheManager.stopCurrentJob()
+        cacheManager.stopCurrentJob()
+        if (accountCount > 0) cacheManager.startJob()
     }
 
     override fun initialize(lifecycle: Lifecycle) {


### PR DESCRIPTION
## Description
When we add multiple account with `forEach` for similar functions, it keeps creating new scope and causing us to have multiple coroutines. 

Previous implementation takes around 3-3.5 mins to load
New implementation takes around 30 secs to load

Tested with ASB file which has 41 accounts and 
26615 Asset holdings and 15529 unique assets
Most accounts have 1-5 assets but there are some accounts with;
- 10104 Assets
- 7103 Assets
- 1102 Assets
- 5159 Assets
- 3105 Assets

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2076
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2075

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
