### PR TITLE
PERA-2132 Check active accounts as chunks of 5

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/common/warningconfirmation/BackupInfoViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/common/warningconfirmation/BackupInfoViewModel.kt
@@ -18,8 +18,11 @@ import com.algorand.android.core.BaseViewModel
 import com.algorand.android.models.AccountCreation
 import com.algorand.android.models.OnboardingAccountType
 import com.algorand.android.modules.tracking.onboarding.register.OnboardingPassphraseUnderstandEventTracker
+import com.algorand.android.ui.onboarding.creation.mapper.AccountCreationHdKeyTypeMapper
 import com.algorand.android.utils.analytics.CreationType
 import com.algorand.android.utils.getOrElse
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
 import com.algorand.wallet.algosdk.transaction.sdk.AlgoAccountSdk
 import com.algorand.wallet.encryption.domain.manager.AESPlatformManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -31,6 +34,8 @@ class BackupInfoViewModel @Inject constructor(
     private val onboardingPassphraseUnderstandEventTracker: OnboardingPassphraseUnderstandEventTracker,
     private val algoAccountSdk: AlgoAccountSdk,
     private val aesPlatformManager: AESPlatformManager,
+    private val bip39WalletProvider: Bip39WalletProvider,
+    private val accountCreationHdKeyTypeMapper: AccountCreationHdKeyTypeMapper,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel() {
 
@@ -48,31 +53,27 @@ class BackupInfoViewModel @Inject constructor(
         }
     }
 
-    fun createHdKeyAccount(): AccountCreation? {
-        val account = algoAccountSdk.createHdAccount()
-            ?: return null
-
+    fun createHdKeyAccount(): AccountCreation {
+        val wallet = bip39WalletProvider.createBip39Wallet()
+        val hdKeyAddress = wallet.generateAddress(HdKeyAddressIndex())
+        val hdKeyType = accountCreationHdKeyTypeMapper(
+            entropy = wallet.getEntropy().value,
+            hdKeyAddress = hdKeyAddress,
+            seedId = null
+        )
         return AccountCreation(
-            address = account.address,
+            address = hdKeyAddress.address,
             customName = null,
             isBackedUp = false,
-            type = AccountCreation.Type.HdKey(
-                account.publicKey,
-                aesPlatformManager.encryptByteArray(account.privateKey),
-                aesPlatformManager.encryptByteArray(account.entropy),
-                account.account,
-                account.change,
-                account.keyIndex,
-                account.derivationType,
-            ),
+            type = hdKeyType,
             creationType = CreationType.CREATE
-        )
+        ).also {
+            wallet.invalidate()
+        }
     }
 
     fun createAlgo25Account(): AccountCreation? {
-        val account = algoAccountSdk.createAlgo25Account()
-            ?: return null
-
+        val account = algoAccountSdk.createAlgo25Account() ?: return null
         return AccountCreation(
             address = account.address,
             customName = null,

--- a/app/src/main/kotlin/com/algorand/android/ui/onboarding/creation/di/OnboardingUiModule.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/onboarding/creation/di/OnboardingUiModule.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.onboarding.creation.di
+
+import com.algorand.android.ui.onboarding.creation.mapper.AccountCreationHdKeyTypeMapper
+import com.algorand.android.ui.onboarding.creation.mapper.DefaultAccountCreationHdKeyTypeMapper
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object OnboardingUiModule {
+
+    @Provides
+    fun provideAccountCreationHdKeyTypeMapper(
+        impl: DefaultAccountCreationHdKeyTypeMapper
+    ): AccountCreationHdKeyTypeMapper = impl
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/onboarding/creation/mapper/AccountCreationHdKeyTypeMapper.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/onboarding/creation/mapper/AccountCreationHdKeyTypeMapper.kt
@@ -10,10 +10,11 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.algosdk.transaction.sdk
+package com.algorand.android.ui.onboarding.creation.mapper
 
-interface PeraBip39Sdk {
-    fun getSeedFromEntropy(entropy: ByteArray): ByteArray?
-    fun getEntropyFromMnemonic(mnemonic: String): ByteArray?
-    fun getMnemonicFromEntropy(entropy: ByteArray): String?
+import com.algorand.android.models.AccountCreation
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddress
+
+fun interface AccountCreationHdKeyTypeMapper {
+    operator fun invoke(entropy: ByteArray, hdKeyAddress: HdKeyAddress, seedId: Int?): AccountCreation.Type.HdKey
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/onboarding/creation/mapper/DefaultAccountCreationHdKeyTypeMapper.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/onboarding/creation/mapper/DefaultAccountCreationHdKeyTypeMapper.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.onboarding.creation.mapper
+
+import com.algorand.android.models.AccountCreation
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddress
+import com.algorand.wallet.encryption.domain.manager.AESPlatformManager
+import javax.inject.Inject
+
+internal class DefaultAccountCreationHdKeyTypeMapper @Inject constructor(
+    private val aesPlatformManager: AESPlatformManager
+) : AccountCreationHdKeyTypeMapper {
+
+    override fun invoke(entropy: ByteArray, hdKeyAddress: HdKeyAddress, seedId: Int?): AccountCreation.Type.HdKey {
+        return with(hdKeyAddress) {
+            AccountCreation.Type.HdKey(
+                publicKey,
+                aesPlatformManager.encryptByteArray(privateKey),
+                aesPlatformManager.encryptByteArray(entropy),
+                index.accountIndex,
+                index.changeIndex,
+                index.keyIndex,
+                derivationType.value,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/onboarding/recoverypassphrase/importregisteredaddresses/RecoverRegisteredAccountsViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/onboarding/recoverypassphrase/importregisteredaddresses/RecoverRegisteredAccountsViewModel.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.viewModelScope
 import com.algorand.android.core.BaseViewModel
 import com.algorand.android.models.AccountCreation
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreviewByType
+import com.algorand.android.ui.onboarding.creation.mapper.AccountCreationHdKeyTypeMapper
 import com.algorand.android.ui.onboarding.recoverypassphrase.importregisteredaddresses.RecoverRegisteredAccountsViewModel.ViewEvent
 import com.algorand.android.ui.onboarding.recoverypassphrase.importregisteredaddresses.RecoverRegisteredAccountsViewModel.ViewState
 import com.algorand.android.ui.onboarding.recoverypassphrase.importregisteredaddresses.RecoverRegisteredAccountsViewModel.ViewState.Content.ContentType
@@ -31,8 +32,10 @@ import com.algorand.wallet.account.detail.domain.model.AccountType
 import com.algorand.wallet.account.info.domain.model.RegisteredHdKey
 import com.algorand.wallet.account.info.domain.usecase.FetchRekeyedAddresses
 import com.algorand.wallet.account.info.domain.usecase.GetRegisteredHdKeys
-import com.algorand.wallet.algosdk.domain.model.HdKeyAccount
-import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddress
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39Wallet
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
 import com.algorand.wallet.encryption.domain.manager.AESPlatformManager
 import com.algorand.wallet.encryption.domain.utils.clearFromMemory
 import com.algorand.wallet.viewmodel.EventDelegate
@@ -52,11 +55,12 @@ import kotlinx.coroutines.supervisorScope
 class RecoverRegisteredAccountsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val aesPlatformManager: AESPlatformManager,
-    private val bip39Sdk: PeraBip39Sdk,
+    private val bip39WalletProvider: Bip39WalletProvider,
     private val accountAdditionUseCase: AccountAdditionUseCase,
     private val getRegisteredHdKeys: GetRegisteredHdKeys,
     private val fetchRekeyedAddresses: FetchRekeyedAddresses,
     private val getAccountIconDrawablePreviewByType: GetAccountIconDrawablePreviewByType,
+    private val accountCreationHdKeyTypeMapper: AccountCreationHdKeyTypeMapper,
     private val stateDelegate: StateDelegate<ViewState>,
     private val eventDelegate: EventDelegate<ViewEvent>
 ) : BaseViewModel(), StateViewModel<ViewState> by stateDelegate, EventViewModel<ViewEvent> by eventDelegate {
@@ -147,12 +151,14 @@ class RecoverRegisteredAccountsViewModel @Inject constructor(
     private suspend fun addSelectedAddresses(selectedAddresses: List<RegisteredHdKey>) {
         val encryptedEntropy = (accountCreation.type as AccountCreation.Type.HdKey).encryptedEntropy
         val entropy = aesPlatformManager.decryptByteArray(encryptedEntropy)
+        val wallet = bip39WalletProvider.getBip39Wallet(entropy.copyOf())
         selectedAddresses.forEach { accountItem ->
-            val hdKeyAccount = createHdKeyAccount(entropy, accountItem) ?: return@forEach
-            val newAccountCreation = createAccountCreation(hdKeyAccount)
+            val hdKeyAccount = createHdKeyAddress(wallet, accountItem)
+            val newAccountCreation = createAccountCreation(entropy, hdKeyAccount)
             accountAdditionUseCase.addNewAccount(newAccountCreation)
         }
         entropy.clearFromMemory()
+        wallet.invalidate()
     }
 
     private suspend fun fetchRekeyedAddresses(
@@ -188,23 +194,16 @@ class RecoverRegisteredAccountsViewModel @Inject constructor(
         )
     }
 
-    private fun createHdKeyAccount(entropy: ByteArray, accountItem: RegisteredHdKey): HdKeyAccount? {
+    private fun createHdKeyAddress(bip39Wallet: Bip39Wallet, accountItem: RegisteredHdKey): HdKeyAddress {
         return with(accountItem) {
-            bip39Sdk.getHdKeyAccount(entropy.copyOf(), account, change, keyIndex)
+            val index = HdKeyAddressIndex(accountIndex = account, changeIndex = change, keyIndex = keyIndex)
+            bip39Wallet.generateAddress(index)
         }
     }
 
-    private fun createAccountCreation(account: HdKeyAccount): AccountCreation {
-        return with(account) {
-            val hdKeyType = AccountCreation.Type.HdKey(
-                publicKey,
-                aesPlatformManager.encryptByteArray(privateKey),
-                aesPlatformManager.encryptByteArray(entropy),
-                account.account,
-                change,
-                keyIndex,
-                derivationType,
-            )
+    private fun createAccountCreation(entropy: ByteArray, hdKeyAddress: HdKeyAddress): AccountCreation {
+        return with(hdKeyAddress) {
+            val hdKeyType = accountCreationHdKeyTypeMapper(entropy, hdKeyAddress, seedId = null)
             AccountCreation(
                 address = address,
                 customName = address.toShortenedAddress(),

--- a/app/src/main/kotlin/com/algorand/android/ui/register/initialregisterintro/InitialRegisterIntroViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/register/initialregisterintro/InitialRegisterIntroViewModel.kt
@@ -14,36 +14,31 @@ package com.algorand.android.ui.register.initialregisterintro
 
 import com.algorand.android.core.BaseViewModel
 import com.algorand.android.models.AccountCreation
+import com.algorand.android.ui.onboarding.creation.mapper.AccountCreationHdKeyTypeMapper
 import com.algorand.android.utils.analytics.CreationType
-import com.algorand.wallet.algosdk.transaction.sdk.AlgoAccountSdk
-import com.algorand.wallet.encryption.domain.manager.AESPlatformManager
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class InitialRegisterIntroViewModel @Inject constructor(
-    private val algoAccountSdk: AlgoAccountSdk,
-    private val aesPlatformManager: AESPlatformManager,
+    private val bip39WalletProvider: Bip39WalletProvider,
+    private val accountCreationHdKeyTypeMapper: AccountCreationHdKeyTypeMapper
 ) : BaseViewModel() {
 
-    fun createHdKeyAccount(): AccountCreation? {
-        val account = algoAccountSdk.createHdAccount()
-            ?: return null
-
+    fun createHdKeyAccount(): AccountCreation {
+        val wallet = bip39WalletProvider.createBip39Wallet()
+        val hdKeyAddress = wallet.generateAddress(HdKeyAddressIndex())
+        val hdKeyType = accountCreationHdKeyTypeMapper(wallet.getEntropy().value, hdKeyAddress, null)
         return AccountCreation(
-            address = account.address,
+            address = hdKeyAddress.address,
             customName = null,
             isBackedUp = false,
-            type = AccountCreation.Type.HdKey(
-                account.publicKey,
-                aesPlatformManager.encryptByteArray(account.privateKey),
-                aesPlatformManager.encryptByteArray(account.entropy),
-                account.account,
-                account.change,
-                account.keyIndex,
-                account.derivationType,
-            ),
+            type = hdKeyType,
             creationType = CreationType.CREATE
-        )
+        ).also {
+            wallet.invalidate()
+        }
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/register/registerintro/RegisterIntroViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/register/registerintro/RegisterIntroViewModel.kt
@@ -17,19 +17,22 @@ import androidx.lifecycle.viewModelScope
 import com.algorand.android.core.BaseViewModel
 import com.algorand.android.models.AccountCreation
 import com.algorand.android.models.RegisterIntroPreview
+import com.algorand.android.ui.onboarding.creation.mapper.AccountCreationHdKeyTypeMapper
 import com.algorand.android.usecase.IsOnHdWalletUseCase
 import com.algorand.android.usecase.RegisterIntroPreviewUseCase
 import com.algorand.android.usecase.RegistrationUseCase
 import com.algorand.android.utils.analytics.CreationType
 import com.algorand.android.utils.getOrElse
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
 import com.algorand.wallet.algosdk.transaction.sdk.AlgoAccountSdk
 import com.algorand.wallet.encryption.domain.manager.AESPlatformManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @HiltViewModel
 class RegisterIntroViewModel @Inject constructor(
@@ -38,6 +41,8 @@ class RegisterIntroViewModel @Inject constructor(
     private val isOnHdWalletUseCase: IsOnHdWalletUseCase,
     private val algoAccountSdk: AlgoAccountSdk,
     private val aesPlatformManager: AESPlatformManager,
+    private val bip39WalletProvider: Bip39WalletProvider,
+    private val accountCreationHdKeyTypeMapper: AccountCreationHdKeyTypeMapper,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel() {
 
@@ -78,38 +83,26 @@ class RegisterIntroViewModel @Inject constructor(
         return isOnHdWalletUseCase.invoke()
     }
 
-    fun createHdKeyAccount(): AccountCreation? {
-        val account = algoAccountSdk.createHdAccount()
-            ?: return null
-
+    fun createHdKeyAccount(): AccountCreation {
+        val wallet = bip39WalletProvider.createBip39Wallet()
+        val hdKeyAddress = wallet.generateAddress(HdKeyAddressIndex())
+        val hdKeyType = accountCreationHdKeyTypeMapper(wallet.getEntropy().value, hdKeyAddress, seedId = null)
         return AccountCreation(
-            address = account.address,
+            address = hdKeyAddress.address,
             customName = null,
             isBackedUp = false,
-            type = AccountCreation.Type.HdKey(
-                account.publicKey,
-                aesPlatformManager.encryptByteArray(account.privateKey),
-                aesPlatformManager.encryptByteArray(account.entropy),
-                account.account,
-                account.change,
-                account.keyIndex,
-                account.derivationType,
-            ),
+            type = hdKeyType,
             creationType = CreationType.CREATE
         )
     }
 
     fun createAlgo25Account(): AccountCreation? {
-        val account = algoAccountSdk.createAlgo25Account()
-            ?: return null
-
+        val account = algoAccountSdk.createAlgo25Account() ?: return null
         return AccountCreation(
             address = account.address,
             customName = null,
             isBackedUp = false,
-            type = AccountCreation.Type.Algo25(
-                aesPlatformManager.encryptByteArray(account.secretKey)
-            ),
+            type = AccountCreation.Type.Algo25(aesPlatformManager.encryptByteArray(account.secretKey)),
             creationType = CreationType.CREATE
         )
     }

--- a/app/src/main/kotlin/com/algorand/android/ui/register/selectwallet/HdWalletSelectionViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/register/selectwallet/HdWalletSelectionViewModel.kt
@@ -15,32 +15,32 @@ package com.algorand.android.ui.register.selectwallet
 import androidx.lifecycle.viewModelScope
 import com.algorand.android.core.BaseViewModel
 import com.algorand.android.models.AccountCreation
+import com.algorand.android.ui.onboarding.creation.mapper.AccountCreationHdKeyTypeMapper
 import com.algorand.android.ui.register.selectwallet.HdWalletSelectionViewModel.ViewEvent
 import com.algorand.android.ui.register.selectwallet.HdWalletSelectionViewModel.ViewState
 import com.algorand.android.utils.analytics.CreationType
 import com.algorand.android.utils.launchIO
 import com.algorand.wallet.account.local.domain.usecase.GetHdEntropy
 import com.algorand.wallet.account.local.domain.usecase.GetHdWalletSummaries
-import com.algorand.wallet.algosdk.transaction.sdk.AlgoAccountSdk
-import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
-import com.algorand.wallet.encryption.domain.manager.AESPlatformManager
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
+import com.algorand.wallet.encryption.domain.utils.clearFromMemory
 import com.algorand.wallet.viewmodel.EventDelegate
 import com.algorand.wallet.viewmodel.EventViewModel
 import com.algorand.wallet.viewmodel.StateDelegate
 import com.algorand.wallet.viewmodel.StateViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class HdWalletSelectionViewModel @Inject constructor(
     private val stateDelegate: StateDelegate<ViewState>,
     private val eventDelegate: EventDelegate<ViewEvent>,
-    private val aesPlatformManager: AESPlatformManager,
-    private val algoAccountSdk: AlgoAccountSdk,
-    private val bip39Sdk: PeraBip39Sdk,
+    private val bip39WalletProvider: Bip39WalletProvider,
     private val getHdEntropy: GetHdEntropy,
-    private val getHdWalletSummaries: GetHdWalletSummaries
+    private val getHdWalletSummaries: GetHdWalletSummaries,
+    private val accountCreationHdKeyTypeMapper: AccountCreationHdKeyTypeMapper
 ) : BaseViewModel(), StateViewModel<ViewState> by stateDelegate, EventViewModel<ViewEvent> by eventDelegate {
 
     init {
@@ -70,22 +70,14 @@ class HdWalletSelectionViewModel @Inject constructor(
 
     fun createNewHdWallet() {
         viewModelScope.launchIO {
-            val account = algoAccountSdk.createHdAccount()
-                ?: return@launchIO
-
+            val wallet = bip39WalletProvider.createBip39Wallet()
+            val hdKeyAddress = wallet.generateAddress(HdKeyAddressIndex())
+            val hdKeyType = accountCreationHdKeyTypeMapper(wallet.getEntropy().value, hdKeyAddress, seedId = null)
             val accountCreation = AccountCreation(
-                address = account.address,
+                address = hdKeyAddress.address,
                 customName = null,
                 isBackedUp = false,
-                type = AccountCreation.Type.HdKey(
-                    account.publicKey,
-                    aesPlatformManager.encryptByteArray(account.privateKey),
-                    aesPlatformManager.encryptByteArray(account.entropy),
-                    account.account,
-                    account.change,
-                    account.keyIndex,
-                    account.derivationType,
-                ),
+                type = hdKeyType,
                 creationType = CreationType.CREATE
             )
             eventDelegate.sendEvent(ViewEvent.NavigateToCreateWalletNameRegistrationNavigation(accountCreation))
@@ -95,27 +87,20 @@ class HdWalletSelectionViewModel @Inject constructor(
     fun createNewHdAccount(seedId: Int, maxAccountIndex: Int) {
         viewModelScope.launchIO {
 
-            val entropy = getHdEntropy(seedId)
+            val entropy = getHdEntropy(seedId) ?: return@launchIO
             val nextHdAccountIndex = maxAccountIndex + 1
-            val account = bip39Sdk.getHdKeyAccount(
-                entropy = entropy ?: return@launchIO,
-                accountIndex = nextHdAccountIndex,
-                changeIndex = 0,
-                keyIndex = 0
-            ) ?: return@launchIO
-
+            val wallet = bip39WalletProvider.getBip39Wallet(entropy)
+            val index = HdKeyAddressIndex(nextHdAccountIndex, changeIndex = 0, keyIndex = 0)
+            val hdKeyAddress = wallet.generateAddress(index)
             val accountCreation = AccountCreation(
-                address = account.address, customName = null, isBackedUp = false, type = AccountCreation.Type.HdKey(
-                    account.publicKey,
-                    aesPlatformManager.encryptByteArray(account.privateKey),
-                    aesPlatformManager.encryptByteArray(account.entropy),
-                    account.account,
-                    account.change,
-                    account.keyIndex,
-                    account.derivationType,
-                    seedId
-                ), creationType = CreationType.CREATE
+                address = hdKeyAddress.address,
+                customName = null,
+                isBackedUp = false,
+                type = accountCreationHdKeyTypeMapper(entropy, hdKeyAddress, seedId),
+                creationType = CreationType.CREATE
             )
+            entropy.clearFromMemory()
+            wallet.invalidate()
             eventDelegate.sendEvent(ViewEvent.NavigateToCreateAccountNameRegistrationNavigation(accountCreation))
         }
     }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/mapper/DefaultHdAccountAddressMapper.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/mapper/DefaultHdAccountAddressMapper.kt
@@ -14,22 +14,22 @@ package com.algorand.wallet.account.info.domain.mapper
 
 import com.algorand.wallet.account.info.domain.model.AccountFastLookup
 import com.algorand.wallet.account.info.domain.model.ActiveHdAccount.HdAccountAddress
-import com.algorand.wallet.account.info.domain.model.HdKeyDetail
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressLite
 import javax.inject.Inject
 
 internal class DefaultHdAccountAddressMapper @Inject constructor() : HdAccountAddressMapper {
 
     override fun invoke(
-        hdKeyDetails: List<HdKeyDetail>,
+        hdKeyDetails: List<HdKeyAddressLite>,
         accountFastLookupBatch: Map<String, AccountFastLookup?>
     ): List<HdAccountAddress> {
         return hdKeyDetails.map { hdKeyDetail ->
             HdAccountAddress(
-                address = hdKeyDetail.algoAddress,
-                accountIndex = hdKeyDetail.accountIndex,
-                changeIndex = hdKeyDetail.changeIndex,
-                keyIndex = hdKeyDetail.keyIndex,
-                fastLookup = accountFastLookupBatch[hdKeyDetail.algoAddress]
+                address = hdKeyDetail.address,
+                accountIndex = hdKeyDetail.index.accountIndex,
+                changeIndex = hdKeyDetail.index.changeIndex,
+                keyIndex = hdKeyDetail.index.keyIndex,
+                fastLookup = accountFastLookupBatch[hdKeyDetail.address]
             )
         }
     }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountAddressesUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountAddressesUseCase.kt
@@ -16,24 +16,28 @@ import com.algorand.wallet.account.info.domain.mapper.HdAccountAddressMapper
 import com.algorand.wallet.account.info.domain.model.AccountFastLookup
 import com.algorand.wallet.account.info.domain.model.ActiveHdAccount
 import com.algorand.wallet.account.info.domain.model.ActiveHdAccount.HdAccountAddress
-import com.algorand.wallet.account.info.domain.model.HdKeyDetail
-import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressLite
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39Wallet
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
 import javax.inject.Inject
 
 internal class GetActiveHdAccountAddressesUseCase @Inject constructor(
-    private val peraBip39Sdk: PeraBip39Sdk,
+    private val bip39WalletProvider: Bip39WalletProvider,
     private val getAccountFastLookupBatch: GetAccountFastLookupBatch,
     private val hdAccountAddressMapper: HdAccountAddressMapper
 ) : GetActiveHdAccountAddresses {
 
     override suspend fun invoke(activeHdAccount: ActiveHdAccount): List<HdAccountAddress> {
+        val accountIndex = activeHdAccount.accountIndex
         val hdKeyDetailsList = mutableListOf<HdAccountAddress>().apply {
             addAll(activeHdAccount.firstBatchHdAccountAddress)
         }
         var rangeStart = SEARCH_BATCH_COUNT
+        val bip39Api = bip39WalletProvider.getBip39Wallet(activeHdAccount.entropy)
         while (true) {
-            val hdKeyDetailsBatch = createHdKeyDetailBatch(activeHdAccount, getSearchBatchRange(rangeStart))
-            val addresses = hdKeyDetailsBatch.map { it.algoAddress }
+            val hdKeyDetailsBatch = createHdKeyDetailBatch(bip39Api, accountIndex, getSearchBatchRange(rangeStart))
+            val addresses = hdKeyDetailsBatch.map { it.address }
             val accountFastLookupBatch = getAccountFastLookupBatch(addresses)
             if (shouldContinueSearching(accountFastLookupBatch)) {
                 val hdAccountAddresses = hdAccountAddressMapper(hdKeyDetailsBatch, accountFastLookupBatch)
@@ -43,6 +47,7 @@ internal class GetActiveHdAccountAddressesUseCase @Inject constructor(
                 break
             }
         }
+        bip39Api.invalidate()
         return hdKeyDetailsList
     }
 
@@ -50,10 +55,10 @@ internal class GetActiveHdAccountAddressesUseCase @Inject constructor(
         return accountFastLookupBatch.values.any { it?.accountExists == true }
     }
 
-    private fun createHdKeyDetailBatch(account: ActiveHdAccount, range: IntRange): List<HdKeyDetail> {
+    private fun createHdKeyDetailBatch(bip39Wallet: Bip39Wallet, accountIndex: Int, range: IntRange): List<HdKeyAddressLite> {
         return range.map { keyIndex ->
-            val address = peraBip39Sdk.generateHdKeyAddress(account.entropy, account.accountIndex, 0, keyIndex)
-            HdKeyDetail(address, account.accountIndex, 0, keyIndex)
+            val index = HdKeyAddressIndex(accountIndex, 0, keyIndex)
+            bip39Wallet.generateAddressLite(index)
         }
     }
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCase.kt
@@ -17,6 +17,10 @@ import com.algorand.wallet.account.info.domain.model.ActiveHdAccount
 import com.algorand.wallet.account.info.domain.model.HdKeyDetail
 import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
 import javax.inject.Inject
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.supervisorScope
 
 internal class GetActiveHdAccountsUseCase @Inject constructor(
     private val peraBip39Sdk: PeraBip39Sdk,
@@ -28,19 +32,44 @@ internal class GetActiveHdAccountsUseCase @Inject constructor(
         val activeHdAccounts = mutableListOf<ActiveHdAccount>()
         var accountIndex = 0
         while (true) {
-            val firstBatchHdKeyDetails = getFirstHdKeyDetailsBatch(accountIndex, entropy)
-            val addresses = firstBatchHdKeyDetails.map { it.algoAddress }
-            val firstBatchAccountFastLookup = getAccountFastLookupBatch(addresses)
-            val isAccountActive = firstBatchAccountFastLookup.any { it.value?.accountExists == true }
-            if (isAccountActive) {
-                val hdAccountAddresses = hdAccountAddressMapper(firstBatchHdKeyDetails, firstBatchAccountFastLookup)
-                activeHdAccounts.add(ActiveHdAccount(accountIndex, entropy, hdAccountAddresses))
-                accountIndex++
-            } else {
+            val activeAccountsBatch = getActiveAccountsBatchDeferred(accountIndex, entropy)
+                .awaitAll()
+                .filterNotNull()
+
+            if (activeAccountsBatch.isEmpty()) {
                 break
+            } else {
+                activeHdAccounts.addAll(activeAccountsBatch)
+                accountIndex += SEARCH_BATCH_COUNT
             }
         }
         return activeHdAccounts
+    }
+
+    private suspend fun getActiveAccountsBatchDeferred(
+        accountIndex: Int,
+        entropy: ByteArray
+    ): List<Deferred<ActiveHdAccount?>> {
+        return supervisorScope {
+            (accountIndex until accountIndex + SEARCH_BATCH_COUNT).map { index ->
+                async {
+                    getActiveHdAccountIfExist(index, entropy)
+                }
+            }
+        }
+    }
+
+    private suspend fun getActiveHdAccountIfExist(accountIndex: Int, entropy: ByteArray): ActiveHdAccount? {
+        val firstBatchHdKeyDetails = getFirstHdKeyDetailsBatch(accountIndex, entropy)
+        val addresses = firstBatchHdKeyDetails.map { it.algoAddress }
+        val firstBatchAccountFastLookup = getAccountFastLookupBatch(addresses)
+        val isAccountActive = firstBatchAccountFastLookup.any { it.value?.accountExists == true }
+        return if (isAccountActive) {
+            val hdAccountAddresses = hdAccountAddressMapper(firstBatchHdKeyDetails, firstBatchAccountFastLookup)
+            ActiveHdAccount(accountIndex, entropy, hdAccountAddresses)
+        } else {
+            null
+        }
     }
 
     private fun getFirstHdKeyDetailsBatch(accountIndex: Int, entropy: ByteArray): List<HdKeyDetail> {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCase.kt
@@ -14,16 +14,17 @@ package com.algorand.wallet.account.info.domain.usecase
 
 import com.algorand.wallet.account.info.domain.mapper.HdAccountAddressMapper
 import com.algorand.wallet.account.info.domain.model.ActiveHdAccount
-import com.algorand.wallet.account.info.domain.model.HdKeyDetail
-import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressLite
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39Wallet
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
 import javax.inject.Inject
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.supervisorScope
 
 internal class GetActiveHdAccountsUseCase @Inject constructor(
-    private val peraBip39Sdk: PeraBip39Sdk,
+    private val bip39WalletProvider: Bip39WalletProvider,
     private val getAccountFastLookupBatch: GetAccountFastLookupBatch,
     private val hdAccountAddressMapper: HdAccountAddressMapper
 ) : GetActiveHdAccounts {
@@ -31,37 +32,41 @@ internal class GetActiveHdAccountsUseCase @Inject constructor(
     override suspend fun invoke(entropy: ByteArray): List<ActiveHdAccount> {
         val activeHdAccounts = mutableListOf<ActiveHdAccount>()
         var accountIndex = 0
+        val bip39Api = bip39WalletProvider.getBip39Wallet(entropy)
         while (true) {
-            val activeAccountsBatch = getActiveAccountsBatchDeferred(accountIndex, entropy)
-                .awaitAll()
-                .filterNotNull()
-
-            if (activeAccountsBatch.isEmpty()) {
+            val activeAccounts = getActiveAccountsBatchDeferred(accountIndex, entropy, bip39Api)
+            if (activeAccounts.isEmpty()) {
                 break
             } else {
-                activeHdAccounts.addAll(activeAccountsBatch)
+                activeHdAccounts.addAll(activeAccounts)
                 accountIndex += SEARCH_BATCH_COUNT
             }
         }
+        bip39Api.invalidate()
         return activeHdAccounts
     }
 
     private suspend fun getActiveAccountsBatchDeferred(
         accountIndex: Int,
-        entropy: ByteArray
-    ): List<Deferred<ActiveHdAccount?>> {
+        entropy: ByteArray,
+        bip39Wallet: Bip39Wallet
+    ): List<ActiveHdAccount> {
         return supervisorScope {
             (accountIndex until accountIndex + SEARCH_BATCH_COUNT).map { index ->
                 async {
-                    getActiveHdAccountIfExist(index, entropy)
+                    getActiveHdAccountIfExist(index, entropy, bip39Wallet)
                 }
             }
-        }
+        }.awaitAll().filterNotNull()
     }
 
-    private suspend fun getActiveHdAccountIfExist(accountIndex: Int, entropy: ByteArray): ActiveHdAccount? {
-        val firstBatchHdKeyDetails = getFirstHdKeyDetailsBatch(accountIndex, entropy)
-        val addresses = firstBatchHdKeyDetails.map { it.algoAddress }
+    private suspend fun getActiveHdAccountIfExist(
+        accountIndex: Int,
+        entropy: ByteArray,
+        bip39Wallet: Bip39Wallet
+    ): ActiveHdAccount? {
+        val firstBatchHdKeyDetails = getFirstHdKeyDetailsBatch(accountIndex, bip39Wallet)
+        val addresses = firstBatchHdKeyDetails.map { it.address }
         val firstBatchAccountFastLookup = getAccountFastLookupBatch(addresses)
         val isAccountActive = firstBatchAccountFastLookup.any { it.value?.accountExists == true }
         return if (isAccountActive) {
@@ -72,11 +77,11 @@ internal class GetActiveHdAccountsUseCase @Inject constructor(
         }
     }
 
-    private fun getFirstHdKeyDetailsBatch(accountIndex: Int, entropy: ByteArray): List<HdKeyDetail> {
+    private fun getFirstHdKeyDetailsBatch(accountIndex: Int, bip39Wallet: Bip39Wallet): List<HdKeyAddressLite> {
         val range = 0 until SEARCH_BATCH_COUNT
         return range.map { keyIndex ->
-            val address = peraBip39Sdk.generateHdKeyAddress(entropy, accountIndex, 0, keyIndex)
-            HdKeyDetail(address, accountIndex, 0, keyIndex)
+            val index = HdKeyAddressIndex(accountIndex, 0, keyIndex)
+            bip39Wallet.generateAddressLite(index)
         }
     }
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/GetRegisteredHdKeysUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/GetRegisteredHdKeysUseCase.kt
@@ -20,7 +20,7 @@ import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
 import javax.inject.Inject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.supervisorScope
 
 internal class GetRegisteredHdKeysUseCase @Inject constructor(
     private val getLocalAccountsAddresses: GetLocalAccountsAddresses,
@@ -38,7 +38,7 @@ internal class GetRegisteredHdKeysUseCase @Inject constructor(
             return getFirstAccountFirstAddress(entropy, localAccountAddresses)
         }
 
-        val activeHdAccountAddresses = coroutineScope {
+        val activeHdAccountAddresses = supervisorScope {
             activeHdAccounts.map { activeHdAccount ->
                 async {
                     getActiveHdAccountAddresses(activeHdAccount)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/GetRegisteredHdKeysUseCase.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/domain/usecase/GetRegisteredHdKeysUseCase.kt
@@ -16,7 +16,9 @@ import com.algorand.wallet.account.info.domain.mapper.RegisteredHdKeyMapper
 import com.algorand.wallet.account.info.domain.model.ActiveHdAccount
 import com.algorand.wallet.account.info.domain.model.RegisteredHdKey
 import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountsAddresses
-import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39Wallet
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
 import javax.inject.Inject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -27,15 +29,16 @@ internal class GetRegisteredHdKeysUseCase @Inject constructor(
     private val getActiveHdAccounts: GetActiveHdAccounts,
     private val getActiveHdAccountAddresses: GetActiveHdAccountAddresses,
     private val registeredHdKeyMapper: RegisteredHdKeyMapper,
-    private val peraBip39Sdk: PeraBip39Sdk,
+    private val bip39WalletProvider: Bip39WalletProvider
 ) : GetRegisteredHdKeys {
 
     override suspend fun invoke(entropy: ByteArray): List<RegisteredHdKey> {
         val localAccountAddresses = getLocalAccountsAddresses()
         val activeHdAccounts = getActiveHdAccounts(entropy)
+        val walletApi = bip39WalletProvider.getBip39Wallet(entropy)
 
         if (activeHdAccounts.isEmpty()) {
-            return getFirstAccountFirstAddress(entropy, localAccountAddresses)
+            return getFirstAccountFirstAddress(walletApi, localAccountAddresses)
         }
 
         val activeHdAccountAddresses = supervisorScope {
@@ -53,15 +56,18 @@ internal class GetRegisteredHdKeysUseCase @Inject constructor(
             val isAlreadyImported = localAccountAddresses.contains(hdAccountAddress.address)
             registeredHdKeyMapper(hdAccountAddress, hdAccountAddress.fastLookup, isAlreadyImported)
         }.ifEmpty {
-            getFirstAccountFirstAddress(entropy, localAccountAddresses)
+            getFirstAccountFirstAddress(walletApi, localAccountAddresses)
+        }.also {
+            walletApi.invalidate()
         }
     }
 
     private fun getFirstAccountFirstAddress(
-        entropy: ByteArray,
+        bip39Wallet: Bip39Wallet,
         localAccountAddresses: List<String>
     ): List<RegisteredHdKey> {
-        val address = peraBip39Sdk.generateHdKeyAddress(entropy, 0, 0, 0)
+        val index = HdKeyAddressIndex(accountIndex = 0, changeIndex = 0, keyIndex = 0)
+        val address = bip39Wallet.generateAddressLite(index).address
         val hdAccountAddress = ActiveHdAccount.HdAccountAddress(address, 0, 0, 0, null)
         val isAlreadyImported = localAccountAddresses.contains(address)
         return listOf(registeredHdKeyMapper(hdAccountAddress, null, isAlreadyImported))

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/di/Bip39Module.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/di/Bip39Module.kt
@@ -10,10 +10,19 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.algosdk.transaction.sdk
+package com.algorand.wallet.algosdk.bip39.di
 
-interface PeraBip39Sdk {
-    fun getSeedFromEntropy(entropy: ByteArray): ByteArray?
-    fun getEntropyFromMnemonic(mnemonic: String): ByteArray?
-    fun getMnemonicFromEntropy(entropy: ByteArray): String?
+import com.algorand.wallet.algosdk.bip39.sdk.AlgorandBip39WalletProvider
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object Bip39Module {
+
+    @Provides
+    fun provideBip39ApiProvider(impl: AlgorandBip39WalletProvider): Bip39WalletProvider = impl
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/Bip39Entropy.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/Bip39Entropy.kt
@@ -10,10 +10,20 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.algosdk.transaction.sdk
+package com.algorand.wallet.algosdk.bip39.model
 
-interface PeraBip39Sdk {
-    fun getSeedFromEntropy(entropy: ByteArray): ByteArray?
-    fun getEntropyFromMnemonic(mnemonic: String): ByteArray?
-    fun getMnemonicFromEntropy(entropy: ByteArray): String?
+data class Bip39Entropy internal constructor(val value: ByteArray) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Bip39Entropy
+
+        return value.contentEquals(other.value)
+    }
+
+    override fun hashCode(): Int {
+        return value.contentHashCode()
+    }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/Bip39Mnemonic.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/Bip39Mnemonic.kt
@@ -10,10 +10,6 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.algosdk.transaction.sdk
+package com.algorand.wallet.algosdk.bip39.model
 
-interface PeraBip39Sdk {
-    fun getSeedFromEntropy(entropy: ByteArray): ByteArray?
-    fun getEntropyFromMnemonic(mnemonic: String): ByteArray?
-    fun getMnemonicFromEntropy(entropy: ByteArray): String?
-}
+data class Bip39Mnemonic internal constructor(val words: List<String>)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/Bip39Seed.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/Bip39Seed.kt
@@ -10,10 +10,20 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.algosdk.transaction.sdk
+package com.algorand.wallet.algosdk.bip39.model
 
-interface PeraBip39Sdk {
-    fun getSeedFromEntropy(entropy: ByteArray): ByteArray?
-    fun getEntropyFromMnemonic(mnemonic: String): ByteArray?
-    fun getMnemonicFromEntropy(entropy: ByteArray): String?
+data class Bip39Seed internal constructor(val value: ByteArray) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Bip39Seed
+
+        return value.contentEquals(other.value)
+    }
+
+    override fun hashCode(): Int {
+        return value.contentHashCode()
+    }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/HdKeyAddress.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/HdKeyAddress.kt
@@ -10,10 +10,12 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.algosdk.transaction.sdk
+package com.algorand.wallet.algosdk.bip39.model
 
-interface PeraBip39Sdk {
-    fun getSeedFromEntropy(entropy: ByteArray): ByteArray?
-    fun getEntropyFromMnemonic(mnemonic: String): ByteArray?
-    fun getMnemonicFromEntropy(entropy: ByteArray): String?
-}
+data class HdKeyAddress(
+    val address: String,
+    val index: HdKeyAddressIndex,
+    val privateKey: ByteArray,
+    val publicKey: ByteArray,
+    val derivationType: HdKeyAddressDerivationType
+)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/HdKeyAddressDerivationType.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/HdKeyAddressDerivationType.kt
@@ -10,10 +10,9 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.algosdk.transaction.sdk
+package com.algorand.wallet.algosdk.bip39.model
 
-interface PeraBip39Sdk {
-    fun getSeedFromEntropy(entropy: ByteArray): ByteArray?
-    fun getEntropyFromMnemonic(mnemonic: String): ByteArray?
-    fun getMnemonicFromEntropy(entropy: ByteArray): String?
+enum class HdKeyAddressDerivationType(val value: Int) {
+    Peikert(9),
+    Khovratovich(32)
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/HdKeyAddressIndex.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/HdKeyAddressIndex.kt
@@ -10,10 +10,10 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.algosdk.transaction.sdk
+package com.algorand.wallet.algosdk.bip39.model
 
-interface PeraBip39Sdk {
-    fun getSeedFromEntropy(entropy: ByteArray): ByteArray?
-    fun getEntropyFromMnemonic(mnemonic: String): ByteArray?
-    fun getMnemonicFromEntropy(entropy: ByteArray): String?
-}
+data class HdKeyAddressIndex(
+    val accountIndex: Int = 0,
+    val changeIndex: Int = 0,
+    val keyIndex: Int = 0
+)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/HdKeyAddressLite.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/model/HdKeyAddressLite.kt
@@ -10,10 +10,9 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.algosdk.transaction.sdk
+package com.algorand.wallet.algosdk.bip39.model
 
-interface PeraBip39Sdk {
-    fun getSeedFromEntropy(entropy: ByteArray): ByteArray?
-    fun getEntropyFromMnemonic(mnemonic: String): ByteArray?
-    fun getMnemonicFromEntropy(entropy: ByteArray): String?
-}
+data class HdKeyAddressLite(
+    val address: String,
+    val index: HdKeyAddressIndex,
+)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/sdk/AlgorandBip39Wallet.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/sdk/AlgorandBip39Wallet.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.algosdk.bip39.sdk
+
+import cash.z.ecc.android.bip39.Mnemonics
+import cash.z.ecc.android.bip39.toSeed
+import com.algorand.algosdk.crypto.Address
+import com.algorand.wallet.algosdk.bip39.model.Bip39Entropy
+import com.algorand.wallet.algosdk.bip39.model.Bip39Mnemonic
+import com.algorand.wallet.algosdk.bip39.model.Bip39Seed
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddress
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressDerivationType
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressLite
+import com.algorand.wallet.encryption.domain.utils.clearFromMemory
+import foundation.algorand.xhdwalletapi.Bip32DerivationType
+import foundation.algorand.xhdwalletapi.KeyContext
+import foundation.algorand.xhdwalletapi.XHDWalletAPIAndroid
+import foundation.algorand.xhdwalletapi.XHDWalletAPIBase.Companion.fromSeed
+import foundation.algorand.xhdwalletapi.XHDWalletAPIBase.Companion.getBIP44PathFromContext
+
+internal class AlgorandBip39Wallet internal constructor(private val entropy: Bip39Entropy) : Bip39Wallet {
+
+    private val seed: Bip39Seed
+    private val mnemonic: Bip39Mnemonic
+    private var walletApi: XHDWalletAPIAndroid?
+
+    init {
+        val mnemonicCode = Mnemonics.MnemonicCode(entropy.value)
+        seed = Bip39Seed(mnemonicCode.toSeed())
+        mnemonic = Bip39Mnemonic(mnemonicCode.words.map { it.toString() })
+        walletApi = XHDWalletAPIAndroid(seed.value)
+    }
+
+    override fun generateAddress(index: HdKeyAddressIndex): HdKeyAddress {
+        val publicKey = generatePublicKey(index)
+        return HdKeyAddress(
+            address = Address(publicKey).toString(),
+            index = index,
+            publicKey = publicKey,
+            privateKey = generatePrivateKey(index),
+            derivationType = HdKeyAddressDerivationType.Peikert
+        )
+    }
+
+    override fun generateAddressLite(index: HdKeyAddressIndex): HdKeyAddressLite {
+        val publicKey = generatePublicKey(index)
+        return HdKeyAddressLite(
+            address = Address(publicKey).toString(),
+            index = index
+        )
+    }
+
+    override fun getEntropy(): Bip39Entropy {
+        return Bip39Entropy(entropy.value.copyOf())
+    }
+
+    override fun getSeed(): Bip39Seed {
+        return Bip39Seed(seed.value.copyOf())
+    }
+
+    override fun getMnemonic(): Bip39Mnemonic {
+        return Bip39Mnemonic(mnemonic.words)
+    }
+
+    override fun invalidate() {
+        entropy.value.clearFromMemory()
+        seed.value.clearFromMemory()
+        walletApi = null
+    }
+
+    private fun generatePrivateKey(index: HdKeyAddressIndex): ByteArray {
+        return walletApi!!.deriveKey(fromSeed(seed.value), getBip44Path(index), isPrivate = true)
+    }
+
+    private fun getBip44Path(index: HdKeyAddressIndex): List<UInt> {
+        return getBIP44PathFromContext(
+            context = KeyContext.Address,
+            account = index.accountIndex.toUInt(),
+            change = index.changeIndex.toUInt(),
+            keyIndex = index.keyIndex.toUInt()
+        )
+    }
+
+    private fun generatePublicKey(index: HdKeyAddressIndex): ByteArray {
+        return walletApi!!.keyGen(
+            context = KeyContext.Address,
+            account = index.accountIndex.toUInt(),
+            change = index.changeIndex.toUInt(),
+            keyIndex = index.keyIndex.toUInt(),
+            derivationType = Bip32DerivationType.Peikert
+        )
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/sdk/AlgorandBip39WalletProvider.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/sdk/AlgorandBip39WalletProvider.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.algosdk.bip39.sdk
+
+import cash.z.ecc.android.bip39.Mnemonics
+import com.algorand.wallet.algosdk.bip39.model.Bip39Entropy
+import javax.inject.Inject
+
+internal class AlgorandBip39WalletProvider @Inject constructor() : Bip39WalletProvider {
+
+    override fun getBip39Wallet(entropy: ByteArray): Bip39Wallet {
+        return AlgorandBip39Wallet(Bip39Entropy(entropy))
+    }
+
+    override fun createBip39Wallet(): Bip39Wallet {
+        val entropy = Mnemonics.MnemonicCode(Mnemonics.WordCount.COUNT_24).toEntropy()
+        return AlgorandBip39Wallet(Bip39Entropy(entropy))
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/sdk/Bip39Wallet.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/sdk/Bip39Wallet.kt
@@ -10,15 +10,20 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.account.info.domain.mapper
+package com.algorand.wallet.algosdk.bip39.sdk
 
-import com.algorand.wallet.account.info.domain.model.AccountFastLookup
-import com.algorand.wallet.account.info.domain.model.ActiveHdAccount
+import com.algorand.wallet.algosdk.bip39.model.Bip39Entropy
+import com.algorand.wallet.algosdk.bip39.model.Bip39Mnemonic
+import com.algorand.wallet.algosdk.bip39.model.Bip39Seed
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddress
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
 import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressLite
 
-internal interface HdAccountAddressMapper {
-    operator fun invoke(
-        hdKeyDetails: List<HdKeyAddressLite>,
-        accountFastLookupBatch: Map<String, AccountFastLookup?>
-    ): List<ActiveHdAccount.HdAccountAddress>
+interface Bip39Wallet {
+    fun getEntropy(): Bip39Entropy
+    fun getSeed(): Bip39Seed
+    fun getMnemonic(): Bip39Mnemonic
+    fun generateAddress(index: HdKeyAddressIndex): HdKeyAddress
+    fun generateAddressLite(index: HdKeyAddressIndex): HdKeyAddressLite
+    fun invalidate()
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/sdk/Bip39WalletProvider.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/bip39/sdk/Bip39WalletProvider.kt
@@ -10,10 +10,9 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.algosdk.transaction.sdk
+package com.algorand.wallet.algosdk.bip39.sdk
 
-interface PeraBip39Sdk {
-    fun getSeedFromEntropy(entropy: ByteArray): ByteArray?
-    fun getEntropyFromMnemonic(mnemonic: String): ByteArray?
-    fun getMnemonicFromEntropy(entropy: ByteArray): String?
+interface Bip39WalletProvider {
+    fun getBip39Wallet(entropy: ByteArray): Bip39Wallet
+    fun createBip39Wallet(): Bip39Wallet
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/transaction/sdk/AlgoAccountSdk.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/transaction/sdk/AlgoAccountSdk.kt
@@ -13,11 +13,8 @@
 package com.algorand.wallet.algosdk.transaction.sdk
 
 import com.algorand.wallet.algosdk.domain.model.Algo25Account
-import com.algorand.wallet.algosdk.domain.model.HdKeyAccount
 
 interface AlgoAccountSdk {
-
-    fun createHdAccount(): HdKeyAccount?
 
     fun createAlgo25Account(): Algo25Account?
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/transaction/sdk/AlgoAccountSdkImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/transaction/sdk/AlgoAccountSdkImpl.kt
@@ -15,22 +15,11 @@ package com.algorand.wallet.algosdk.transaction.sdk
 import com.algorand.algosdk.account.Account
 import com.algorand.algosdk.sdk.Sdk
 import com.algorand.wallet.algosdk.domain.model.Algo25Account
-import com.algorand.wallet.algosdk.domain.model.HdKeyAccount
 import com.algorand.wallet.encryption.domain.utils.clearFromMemory
 import java.security.NoSuchAlgorithmException
 import javax.inject.Inject
 
-internal class AlgoAccountSdkImpl @Inject constructor(
-    private val bip39Sdk: PeraBip39Sdk
-) : AlgoAccountSdk {
-
-    override fun createHdAccount(): HdKeyAccount? {
-        return try {
-            bip39Sdk.createHdKeyAccount()
-        } catch (e: Exception) {
-            null
-        }
-    }
+internal class AlgoAccountSdkImpl @Inject constructor() : AlgoAccountSdk {
 
     override fun createAlgo25Account(): Algo25Account? {
         return try {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/transaction/sdk/PeraBip39SdkImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/algosdk/transaction/sdk/PeraBip39SdkImpl.kt
@@ -14,20 +14,9 @@ package com.algorand.wallet.algosdk.transaction.sdk
 
 import cash.z.ecc.android.bip39.Mnemonics
 import cash.z.ecc.android.bip39.toSeed
-import com.algorand.algosdk.crypto.Address
-import com.algorand.wallet.algosdk.domain.model.HdKeyAccount
-import com.algorand.wallet.analytics.domain.service.PeraExceptionLogger
-import com.algorand.wallet.encryption.domain.utils.clearFromMemory
-import foundation.algorand.xhdwalletapi.Bip32DerivationType
-import foundation.algorand.xhdwalletapi.KeyContext
-import foundation.algorand.xhdwalletapi.XHDWalletAPIAndroid
-import foundation.algorand.xhdwalletapi.XHDWalletAPIBase.Companion.fromSeed
-import foundation.algorand.xhdwalletapi.XHDWalletAPIBase.Companion.getBIP44PathFromContext
 import javax.inject.Inject
 
-internal class PeraBip39SdkImpl @Inject constructor(
-    private val peraExceptionLogger: PeraExceptionLogger
-) : PeraBip39Sdk {
+internal class PeraBip39SdkImpl @Inject constructor() : PeraBip39Sdk {
     override fun getSeedFromEntropy(entropy: ByteArray): ByteArray? {
         return try {
             Mnemonics.MnemonicCode(entropy).toSeed()
@@ -53,82 +42,5 @@ internal class PeraBip39SdkImpl @Inject constructor(
         } catch (e: Exception) {
             null
         }
-    }
-
-    override fun createHdKeyAccount(): HdKeyAccount? {
-        var mnemonic = Mnemonics.MnemonicCode(Mnemonics.WordCount.COUNT_24)
-            .words.joinToString(" ") { charArray ->
-                String(charArray)
-            }
-        val mnemonicCode = Mnemonics.MnemonicCode(mnemonic)
-        var entropy = mnemonicCode.toEntropy()
-        val output = getHdKeyAccount(entropy.copyOf(), 0, 0, 0)
-        entropy.clearFromMemory()
-        return output
-    }
-
-    override fun getHdKeyAccount(
-        entropy: ByteArray,
-        accountIndex: Int,
-        changeIndex: Int,
-        keyIndex: Int
-    ): HdKeyAccount? {
-        return try {
-            val mnemonicCode = Mnemonics.MnemonicCode(entropy)
-            var seed = mnemonicCode.toSeed()
-            val xHDWalletAPI = XHDWalletAPIAndroid(seed.copyOf())
-            val keyContext = KeyContext.Address
-            val account = accountIndex.toUInt()
-            val change = changeIndex.toUInt()
-            val keyIndex = keyIndex.toUInt()
-
-            val publicKey = xHDWalletAPI.keyGen(
-                keyContext,
-                account,
-                change,
-                keyIndex
-            )
-
-            // Produce the PK and turn it into an Algorand formatted address
-            val algoAddress = Address(publicKey)
-            var privateKey: ByteArray = xHDWalletAPI.deriveKey(
-                fromSeed(seed.copyOf()),
-                getBIP44PathFromContext(keyContext, account, change, keyIndex),
-                true
-            )
-
-            val output = HdKeyAccount(
-                address = algoAddress.toString(),
-                publicKey = publicKey,
-                privateKey = privateKey.copyOf(),
-                entropy = entropy,
-                account = account.toInt(),
-                change = change.toInt(),
-                keyIndex = keyIndex.toInt(),
-                derivationType = Bip32DerivationType.Peikert.value
-            )
-
-            privateKey.clearFromMemory()
-            seed.clearFromMemory()
-            return output
-        } catch (e: Exception) {
-            peraExceptionLogger.logException(e)
-            null
-        }
-    }
-
-    override fun generateHdKeyAddress(entropy: ByteArray, accountIndex: Int, changeIndex: Int, keyIndex: Int): String {
-        val mnemonicCode = Mnemonics.MnemonicCode(entropy)
-        val seed = mnemonicCode.toSeed()
-        val xHDWalletAPI = XHDWalletAPIAndroid(seed)
-        val key = xHDWalletAPI.keyGen(
-            context = KeyContext.Address,
-            account = accountIndex.toUInt(),
-            change = changeIndex.toUInt(),
-            keyIndex = keyIndex.toUInt(),
-            derivationType = Bip32DerivationType.Peikert
-        )
-        seed.clearFromMemory()
-        return Address(key).toString()
     }
 }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountAddressesUseCaseTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountAddressesUseCaseTest.kt
@@ -16,8 +16,10 @@ import com.algorand.test.peraFixture
 import com.algorand.wallet.account.info.domain.mapper.HdAccountAddressMapper
 import com.algorand.wallet.account.info.domain.model.AccountFastLookup
 import com.algorand.wallet.account.info.domain.model.ActiveHdAccount
-import com.algorand.wallet.account.info.domain.model.HdKeyDetail
-import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressLite
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39Wallet
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -27,23 +29,17 @@ import org.junit.Test
 
 class GetActiveHdAccountAddressesUseCaseTest {
 
-    private val peraBip39Sdk: PeraBip39Sdk = mockk {
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 5) } returns ADDR_6
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 6) } returns ADDR_7
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 7) } returns ADDR_8
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 8) } returns ADDR_9
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 9) } returns ADDR_10
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 10) } returns ADDR_11
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 11) } returns ADDR_12
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 12) } returns ADDR_13
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 13) } returns ADDR_14
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 14) } returns ADDR_15
-    }
     private val getAccountFastLookupBatch: GetAccountFastLookupBatch = mockk()
     private val hdAccountAddressMapper: HdAccountAddressMapper = mockk()
+    private val bip39Wallet: Bip39Wallet = mockk(relaxed = true) {
+        mockBip39Wallet()
+    }
+    private val bip39WalletProvider: Bip39WalletProvider = mockk {
+        every { getBip39Wallet(ENTROPY) } returns bip39Wallet
+    }
 
     private val sut = GetActiveHdAccountAddressesUseCase(
-        peraBip39Sdk = peraBip39Sdk,
+        bip39WalletProvider = bip39WalletProvider,
         getAccountFastLookupBatch = getAccountFastLookupBatch,
         hdAccountAddressMapper = hdAccountAddressMapper
     )
@@ -69,6 +65,29 @@ class GetActiveHdAccountAddressesUseCaseTest {
             SECOND_BATCH_HD_ACCOUNT_ADDRESS
         ).flatten()
         assertEquals(expected, result)
+    }
+
+    private fun Bip39Wallet.mockBip39Wallet() {
+        val add6Index = HdKeyAddressIndex(0, 0, 5)
+        every { generateAddressLite(add6Index) } returns HdKeyAddressLite(ADDR_6, add6Index)
+        val add7Index = HdKeyAddressIndex(0, 0, 6)
+        every { generateAddressLite(add7Index) } returns HdKeyAddressLite(ADDR_7, add7Index)
+        val add8Index = HdKeyAddressIndex(0, 0, 7)
+        every { generateAddressLite(add8Index) } returns HdKeyAddressLite(ADDR_8, add8Index)
+        val add9Index = HdKeyAddressIndex(0, 0, 8)
+        every { generateAddressLite(add9Index) } returns HdKeyAddressLite(ADDR_9, add9Index)
+        val add10Index = HdKeyAddressIndex(0, 0, 9)
+        every { generateAddressLite(add10Index) } returns HdKeyAddressLite(ADDR_10, add10Index)
+        val add11Index = HdKeyAddressIndex(0, 0, 10)
+        every { generateAddressLite(add11Index) } returns HdKeyAddressLite(ADDR_11, add11Index)
+        val add12Index = HdKeyAddressIndex(0, 0, 11)
+        every { generateAddressLite(add12Index) } returns HdKeyAddressLite(ADDR_12, add12Index)
+        val add13Index = HdKeyAddressIndex(0, 0, 12)
+        every { generateAddressLite(add13Index) } returns HdKeyAddressLite(ADDR_13, add13Index)
+        val add14Index = HdKeyAddressIndex(0, 0, 13)
+        every { generateAddressLite(add14Index) } returns HdKeyAddressLite(ADDR_14, add14Index)
+        val add15Index = HdKeyAddressIndex(0, 0, 14)
+        every { generateAddressLite(add15Index) } returns HdKeyAddressLite(ADDR_15, add15Index)
     }
 
     private companion object {
@@ -97,11 +116,11 @@ class GetActiveHdAccountAddressesUseCaseTest {
         val ADDR_14_FAST_LOOKUP = peraFixture<AccountFastLookup>().copy(accountExists = false)
         val ADDR_15_FAST_LOOKUP = peraFixture<AccountFastLookup>().copy(accountExists = false)
 
-        val ADDR_6_HD_KEY_DETAIL = HdKeyDetail(algoAddress = ADDR_6, accountIndex = 0, changeIndex = 0, keyIndex = 5)
-        val ADDR_7_HD_KEY_DETAIL = HdKeyDetail(algoAddress = ADDR_7, accountIndex = 0, changeIndex = 0, keyIndex = 6)
-        val ADDR_8_HD_KEY_DETAIL = HdKeyDetail(algoAddress = ADDR_8, accountIndex = 0, changeIndex = 0, keyIndex = 7)
-        val ADDR_9_HD_KEY_DETAIL = HdKeyDetail(algoAddress = ADDR_9, accountIndex = 0, changeIndex = 0, keyIndex = 8)
-        val ADDR_10_HD_KEY_DETAIL = HdKeyDetail(algoAddress = ADDR_10, accountIndex = 0, changeIndex = 0, keyIndex = 9)
+        val ADDR_6_HD_KEY_DETAIL = HdKeyAddressLite(ADDR_6, HdKeyAddressIndex(0, 0, 5))
+        val ADDR_7_HD_KEY_DETAIL = HdKeyAddressLite(ADDR_7, HdKeyAddressIndex(0, 0, 6))
+        val ADDR_8_HD_KEY_DETAIL = HdKeyAddressLite(ADDR_8, HdKeyAddressIndex(0, 0, 7))
+        val ADDR_9_HD_KEY_DETAIL = HdKeyAddressLite(ADDR_9, HdKeyAddressIndex(0, 0, 8))
+        val ADDR_10_HD_KEY_DETAIL = HdKeyAddressLite(ADDR_10, HdKeyAddressIndex(0, 0, 9))
 
         val SECOND_BATCH_ADDRESSES = listOf(ADDR_6, ADDR_7, ADDR_8, ADDR_9, ADDR_10)
         val SECOND_BATCH_FAST_LOOKUP = mapOf(

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCaseTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCaseTest.kt
@@ -15,7 +15,9 @@ package com.algorand.wallet.account.info.domain.usecase
 import com.algorand.wallet.account.info.domain.mapper.HdAccountAddressMapper
 import com.algorand.wallet.account.info.domain.model.AccountFastLookup
 import com.algorand.wallet.account.info.domain.model.ActiveHdAccount
-import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39Wallet
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -26,12 +28,15 @@ import org.junit.Test
 
 class GetActiveHdAccountsUseCaseTest {
 
-    private val peraBip39Sdk: PeraBip39Sdk = mockk(relaxed = true)
+    private val bip39Wallet: Bip39Wallet = mockk(relaxed = true)
+    private val bip39WalletProvider: Bip39WalletProvider = mockk {
+        every { getBip39Wallet(ENTROPY) } returns bip39Wallet
+    }
     private val getAccountFastLookupBatch: GetAccountFastLookupBatch = mockk()
     private val hdAccountAddressMapper: HdAccountAddressMapper = mockk()
 
     private val sut = GetActiveHdAccountsUseCase(
-        peraBip39Sdk = peraBip39Sdk,
+        bip39WalletProvider = bip39WalletProvider,
         getAccountFastLookupBatch = getAccountFastLookupBatch,
         hdAccountAddressMapper = hdAccountAddressMapper
     )
@@ -110,7 +115,9 @@ class GetActiveHdAccountsUseCaseTest {
     private fun mockPeraBip39SdkGenerateHdKeyAddress(testHelper: GetActiveHdAccountsUseCaseTestHelper) {
         testHelper.getAccountIndexAndAddressesPair().forEach { (accountIndex, addresses) ->
             addresses.forEachIndexed { addressIndex, address ->
-                every { peraBip39Sdk.generateHdKeyAddress(ENTROPY, accountIndex, 0, addressIndex) } returns address
+                every {
+                    bip39Wallet.generateAddressLite(HdKeyAddressIndex(accountIndex, 0, addressIndex))
+                } returns address
             }
         }
     }
@@ -127,7 +134,7 @@ class GetActiveHdAccountsUseCaseTest {
 
     private fun verifyGetAccountFastLookupBatchInvokeCount(testHelper: GetActiveHdAccountsUseCaseTestHelper) {
         testHelper.getAccountIndexAndAddressesPair().forEach { (_, addresses) ->
-            coVerify(exactly = 1) { getAccountFastLookupBatch(addresses) }
+            coVerify(exactly = 1) { getAccountFastLookupBatch(addresses.map { it.address }) }
         }
     }
 

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCaseTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCaseTest.kt
@@ -12,14 +12,12 @@
 
 package com.algorand.wallet.account.info.domain.usecase
 
-import com.algorand.test.peraFixture
 import com.algorand.wallet.account.info.domain.mapper.HdAccountAddressMapper
 import com.algorand.wallet.account.info.domain.model.AccountFastLookup
 import com.algorand.wallet.account.info.domain.model.ActiveHdAccount
-import com.algorand.wallet.account.info.domain.model.ActiveHdAccount.HdAccountAddress
-import com.algorand.wallet.account.info.domain.model.HdKeyDetail
 import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -28,18 +26,7 @@ import org.junit.Test
 
 class GetActiveHdAccountsUseCaseTest {
 
-    private val peraBip39Sdk: PeraBip39Sdk = mockk {
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 0) } returns ACC_1_ADDR_1
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 1) } returns ACC_1_ADDR_2
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 2) } returns ACC_1_ADDR_3
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 3) } returns ACC_1_ADDR_4
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 4) } returns ACC_1_ADDR_5
-        every { generateHdKeyAddress(ENTROPY, 1, 0, 0) } returns ACC_2_ADDR_1
-        every { generateHdKeyAddress(ENTROPY, 1, 0, 1) } returns ACC_2_ADDR_2
-        every { generateHdKeyAddress(ENTROPY, 1, 0, 2) } returns ACC_2_ADDR_3
-        every { generateHdKeyAddress(ENTROPY, 1, 0, 3) } returns ACC_2_ADDR_4
-        every { generateHdKeyAddress(ENTROPY, 1, 0, 4) } returns ACC_2_ADDR_5
-    }
+    private val peraBip39Sdk: PeraBip39Sdk = mockk(relaxed = true)
     private val getAccountFastLookupBatch: GetAccountFastLookupBatch = mockk()
     private val hdAccountAddressMapper: HdAccountAddressMapper = mockk()
 
@@ -50,15 +37,17 @@ class GetActiveHdAccountsUseCaseTest {
     )
 
     @Test
-    fun `EXPECT empty list WHEN the first account addresses are closed or fast lookup null`() = runTest {
-        val batchFastLookupResult = mapOf(
-            ACC_1_ADDR_1 to ACC_1_ADDR_1_FAST_LOOKUP.copy(accountExists = false),
-            ACC_1_ADDR_2 to ACC_1_ADDR_2_FAST_LOOKUP.copy(accountExists = false),
-            ACC_1_ADDR_3 to null,
-            ACC_1_ADDR_4 to ACC_1_ADDR_4_FAST_LOOKUP.copy(accountExists = false),
-            ACC_1_ADDR_5 to ACC_1_ADDR_5_FAST_LOOKUP.copy(accountExists = false),
-        )
-        coEvery { getAccountFastLookupBatch(FIRST_ACCOUNT_ADDRESSES) } returns batchFastLookupResult
+    fun `EXPECT empty list WHEN the first 5 accounts addresses are closed or fast lookup null`() = runTest {
+        val accountCount = 5
+        val testHelper = GetActiveHdAccountsUseCaseTestHelper(accountCount, addressCount = 5)
+        mockPeraBip39SdkGenerateHdKeyAddress(testHelper)
+        val firstFiveAccountBatchFastLookupResults = (0 until accountCount).map {
+            testHelper.getInactiveAccountFastLookupResult(it)
+        }
+        firstFiveAccountBatchFastLookupResults.forEachIndexed { index, fastLookupResult ->
+            val addresses = testHelper.getAccountAddresses(accountIndex = index)
+            coEvery { getAccountFastLookupBatch(addresses) } returns fastLookupResult
+        }
 
         val result = sut(ENTROPY)
 
@@ -66,61 +55,83 @@ class GetActiveHdAccountsUseCaseTest {
     }
 
     @Test
-    fun `EXPECT active account list WHEN there is active accounts`() = runTest {
-        val firstFastLookupResult = mapOf(
-            ACC_1_ADDR_1 to ACC_1_ADDR_1_FAST_LOOKUP.copy(accountExists = false),
-            ACC_1_ADDR_2 to ACC_1_ADDR_2_FAST_LOOKUP.copy(accountExists = false),
-            ACC_1_ADDR_3 to ACC_1_ADDR_3_FAST_LOOKUP.copy(accountExists = false),
-            ACC_1_ADDR_4 to ACC_1_ADDR_4_FAST_LOOKUP.copy(accountExists = true),
-            ACC_1_ADDR_5 to ACC_1_ADDR_5_FAST_LOOKUP.copy(accountExists = false),
+    fun `EXPECT fifth account WHEN first four accounts are closed`() = runTest {
+        val accountCount = 10
+        val testHelper = GetActiveHdAccountsUseCaseTestHelper(accountCount, addressCount = 5)
+        val inactiveAccounts0to4 = (0 until 4).map { testHelper.getInactiveAccountFastLookupResult(it) }
+        val account5 = testHelper.getActiveAccountFastLookupResult(4)
+        val inactiveAccounts5to10 = (5 until accountCount).map { testHelper.getInactiveAccountFastLookupResult(it) }
+        val accountsFastLookupResults = inactiveAccounts0to4 + account5 + inactiveAccounts5to10
+        mockGetAccountFastLookupBatch(testHelper, accountsFastLookupResults)
+        mockPeraBip39SdkGenerateHdKeyAddress(testHelper)
+        val account5HdAccountAddresses = testHelper.getHdAccountAddresses(
+            accountIndex = 4,
+            fastLookups = account5.values.toList()
         )
-        val acc1HdAccountAddresses = listOf(
-            HdAccountAddress(ACC_1_ADDR_1, 0, 0, 0, ACC_1_ADDR_1_FAST_LOOKUP.copy(accountExists = false)),
-            HdAccountAddress(ACC_1_ADDR_2, 0, 0, 1, ACC_1_ADDR_2_FAST_LOOKUP.copy(accountExists = false)),
-            HdAccountAddress(ACC_1_ADDR_3, 0, 0, 2, ACC_1_ADDR_3_FAST_LOOKUP.copy(accountExists = false)),
-            HdAccountAddress(ACC_1_ADDR_4, 0, 0, 3, ACC_1_ADDR_4_FAST_LOOKUP.copy(accountExists = true)),
-            HdAccountAddress(ACC_1_ADDR_5, 0, 0, 4, ACC_1_ADDR_5_FAST_LOOKUP.copy(accountExists = false)),
-        )
-        coEvery { getAccountFastLookupBatch(FIRST_ACCOUNT_ADDRESSES) } returns firstFastLookupResult
-        coEvery { getAccountFastLookupBatch(SECOND_ACCOUNT_ADDRESSES) } returns emptyMap()
-        every { hdAccountAddressMapper(ACC_1_HD_KEY_DETAILS, firstFastLookupResult) } returns acc1HdAccountAddresses
+        every {
+            hdAccountAddressMapper(testHelper.getHdKeyDetails(accountIndex = 4), account5)
+        } returns account5HdAccountAddresses
 
         val result = sut(ENTROPY)
 
-        val expected = listOf(ActiveHdAccount(accountIndex = 0, ENTROPY, acc1HdAccountAddresses))
+        val expected = listOf(ActiveHdAccount(accountIndex = 4, ENTROPY, account5HdAccountAddresses))
         assertEquals(expected, result)
+        verifyGetAccountFastLookupBatchInvokeCount(testHelper)
+    }
+
+    @Test
+    fun `EXPECT first 20 accounts WHEN 21, 22, 23, 24, 25 accounts are inactive`() = runTest {
+        val accountCount = 25
+        val testHelper = GetActiveHdAccountsUseCaseTestHelper(accountCount, addressCount = 5)
+        val activeAccounts = (0 until 20).map { testHelper.getActiveAccountFastLookupResult(it) }
+        val inactiveAccounts = (20 until 25).map { testHelper.getInactiveAccountFastLookupResult(it) }
+        val accountsFastLookupResults = activeAccounts + inactiveAccounts
+        mockGetAccountFastLookupBatch(testHelper, accountsFastLookupResults)
+        mockPeraBip39SdkGenerateHdKeyAddress(testHelper)
+        val activeHdAccountAddresses = activeAccounts.mapIndexed { index, fastLookup ->
+            testHelper.getHdAccountAddresses(accountIndex = index, fastLookups = fastLookup.values.toList())
+        }
+        repeat(20) { accountIndex ->
+            every {
+                hdAccountAddressMapper(testHelper.getHdKeyDetails(accountIndex), activeAccounts[accountIndex])
+            } returns activeHdAccountAddresses[accountIndex]
+        }
+
+        val result = sut(ENTROPY)
+
+        val expected = activeAccounts.map {
+            val accountIndex = activeAccounts.indexOf(it)
+            ActiveHdAccount(accountIndex = accountIndex, ENTROPY, activeHdAccountAddresses[accountIndex])
+        }
+        assertEquals(expected, result)
+        verifyGetAccountFastLookupBatchInvokeCount(testHelper)
+    }
+
+    private fun mockPeraBip39SdkGenerateHdKeyAddress(testHelper: GetActiveHdAccountsUseCaseTestHelper) {
+        testHelper.getAccountIndexAndAddressesPair().forEach { (accountIndex, addresses) ->
+            addresses.forEachIndexed { addressIndex, address ->
+                every { peraBip39Sdk.generateHdKeyAddress(ENTROPY, accountIndex, 0, addressIndex) } returns address
+            }
+        }
+    }
+
+    private fun mockGetAccountFastLookupBatch(
+        testHelper: GetActiveHdAccountsUseCaseTestHelper,
+        accountsFastLookupResults: List<Map<String, AccountFastLookup?>>
+    ) {
+        accountsFastLookupResults.forEachIndexed { index, fastLookupResult ->
+            val addresses = testHelper.getAccountAddresses(accountIndex = index)
+            coEvery { getAccountFastLookupBatch(addresses) } returns fastLookupResult
+        }
+    }
+
+    private fun verifyGetAccountFastLookupBatchInvokeCount(testHelper: GetActiveHdAccountsUseCaseTestHelper) {
+        testHelper.getAccountIndexAndAddressesPair().forEach { (_, addresses) ->
+            coVerify(exactly = 1) { getAccountFastLookupBatch(addresses) }
+        }
     }
 
     private companion object {
         val ENTROPY = byteArrayOf(1, 2, 3)
-
-        const val ACC_1_ADDR_1 = "acc_1_addr_1"
-        const val ACC_1_ADDR_2 = "acc_1_addr_2"
-        const val ACC_1_ADDR_3 = "acc_1_addr_3"
-        const val ACC_1_ADDR_4 = "acc_1_addr_4"
-        const val ACC_1_ADDR_5 = "acc_1_addr_5"
-        const val ACC_2_ADDR_1 = "acc_2_addr_1"
-        const val ACC_2_ADDR_2 = "acc_2_addr_2"
-        const val ACC_2_ADDR_3 = "acc_2_addr_3"
-        const val ACC_2_ADDR_4 = "acc_2_addr_4"
-        const val ACC_2_ADDR_5 = "acc_2_addr_5"
-
-        val FIRST_ACCOUNT_ADDRESSES = listOf(ACC_1_ADDR_1, ACC_1_ADDR_2, ACC_1_ADDR_3, ACC_1_ADDR_4, ACC_1_ADDR_5)
-
-        val ACC_1_ADDR_1_FAST_LOOKUP = peraFixture<AccountFastLookup>()
-        val ACC_1_ADDR_2_FAST_LOOKUP = peraFixture<AccountFastLookup>()
-        val ACC_1_ADDR_3_FAST_LOOKUP = peraFixture<AccountFastLookup>()
-        val ACC_1_ADDR_4_FAST_LOOKUP = peraFixture<AccountFastLookup>()
-        val ACC_1_ADDR_5_FAST_LOOKUP = peraFixture<AccountFastLookup>()
-
-        val ACC_1_HD_KEY_DETAILS = listOf(
-            HdKeyDetail(ACC_1_ADDR_1, 0, 0, 0),
-            HdKeyDetail(ACC_1_ADDR_2, 0, 0, 1),
-            HdKeyDetail(ACC_1_ADDR_3, 0, 0, 2),
-            HdKeyDetail(ACC_1_ADDR_4, 0, 0, 3),
-            HdKeyDetail(ACC_1_ADDR_5, 0, 0, 4)
-        )
-
-        val SECOND_ACCOUNT_ADDRESSES = listOf(ACC_2_ADDR_1, ACC_2_ADDR_2, ACC_2_ADDR_3, ACC_2_ADDR_4, ACC_2_ADDR_5)
     }
 }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCaseTestHelper.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCaseTestHelper.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.account.info.domain.usecase
+
+import com.algorand.test.peraFixture
+import com.algorand.wallet.account.info.domain.model.AccountFastLookup
+import com.algorand.wallet.account.info.domain.model.ActiveHdAccount.HdAccountAddress
+import com.algorand.wallet.account.info.domain.model.HdKeyDetail
+
+internal class GetActiveHdAccountsUseCaseTestHelper(accountCount: Int, addressCount: Int) {
+
+    private data class AccountIndex(val index: Int)
+
+    private data class Address(val index: Int, val address: String)
+
+    private val accounts: Map<AccountIndex, List<Address>>
+
+    init {
+        accounts = generateAccounts(accountCount, addressCount)
+    }
+
+    fun getAccountAddresses(accountIndex: Int): List<String> {
+        return accounts[AccountIndex(accountIndex)]!!.map { it.address }
+    }
+
+    fun getAccountIndexAndAddressesPair(): List<Pair<Int, List<String>>> {
+        return accounts.map { (account, addresses) ->
+            account.index to addresses.map { it.address }
+        }
+    }
+
+    fun getActiveAccountFastLookupResult(index: Int): Map<String, AccountFastLookup?> {
+        return accounts[AccountIndex((index))]!!.associate { address ->
+            address.address to peraFixture<AccountFastLookup>().copy(accountExists = true)
+        }
+    }
+
+    fun getInactiveAccountFastLookupResult(index: Int): Map<String, AccountFastLookup?> {
+        return accounts[AccountIndex(index)]!!.associate { address ->
+            address.address to peraFixture<AccountFastLookup?>()?.copy(accountExists = false)
+        }
+    }
+
+    fun getHdAccountAddresses(
+        accountIndex: Int,
+        fastLookups: List<AccountFastLookup?>
+    ): List<HdAccountAddress> {
+        return fastLookups.mapIndexed { index, accountFastLookup ->
+            val address = getAccountAddresses(accountIndex)[index]
+            HdAccountAddress(address, accountIndex, 0, index, accountFastLookup)
+        }
+    }
+
+    fun getHdKeyDetails(accountIndex: Int): List<HdKeyDetail> {
+        return accounts[AccountIndex(accountIndex)]!!.map { address ->
+            HdKeyDetail(address.address, accountIndex, 0, keyIndex = address.index)
+        }
+    }
+
+    private fun generateAccounts(accountCount: Int, addressCount: Int): Map<AccountIndex, List<Address>> {
+        return (0 until accountCount).associate { accountIndex ->
+            AccountIndex(accountIndex) to (0 until addressCount).map { addressIndex ->
+                Address(addressIndex, "acc_${accountIndex}_addr_$addressIndex")
+            }
+        }
+    }
+}

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCaseTestHelper.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetActiveHdAccountsUseCaseTestHelper.kt
@@ -15,7 +15,8 @@ package com.algorand.wallet.account.info.domain.usecase
 import com.algorand.test.peraFixture
 import com.algorand.wallet.account.info.domain.model.AccountFastLookup
 import com.algorand.wallet.account.info.domain.model.ActiveHdAccount.HdAccountAddress
-import com.algorand.wallet.account.info.domain.model.HdKeyDetail
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressLite
 
 internal class GetActiveHdAccountsUseCaseTestHelper(accountCount: Int, addressCount: Int) {
 
@@ -33,9 +34,11 @@ internal class GetActiveHdAccountsUseCaseTestHelper(accountCount: Int, addressCo
         return accounts[AccountIndex(accountIndex)]!!.map { it.address }
     }
 
-    fun getAccountIndexAndAddressesPair(): List<Pair<Int, List<String>>> {
+    fun getAccountIndexAndAddressesPair(): List<Pair<Int, List<HdKeyAddressLite>>> {
         return accounts.map { (account, addresses) ->
-            account.index to addresses.map { it.address }
+            account.index to addresses.map {
+                HdKeyAddressLite(it.address, HdKeyAddressIndex(account.index, 0, keyIndex = it.index))
+            }
         }
     }
 
@@ -61,9 +64,9 @@ internal class GetActiveHdAccountsUseCaseTestHelper(accountCount: Int, addressCo
         }
     }
 
-    fun getHdKeyDetails(accountIndex: Int): List<HdKeyDetail> {
+    fun getHdKeyDetails(accountIndex: Int): List<HdKeyAddressLite> {
         return accounts[AccountIndex(accountIndex)]!!.map { address ->
-            HdKeyDetail(address.address, accountIndex, 0, keyIndex = address.index)
+            HdKeyAddressLite(address.address, HdKeyAddressIndex(accountIndex, 0, keyIndex = address.index))
         }
     }
 

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetRegisteredHdKeysUseCaseTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/account/info/domain/usecase/GetRegisteredHdKeysUseCaseTest.kt
@@ -19,7 +19,10 @@ import com.algorand.wallet.account.info.domain.model.ActiveHdAccount
 import com.algorand.wallet.account.info.domain.model.ActiveHdAccount.HdAccountAddress
 import com.algorand.wallet.account.info.domain.model.RegisteredHdKey
 import com.algorand.wallet.account.local.domain.usecase.GetLocalAccountsAddresses
-import com.algorand.wallet.algosdk.transaction.sdk.PeraBip39Sdk
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressIndex
+import com.algorand.wallet.algosdk.bip39.model.HdKeyAddressLite
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39Wallet
+import com.algorand.wallet.algosdk.bip39.sdk.Bip39WalletProvider
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -33,8 +36,11 @@ class GetRegisteredHdKeysUseCaseTest {
     private val getActiveHdAccounts: GetActiveHdAccounts = mockk()
     private val getActiveHdAccountAddresses: GetActiveHdAccountAddresses = mockk()
     private val registeredHdKeyMapper: RegisteredHdKeyMapper = mockk()
-    private val peraBip39Sdk: PeraBip39Sdk = mockk {
-        every { generateHdKeyAddress(ENTROPY, 0, 0, 0) } returns FIRST_ADDRESS
+    private val bip39Wallet: Bip39Wallet = mockk(relaxed = true) {
+        every { generateAddressLite(HdKeyAddressIndex()) } returns HdKeyAddressLite(FIRST_ADDRESS, HdKeyAddressIndex())
+    }
+    private val bip39WalletProvider: Bip39WalletProvider = mockk {
+        every { getBip39Wallet(ENTROPY) } returns bip39Wallet
     }
 
     private val sut = GetRegisteredHdKeysUseCase(
@@ -42,7 +48,7 @@ class GetRegisteredHdKeysUseCaseTest {
         getActiveHdAccounts = getActiveHdAccounts,
         getActiveHdAccountAddresses = getActiveHdAccountAddresses,
         registeredHdKeyMapper = registeredHdKeyMapper,
-        peraBip39Sdk = peraBip39Sdk
+        bip39WalletProvider = bip39WalletProvider
     )
 
     @Test
@@ -87,7 +93,9 @@ class GetRegisteredHdKeysUseCaseTest {
         coEvery { getLocalAccountsAddresses() } returns listOf(ADDRESS_1, ADDRESS_2)
         coEvery { getActiveHdAccountAddresses(ACTIVE_HD_ACCOUNT_1) } returns listOf(FIRST_ACCOUNT_HD_ACCOUNT_ADDRESS)
         coEvery { getActiveHdAccountAddresses(ACTIVE_HD_ACCOUNT_2) } returns listOf(SECOND_ACCOUNT_HD_ACCOUNT_ADDRESS)
-        every { peraBip39Sdk.generateHdKeyAddress(ENTROPY, 0, 0, 0) } returns ADDRESS_1
+        every {
+            bip39Wallet.generateAddressLite(HdKeyAddressIndex())
+        } returns HdKeyAddressLite(ADDRESS_1, HdKeyAddressIndex())
         coEvery {
             registeredHdKeyMapper(
                 FIRST_ACCOUNT_HD_ACCOUNT_ADDRESS,
@@ -122,7 +130,9 @@ class GetRegisteredHdKeysUseCaseTest {
         coEvery { getActiveHdAccountAddresses(ACTIVE_HD_ACCOUNT_1) } returns listOf(firstAccountAddress)
         coEvery { getActiveHdAccountAddresses(ACTIVE_HD_ACCOUNT_2) } returns listOf(secondAccountAddress)
         coEvery { getActiveHdAccountAddresses(ACTIVE_HD_ACCOUNT_3) } returns listOf(THIRD_ACCOUNT_HD_ACCOUNT_ADDRESS)
-        every { peraBip39Sdk.generateHdKeyAddress(ENTROPY, 0, 0, 0) } returns ADDRESS_1
+        every {
+            bip39Wallet.generateAddressLite(HdKeyAddressIndex())
+        } returns HdKeyAddressLite(ADDRESS_1, HdKeyAddressIndex())
         coEvery {
             registeredHdKeyMapper(
                 THIRD_ACCOUNT_HD_ACCOUNT_ADDRESS,


### PR DESCRIPTION
## Description
- From now on, instead of checking accounts one by one, it will check in chunks until the whole chunk is closed

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2132

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you added any necessary tests for your changes?

## Additional Notes
It is not suggested to use functions/logics to create mock data, however creating and mocking necessary objects (25 accounts and each account has 5 addresses) was not an option for this class' test.

