### PR TITLE
PERA-2268 :: Remove enable_immersve flag

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/CoreActionsTabBarViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/CoreActionsTabBarViewModel.kt
@@ -17,13 +17,12 @@ import com.algorand.android.BuildConfig.DISCOVER_MAINNET_URL
 import com.algorand.android.BuildConfig.DISCOVER_TESTNET_URL
 import com.algorand.android.usecase.GetIsActiveNodeTestnetUseCase
 import com.algorand.android.usecase.GetIsProductionBuildUseCase
-import com.algorand.wallet.remoteconfig.domain.usecase.IMMERSVE_BUTTON_TOGGLE
 import com.algorand.wallet.remoteconfig.domain.usecase.IsFeatureToggleEnabled
 import com.algorand.wallet.remoteconfig.domain.usecase.STAKING_BUTTON_TOGGLE
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
 
 @HiltViewModel
 class CoreActionsTabBarViewModel @Inject constructor(
@@ -36,11 +35,9 @@ class CoreActionsTabBarViewModel @Inject constructor(
     val viewState get() = _viewState.asStateFlow()
 
     fun changeViewStateForFeatureFlag() {
-        val isImmersveToggleEnabled = isFeatureToggleEnabled(IMMERSVE_BUTTON_TOGGLE) &&
-                !(isConnectedToTestnet() && isProductionBuild())
         val isStakingToggleEnabled = isFeatureToggleEnabled(STAKING_BUTTON_TOGGLE) &&
                 !isConnectedToTestnet()
-        _viewState.value = ViewState.Content(isImmersveToggleEnabled, isStakingToggleEnabled)
+        _viewState.value = ViewState.Content(isStakingToggleEnabled)
     }
 
     fun getDiscoverBrowseDappUrl(): String {
@@ -65,7 +62,6 @@ class CoreActionsTabBarViewModel @Inject constructor(
     sealed interface ViewState {
         data object Idle : ViewState
         data class Content(
-            val isImmersveEnabled: Boolean,
             val isStakingEnabled: Boolean
         ) : ViewState
     }

--- a/app/src/main/kotlin/com/algorand/android/customviews/CoreActionsTabBarView.kt
+++ b/app/src/main/kotlin/com/algorand/android/customviews/CoreActionsTabBarView.kt
@@ -81,15 +81,14 @@ class CoreActionsTabBarView @JvmOverloads constructor(
     fun initViewState(viewState: CoreActionsTabBarViewModel.ViewState) {
         when (viewState) {
             is Content -> {
-                binding.cardsButton.isVisible = viewState.isImmersveEnabled
                 binding.stakingButton.isVisible = viewState.isStakingEnabled
                 binding.sendButton.isVisible = !viewState.isStakingEnabled
                 binding.scanQrButton.isVisible = !viewState.isStakingEnabled
                 binding.buySellButton.isVisible = binding.buySellButton.isEnabled
                 binding.browseDAppsButton.isVisible = binding.browseDAppsButton.isEnabled
             }
+
             Idle -> {
-                binding.cardsButton.visibility = GONE
                 binding.stakingButton.visibility = GONE
             }
         }

--- a/app/src/main/kotlin/com/algorand/android/modules/accounts/ui/model/BaseAccountListItem.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accounts/ui/model/BaseAccountListItem.kt
@@ -34,7 +34,6 @@ sealed interface BaseAccountListItem : RecyclerListItem {
 
     data class QuickActionsItem(
         val isSwapButtonSelected: Boolean,
-        val isImmersveEnabled: Boolean,
         val isStakingEnabled: Boolean
     ) : BaseAccountListItem {
 

--- a/app/src/main/kotlin/com/algorand/android/modules/accounts/ui/viewmodel/AccountPreviewProcessor.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accounts/ui/viewmodel/AccountPreviewProcessor.kt
@@ -36,7 +36,6 @@ import com.algorand.wallet.account.detail.domain.model.AccountType
 import com.algorand.wallet.account.detail.domain.usecase.GetAccountRegistrationType
 import com.algorand.wallet.account.local.domain.model.LocalAccount
 import com.algorand.wallet.account.local.domain.usecase.GetLocalAccounts
-import com.algorand.wallet.remoteconfig.domain.usecase.IMMERSVE_BUTTON_TOGGLE
 import com.algorand.wallet.remoteconfig.domain.usecase.IsFeatureToggleEnabled
 import com.algorand.wallet.remoteconfig.domain.usecase.STAKING_BUTTON_TOGGLE
 import java.math.BigDecimal
@@ -191,7 +190,6 @@ class AccountPreviewProcessor @Inject constructor(
             index = QUICK_ACTIONS_ITEM_INDEX,
             element = BaseAccountListItem.QuickActionsItem(
                 isSwapButtonSelected = getSwapFeatureRedDotVisibility.getSwapFeatureRedDotVisibility(),
-                isImmersveEnabled = isFeatureToggleEnabled(IMMERSVE_BUTTON_TOGGLE),
                 isStakingEnabled = isFeatureToggleEnabled(STAKING_BUTTON_TOGGLE)
             )
         )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/remoteconfig/domain/usecase/IsFeatureToggleEnabled.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/remoteconfig/domain/usecase/IsFeatureToggleEnabled.kt
@@ -12,7 +12,6 @@
 
 package com.algorand.wallet.remoteconfig.domain.usecase
 
-const val IMMERSVE_BUTTON_TOGGLE = "enable_immersve"
 const val STAKING_BUTTON_TOGGLE = "enable_staking"
 const val HD_WALLET_BUTTON_TOGGLE = "enable_hd_wallet"
 const val DISCOVER_V5_TOGGLE = "enable_discover_v5"


### PR DESCRIPTION
# Pull Request Template

## Description
- Cards button is now always visible. Feature flag is removed.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2268

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
