### PR TITLE
PERA-2222 :: Add custom wallet name to account information

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/accountstatusdetail/ui/AccountStatusDetailBottomSheet.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/accountstatusdetail/ui/AccountStatusDetailBottomSheet.kt
@@ -82,6 +82,9 @@ class AccountStatusDetailBottomSheet : BaseBottomSheet(R.layout.bottom_sheet_acc
             is ViewEvent.NavigateToRekeyToLedgerAccount -> {
                 navToRekeyToLedgerAccountNavigation()
             }
+            is ViewEvent.NavigateToHdScanNewAddresses -> {
+                // Will be added when hd widget is merged in
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/accountstatusdetail/ui/AccountStatusDetailViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/accountstatusdetail/ui/AccountStatusDetailViewModel.kt
@@ -15,6 +15,7 @@ package com.algorand.android.modules.accountdetail.accountstatusdetail.ui
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.algorand.android.core.BaseViewModel
+import com.algorand.android.models.AccountCreation
 import com.algorand.android.models.AnnotatedString
 import com.algorand.android.models.ui.AccountAssetItemButtonState
 import com.algorand.android.modules.accountcore.ui.model.AccountDisplayName
@@ -25,9 +26,19 @@ import com.algorand.android.modules.accountdetail.accountstatusdetail.ui.Account
 import com.algorand.android.modules.accountdetail.accountstatusdetail.ui.AccountStatusDetailViewModel.ViewState
 import com.algorand.android.modules.accountdetail.accountstatusdetail.ui.decider.AccountStatusDetailPreviewDecider
 import com.algorand.android.modules.accounticon.ui.model.AccountIconDrawablePreview
-import com.algorand.android.modules.accounts.lite.domain.model.AccountLiteCacheStatus
-import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheFlow
+import com.algorand.android.utils.analytics.CreationType
+import com.algorand.android.utils.launchIO
+import com.algorand.wallet.account.core.domain.usecase.GetAccountDetailFlow
+import com.algorand.wallet.account.detail.domain.model.AccountType
 import com.algorand.wallet.account.detail.domain.model.AccountType.Companion.canSignTransaction
+import com.algorand.wallet.account.detail.domain.usecase.GetAccountRegistrationType
+import com.algorand.wallet.account.info.domain.usecase.GetAccountInformation
+import com.algorand.wallet.account.local.domain.model.LocalAccount
+import com.algorand.wallet.account.local.domain.usecase.GetHdEntropy
+import com.algorand.wallet.account.local.domain.usecase.GetHdKeyPrivateKey
+import com.algorand.wallet.account.local.domain.usecase.GetLocalAccount
+import com.algorand.wallet.encryption.domain.manager.AESPlatformManager
+import com.algorand.wallet.encryption.domain.utils.clearFromMemory
 import com.algorand.wallet.viewmodel.EventDelegate
 import com.algorand.wallet.viewmodel.EventViewModel
 import com.algorand.wallet.viewmodel.StateDelegate
@@ -37,6 +48,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
+@Suppress("LongParameterList")
 @HiltViewModel
 class AccountStatusDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -46,7 +58,13 @@ class AccountStatusDetailViewModel @Inject constructor(
     private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview,
     private val getAccountOriginalStateIconDrawablePreview: GetAccountOriginalStateIconDrawablePreview,
     private val accountStatusDetailPreviewDecider: AccountStatusDetailPreviewDecider,
-    private val getAccountLiteCacheFlow: GetAccountLiteCacheFlow
+    private val getAccountDetailFlow: GetAccountDetailFlow,
+    private val getAccountInformation: GetAccountInformation,
+    private val getAccountRegistrationType: GetAccountRegistrationType,
+    private val getLocalAccount: GetLocalAccount,
+    private val aesPlatformManager: AESPlatformManager,
+    private val getHdKeyPrivateKey: GetHdKeyPrivateKey,
+    private val getHdEntropy: GetHdEntropy
 ) : BaseViewModel(), StateViewModel<ViewState> by stateDelegate, EventViewModel<ViewEvent> by eventDelegate {
 
     private val navArgs = AccountStatusDetailBottomSheetArgs.fromSavedStateHandle(savedStateHandle)
@@ -56,24 +74,46 @@ class AccountStatusDetailViewModel @Inject constructor(
         stateDelegate.setDefaultState(ViewState.Idle)
     }
 
+    @Suppress("LongMethod")
     fun loadAccountStatusDetail() {
         stateDelegate.updateState { ViewState.Loading }
         viewModelScope.launch {
-            getAccountLiteCacheFlow().collectLatest { cacheStatus ->
-                val accountLite = (cacheStatus as? AccountLiteCacheStatus.Data)?.accountLites?.get(accountAddress)
-                if (accountLite?.cachedInfo == null) return@collectLatest
+            getAccountDetailFlow(accountAddress).collectLatest { accountDetail ->
+                if (accountDetail == null) return@collectLatest
+                val accountType = accountDetail.accountType
 
-                val accountType = accountLite.cachedInfo.type
-
-                val authAccountAddress = accountLite.cachedInfo.rekeyAuthAddress
-                val hasAccountAuthority = accountType.canSignTransaction()
+                val accountInformation = getAccountInformation(accountAddress)
+                val authAccountAddress = accountInformation?.rekeyAdminAddress
+                val hasAccountAuthority = accountDetail.accountType?.canSignTransaction() == true
 
                 val titleString = accountStatusDetailPreviewDecider.decideTitleString(accountType)
-                val accountOriginalTypeDisplayName = getAccountDisplayName(accountAddress)
+                val accountOriginalTypeDisplayName = if (accountType == AccountType.HdKey) {
+                    AccountDisplayName(
+                        accountAddress = accountAddress,
+                        primaryDisplayName = accountDetail.customHdSeedInfo?.entropyCustomName ?: accountAddress,
+                        secondaryDisplayName = accountDetail.customHdSeedInfo?.entropyCustomName ?: accountAddress
+                    )
+                } else {
+                    getAccountDisplayName(accountAddress)
+                }
+
                 val accountOriginalTypeIconDrawablePreview = getAccountOriginalStateIconDrawablePreview(accountAddress)
                 val accountTypeDrawablePreview = getAccountIconDrawablePreview(accountAddress)
-                val accountTypeString = accountStatusDetailPreviewDecider.decideAccountTypeString(accountLite)
-                val descriptionDetail = accountStatusDetailPreviewDecider.decideDescriptionDetail(accountLite)
+
+                val rekeyAdminRegistrationType = accountInformation?.rekeyAdminAddress?.let {
+                    getAccountRegistrationType(it)
+                }
+                val accountTypeString = accountStatusDetailPreviewDecider
+                    .decideAccountTypeString(
+                        accountType,
+                        accountDetail.accountRegistrationType,
+                        rekeyAdminRegistrationType
+                    )
+                val descriptionDetail = accountStatusDetailPreviewDecider
+                    .decideDescriptionDetail(
+                        accountType,
+                        rekeyAdminRegistrationType
+                    )
                 val authAccountDisplayName = authAccountAddress?.let { safeAuthAddress ->
                     getAccountDisplayName(safeAuthAddress)
                 }
@@ -96,6 +136,7 @@ class AccountStatusDetailViewModel @Inject constructor(
                         accountTypeDrawablePreview = accountTypeDrawablePreview,
                         descriptionDetail = descriptionDetail,
                         accountTypeString = accountTypeString,
+                        isHdWallet = accountType == AccountType.HdKey,
                         isRekeyGroupVisible = authAccountAddress != null,
                         isRekeyToLedgerAccountVisible = hasAccountAuthority,
                         isRekeyToStandardAccountVisible = hasAccountAuthority
@@ -121,6 +162,39 @@ class AccountStatusDetailViewModel @Inject constructor(
         eventDelegate.sendEvent(viewModelScope, ViewEvent.NavigateToRekeyToLedgerAccount)
     }
 
+    fun navToHdScanNewAddresses() {
+        viewModelScope.launchIO {
+            val account = getLocalAccount.invoke(accountAddress)
+            when (account) {
+                is LocalAccount.HdKey -> {
+                    val privateKey = getHdKeyPrivateKey.invoke(accountAddress)
+                    val entropy = getHdEntropy.invoke(account.seedId)
+                    if (privateKey != null && entropy != null) {
+                        val accountCreation = AccountCreation(
+                            address = account.algoAddress,
+                            customName = null,
+                            isBackedUp = false,
+                            type = AccountCreation.Type.HdKey(
+                                account.publicKey,
+                                aesPlatformManager.encryptByteArray(privateKey.copyOf()),
+                                aesPlatformManager.encryptByteArray(entropy.copyOf()),
+                                account.account,
+                                account.change,
+                                account.keyIndex,
+                                account.derivationType,
+                            ),
+                            creationType = CreationType.RECOVER
+                        )
+                        privateKey.clearFromMemory()
+                        entropy.clearFromMemory()
+                        eventDelegate.sendEvent(viewModelScope, ViewEvent.NavigateToHdScanNewAddresses(accountCreation))
+                    }
+                }
+                else -> { }
+            }
+        }
+    }
+
     sealed interface ViewState {
         data object Idle : ViewState
         data object Loading : ViewState
@@ -136,6 +210,7 @@ class AccountStatusDetailViewModel @Inject constructor(
             val accountTypeDrawablePreview: AccountIconDrawablePreview? = null,
             val descriptionDetail: DescriptionDetail,
             val accountTypeString: String? = null,
+            val isHdWallet: Boolean? = null,
             val isRekeyGroupVisible: Boolean? = null,
             val isRekeyToLedgerAccountVisible: Boolean? = null,
             val isRekeyToStandardAccountVisible: Boolean? = null
@@ -151,6 +226,7 @@ class AccountStatusDetailViewModel @Inject constructor(
 
     sealed interface ViewEvent {
         data class CopyAccountAddressToClipboard(val address: String) : ViewEvent
+        data class NavigateToHdScanNewAddresses(val accountCreation: AccountCreation) : ViewEvent
         data object NavigateToUndoRekey : ViewEvent
         data object NavigateToRekeyToStandardAccount : ViewEvent
         data object NavigateToRekeyToLedgerAccount : ViewEvent

--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/accountstatusdetail/ui/decider/AccountStatusDetailPreviewDecider.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/accountstatusdetail/ui/decider/AccountStatusDetailPreviewDecider.kt
@@ -17,7 +17,6 @@ import com.algorand.android.R
 import com.algorand.android.models.AnnotatedString
 import com.algorand.android.models.ui.AccountAssetItemButtonState
 import com.algorand.android.modules.accountdetail.accountstatusdetail.ui.AccountStatusDetailViewModel.ViewState.Content.DescriptionDetail
-import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
 import com.algorand.android.utils.browser.ALGO25_ACCOUNT_SUPPORT_URL
 import com.algorand.android.utils.browser.HD_ACCOUNT_SUPPORT_URL
 import com.algorand.android.utils.browser.LEDGER_SUPPORT_URL
@@ -49,19 +48,23 @@ class AccountStatusDetailPreviewDecider @Inject constructor(
         return accountTypeString
     }
 
-    fun decideAccountTypeString(accountLite: AccountLite): String {
-        val accountTypeString = when (accountLite.cachedInfo?.type) {
+    fun decideAccountTypeString(
+        accountType: AccountType?,
+        accountRegistrationType: AccountRegistrationType?,
+        rekeyAdminAccountType: AccountRegistrationType?
+    ): String {
+        val accountTypeString = when (accountType) {
             AccountType.LedgerBle -> context.getString(R.string.ledger)
             AccountType.NoAuth -> context.getString(R.string.watch)
             AccountType.Algo25 -> context.getString(R.string.standard)
             AccountType.Rekeyed -> context.getString(R.string.no_auth)
             AccountType.RekeyedAuth -> {
-                val accountOriginalState = when (accountLite.registrationType) {
+                val accountOriginalState = when (accountRegistrationType) {
                     AccountRegistrationType.LedgerBle -> R.string.ledger
                     AccountRegistrationType.NoAuth -> R.string.watch
                     else -> R.string.standard
                 }
-                val accountAuthState = when (accountLite.cachedInfo.rekeyAuthRegistrationType) {
+                val accountAuthState = when (rekeyAdminAccountType) {
                     AccountRegistrationType.LedgerBle -> R.string.ledger
                     AccountRegistrationType.NoAuth -> R.string.watch
                     else -> R.string.standard
@@ -82,14 +85,17 @@ class AccountStatusDetailPreviewDecider @Inject constructor(
         return accountTypeString
     }
 
-    fun decideDescriptionDetail(accountLite: AccountLite): DescriptionDetail {
-        val descriptionStringResId = when (accountLite.cachedInfo?.type) {
+    fun decideDescriptionDetail(
+        accountType: AccountType?,
+        rekeyAdminAccountType: AccountRegistrationType?
+    ): DescriptionDetail {
+        val descriptionStringResId = when (accountType) {
             AccountType.LedgerBle -> R.string.your_account_is_a_Ledger
             AccountType.NoAuth -> R.string.this_account_was_not
             AccountType.Algo25 -> R.string.your_account_is_a_standard
             AccountType.Rekeyed -> R.string.your_account_is_rekeyed_to_an
             AccountType.RekeyedAuth -> {
-                when (accountLite.cachedInfo.rekeyAuthRegistrationType) {
+                when (rekeyAdminAccountType) {
                     AccountRegistrationType.Algo25, AccountRegistrationType.HdKey -> {
                         R.string.your_account_is_rekeyed_to_another
                     }
@@ -97,10 +103,10 @@ class AccountStatusDetailPreviewDecider @Inject constructor(
                     else -> R.string.your_account_is_rekeyed_to_unknown
                 }
             }
-            null -> R.string.your_account_is_rekeyed_to_an
             AccountType.HdKey -> R.string.your_account_is_a_hd_wallet_address
+            null -> R.string.your_account_is_rekeyed_to_an
         }
-        val hyperlinkUrl = when (accountLite.cachedInfo?.type) {
+        val hyperlinkUrl = when (accountType) {
             AccountType.Algo25 -> ALGO25_ACCOUNT_SUPPORT_URL
             AccountType.HdKey -> HD_ACCOUNT_SUPPORT_URL
             AccountType.LedgerBle -> LEDGER_SUPPORT_URL

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/core/domain/usecase/GetAccountDetailFlowUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/core/domain/usecase/GetAccountDetailFlowUseCase.kt
@@ -13,6 +13,8 @@
 package com.algorand.wallet.account.core.domain.usecase
 
 import com.algorand.wallet.account.custom.domain.usecase.GetAccountCustomInfoOrNull
+import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedCustomInfoOrNull
+import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedIdFromAddress
 import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import com.algorand.wallet.account.detail.domain.usecase.GetAccountRegistrationType
 import com.algorand.wallet.account.detail.domain.usecase.GetAccountType
@@ -26,6 +28,8 @@ internal class GetAccountDetailFlowUseCase @Inject constructor(
     private val getAccountCustomInfoOrNull: GetAccountCustomInfoOrNull,
     private val getAccountType: GetAccountType,
     private val getAccountRegistrationType: GetAccountRegistrationType,
+    private val getHdSeedCustomInfoOrNull: GetHdSeedCustomInfoOrNull,
+    private val getHdSeedIdFromAddress: GetHdSeedIdFromAddress
 ) : GetAccountDetailFlow {
 
     override fun invoke(address: String): Flow<AccountDetail?> {
@@ -34,6 +38,7 @@ internal class GetAccountDetailFlowUseCase @Inject constructor(
             AccountDetail(
                 address = address,
                 customAccountInfo = getAccountCustomInfoOrNull(address),
+                customHdSeedInfo = getHdSeedCustomInfoOrNull(getHdSeedIdFromAddress.invoke(address)),
                 accountRegistrationType = getAccountRegistrationType(address),
                 accountType = getAccountType(address),
             )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/core/domain/usecase/GetAccountsDetailsFlowUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/core/domain/usecase/GetAccountsDetailsFlowUseCase.kt
@@ -13,6 +13,8 @@
 package com.algorand.wallet.account.core.domain.usecase
 
 import com.algorand.wallet.account.custom.domain.usecase.GetAccountCustomInfoOrNull
+import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedCustomInfoOrNull
+import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedIdFromAddress
 import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import com.algorand.wallet.account.detail.domain.usecase.GetAccountRegistrationType
 import com.algorand.wallet.account.detail.domain.usecase.GetAccountType
@@ -25,7 +27,9 @@ internal class GetAccountsDetailsFlowUseCase @Inject constructor(
     private val getAllLocalAccountAddressesAsFlow: GetAllLocalAccountAddressesAsFlow,
     private val getAccountType: GetAccountType,
     private val getAccountRegistrationType: GetAccountRegistrationType,
-    private val getAccountCustomInfoOrNull: GetAccountCustomInfoOrNull
+    private val getAccountCustomInfoOrNull: GetAccountCustomInfoOrNull,
+    private val getHdSeedCustomInfoOrNull: GetHdSeedCustomInfoOrNull,
+    private val getHdSeedIdFromAddress: GetHdSeedIdFromAddress
 ) : GetAccountsDetailsFlow {
 
     override fun invoke(): Flow<List<AccountDetail>> {
@@ -35,6 +39,7 @@ internal class GetAccountsDetailsFlowUseCase @Inject constructor(
                 AccountDetail(
                     address = address,
                     customAccountInfo = customInfo,
+                    customHdSeedInfo = getHdSeedCustomInfoOrNull(getHdSeedIdFromAddress.invoke(address)),
                     accountRegistrationType = getAccountRegistrationType(address),
                     accountType = getAccountType(address)
                 )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/custom/di/CustomInfoModule.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/custom/di/CustomInfoModule.kt
@@ -42,6 +42,8 @@ import com.algorand.wallet.account.custom.domain.usecase.GetBackedUpAccounts
 import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedAsbBackUpStatus
 import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedCustomInfoOrNull
 import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedCustomName
+import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedIdFromAddress
+import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedIdFromAddressUseCase
 import com.algorand.wallet.account.custom.domain.usecase.GetNotBackedUpAccounts
 import com.algorand.wallet.account.custom.domain.usecase.SetAccountCustomInfo
 import com.algorand.wallet.account.custom.domain.usecase.SetAccountCustomName
@@ -205,4 +207,7 @@ internal object CustomInfoModule {
 
     @Provides
     fun provideClearAllCustomInformation(useCase: ClearAllCustomInformationUseCase): ClearAllCustomInformation = useCase
+
+    @Provides
+    fun provideGetHdSeedIdFromAddress(useCase: GetHdSeedIdFromAddressUseCase): GetHdSeedIdFromAddress = useCase
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/custom/domain/usecase/CustomInfoUseCases.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/custom/domain/usecase/CustomInfoUseCases.kt
@@ -38,6 +38,10 @@ fun interface SetAccountCustomInfo {
     suspend operator fun invoke(customInfo: CustomAccountInfo)
 }
 
+fun interface GetHdSeedIdFromAddress {
+    suspend operator fun invoke(address: String): Int
+}
+
 fun interface GetAccountCustomInfoOrNull {
     suspend operator fun invoke(address: String): CustomAccountInfo?
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/custom/domain/usecase/GetHdSeedIdFromAddressUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/custom/domain/usecase/GetHdSeedIdFromAddressUseCase.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.custom.domain.usecase
+
+import com.algorand.wallet.account.local.domain.model.LocalAccount
+import com.algorand.wallet.account.local.domain.usecase.GetLocalAccount
+import javax.inject.Inject
+
+internal class GetHdSeedIdFromAddressUseCase @Inject constructor(
+    private val getLocalAccount: GetLocalAccount
+) : GetHdSeedIdFromAddress {
+
+    override suspend fun invoke(address: String): Int {
+        val localAccount = getLocalAccount.invoke(address)
+        when (localAccount) {
+            is LocalAccount.HdKey -> {
+                return localAccount.seedId
+            }
+            else -> return 0
+        }
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/model/AccountDetail.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/model/AccountDetail.kt
@@ -13,11 +13,13 @@
 package com.algorand.wallet.account.detail.domain.model
 
 import com.algorand.wallet.account.custom.domain.model.CustomAccountInfo
+import com.algorand.wallet.account.custom.domain.model.CustomHdSeedInfo
 import com.algorand.wallet.account.detail.domain.model.AccountType.Companion.canSignTransaction
 
 data class AccountDetail(
     val address: String,
     val customAccountInfo: CustomAccountInfo?,
+    val customHdSeedInfo: CustomHdSeedInfo?,
     val accountRegistrationType: AccountRegistrationType?,
     val accountType: AccountType?
 ) {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/usecase/GetAccountDetailUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/detail/domain/usecase/GetAccountDetailUseCase.kt
@@ -13,12 +13,16 @@
 package com.algorand.wallet.account.detail.domain.usecase
 
 import com.algorand.wallet.account.custom.domain.usecase.GetAccountCustomInfoOrNull
+import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedCustomInfoOrNull
+import com.algorand.wallet.account.custom.domain.usecase.GetHdSeedIdFromAddress
 import com.algorand.wallet.account.detail.domain.model.AccountDetail
 import javax.inject.Inject
 
 internal class GetAccountDetailUseCase @Inject constructor(
     private val getCustomInfoOrNull: GetAccountCustomInfoOrNull,
-    private val getAccountState: GetAccountState
+    private val getAccountState: GetAccountState,
+    private val getHdSeedCustomInfoOrNull: GetHdSeedCustomInfoOrNull,
+    private val getHdSeedIdFromAddress: GetHdSeedIdFromAddress
 ) : GetAccountDetail {
 
     override suspend fun invoke(address: String): AccountDetail {
@@ -26,6 +30,7 @@ internal class GetAccountDetailUseCase @Inject constructor(
         return AccountDetail(
             address = address,
             customAccountInfo = getCustomInfoOrNull(address),
+            customHdSeedInfo = getHdSeedCustomInfoOrNull(getHdSeedIdFromAddress.invoke(address)),
             accountRegistrationType = accountState.accountRegistrationType,
             accountType = accountState.accountType
         )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/model/AccountInformationMapperImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/mapper/model/AccountInformationMapperImpl.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 
 internal class AccountInformationMapperImpl @Inject constructor(
     private val appStateSchemeMapper: AppStateSchemeMapper,
-    private val assetHoldingMapper: AssetHoldingMapper,
+    private val assetHoldingMapper: AssetHoldingMapper
 ) : AccountInformationMapper {
 
     override fun invoke(response: AccountInformationResponse): AccountInformation? {
@@ -43,6 +43,7 @@ internal class AccountInformationMapperImpl @Inject constructor(
         val assetHoldingList = response.allAssetHoldingList.orEmpty().map {
             assetHoldingMapper(it)
         }
+
         if (assetHoldingList.any { it == null }) return null
         return AccountInformation(
             address = response.address ?: return null,


### PR DESCRIPTION
# Pull Request Template

## Description
- Add custom wallet name to account information

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2222

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- We need to land this first so account status detail bottomsheet hd widget is easier to land
- I switched account status detail back to use account detail / information instead of account lite because loading all the parent hd wallet info into account lite isn't needed
- `navToHdScanNewAddresses` will be used in hd widget, I'm just trying to merge data layer changes first
