### PR TITLE
PERA-2331 :: Implement address naming for single hd imports

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/addressnaming/model/AddressNamingScreenConfig.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/addressnaming/model/AddressNamingScreenConfig.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.addressnaming.model
+
+import androidx.annotation.StringRes
+
+data class AddressNamingScreenConfig(
+    @StringRes val buttonResId: Int
+)

--- a/app/src/main/kotlin/com/algorand/android/ui/addressnaming/view/AddressNamingScreen.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/addressnaming/view/AddressNamingScreen.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.addressnaming.view
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.algorand.android.R
+import com.algorand.android.ui.addressnaming.model.AddressNamingScreenConfig
+import com.algorand.android.ui.addressnaming.viewmodel.AddressNamingViewModel
+import com.algorand.android.ui.addressnaming.viewmodel.AddressNamingViewModel.ViewEvent.NavToNextScreen
+import com.algorand.android.ui.addressnaming.viewmodel.AddressNamingViewModel.ViewState.Content
+import com.algorand.android.ui.addressnaming.viewmodel.AddressNamingViewModel.ViewState.Idle
+import com.algorand.android.ui.compose.theme.PeraTheme
+import com.algorand.android.ui.compose.widget.button.PeraButtonState.DISABLED
+import com.algorand.android.ui.compose.widget.button.PeraButtonState.ENABLED
+import com.algorand.android.ui.compose.widget.button.PeraPrimaryButton
+import com.algorand.android.ui.compose.widget.textfield.PeraTextField
+import com.algorand.android.ui.compose.widget.textfield.PeraTextFieldIcon
+import com.algorand.android.ui.compose.widget.textfield.PeraTextFieldLabel
+import kotlinx.coroutines.flow.collectLatest
+
+@Composable
+fun AddressNamingScreen(
+    config: AddressNamingScreenConfig,
+    listener: AddressNamingScreenListener,
+    viewModel: AddressNamingViewModel
+) {
+    Surface(
+        modifier = Modifier
+            .background(PeraTheme.colors.background.primary)
+            .padding(start = 24.dp, end = 24.dp, bottom = 24.dp)
+    ) {
+        val state = viewModel.state.collectAsStateWithLifecycle()
+        when (val currentState = state.value) {
+            Idle -> Unit
+            is Content -> {
+                Column(
+                    modifier = Modifier
+                        .background(PeraTheme.colors.background.primary)
+                        .imePadding()
+                ) {
+                    val nameInput = remember { mutableStateOf(currentState.currentName) }
+                    TitleText()
+                    Spacer(modifier = Modifier.height(14.dp))
+                    DescriptionText()
+                    Spacer(modifier = Modifier.height(32.dp))
+                    NameInput(nameInput)
+                    Spacer(modifier = Modifier.weight(1f))
+                    ConfirmButton(nameInput, config.buttonResId) {
+                        viewModel.saveCustomName(nameInput.value)
+                    }
+                }
+            }
+        }
+
+        LaunchedEffect(viewModel.viewEvent) {
+            viewModel.viewEvent.collectLatest {
+                when (it) {
+                    NavToNextScreen -> listener.onNamingCompleted()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TitleText() {
+    Text(
+        text = stringResource(R.string.name_your_account),
+        style = PeraTheme.typography.title.regular.sansMedium,
+        color = PeraTheme.colors.text.main
+    )
+}
+
+@Composable
+private fun DescriptionText() {
+    Text(
+        text = stringResource(R.string.name_your_account_to),
+        style = PeraTheme.typography.body.regular.sans,
+        color = PeraTheme.colors.text.gray
+    )
+}
+
+@Composable
+private fun NameInput(nameInput: MutableState<String>) {
+    PeraTextField(
+        modifier = Modifier.fillMaxWidth(),
+        text = nameInput.value,
+        onTextChanged = { nameInput.value = it },
+        label = { PeraTextFieldLabel(text = stringResource(R.string.account_name)) },
+        trailingIcon = if (nameInput.value.isNotBlank()) {
+            {
+                PeraTextFieldIcon(iconResId = R.drawable.ic_close) {
+                    nameInput.value = ""
+                }
+            }
+        } else {
+            null
+        }
+    )
+}
+
+@Composable
+private fun ConfirmButton(nameInput: MutableState<String>, @StringRes buttonResId: Int, onConfirmClick: () -> Unit) {
+    PeraPrimaryButton(
+        modifier = Modifier.fillMaxWidth(),
+        text = stringResource(buttonResId),
+        state = if (nameInput.value.isNotBlank()) ENABLED else DISABLED,
+        onClick = onConfirmClick
+    )
+}
+
+interface AddressNamingScreenListener {
+    fun onNamingCompleted()
+}
+
+@Preview
+@Composable
+private fun PreviewAddressNamingScreen() {
+    AddressNamingScreenPreview()
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/addressnaming/view/AddressNamingScreenPreview.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/addressnaming/view/AddressNamingScreenPreview.kt
@@ -1,0 +1,52 @@
+@file:Suppress("EmptyFunctionBlock")
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.addressnaming.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.algorand.android.R
+import com.algorand.android.ui.addressnaming.model.AddressNamingScreenConfig
+import com.algorand.android.ui.addressnaming.viewmodel.AddressNamingViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+@Preview
+@Composable
+fun AddressNamingScreenPreview() {
+    val listener = object : AddressNamingScreenListener {
+        override fun onNamingCompleted() {}
+    }
+
+    val viewModel = object : AddressNamingViewModel {
+        override fun init(address: String) {}
+
+        override fun saveCustomName(name: String) {}
+
+        override val state: StateFlow<AddressNamingViewModel.ViewState>
+            get() = MutableStateFlow(AddressNamingViewModel.ViewState.Content(
+                "address",
+                currentName = "ADDDRRR...DDDSSS"
+            ))
+        override val viewEvent: Flow<AddressNamingViewModel.ViewEvent>
+            get() = MutableSharedFlow()
+    }
+
+    AddressNamingScreen(
+        config = AddressNamingScreenConfig(R.string.finish_account_creation),
+        listener = listener,
+        viewModel = viewModel
+    )
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/addressnaming/view/NewAddressNamingFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/addressnaming/view/NewAddressNamingFragment.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.addressnaming.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.navArgs
+import com.algorand.android.R
+import com.algorand.android.core.BaseFragment
+import com.algorand.android.models.FragmentConfiguration
+import com.algorand.android.models.ToolbarConfiguration
+import com.algorand.android.ui.addressnaming.model.AddressNamingScreenConfig
+import com.algorand.android.ui.addressnaming.viewmodel.DefaultAddressNamingViewModel
+import com.algorand.android.ui.compose.extensions.createComposeView
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class NewAddressNamingFragment : BaseFragment(R.layout.fragment_address_naming), AddressNamingScreenListener {
+
+    private val toolbarConfiguration = ToolbarConfiguration(
+        startIconResId = R.drawable.ic_left_arrow,
+        startIconClick = ::navBack
+    )
+
+    override val fragmentConfiguration = FragmentConfiguration(toolbarConfiguration = toolbarConfiguration)
+
+    private val viewModel: DefaultAddressNamingViewModel by viewModels()
+
+    private val args: NewAddressNamingFragmentArgs by navArgs()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return createComposeView {
+            AddressNamingScreen(
+                config = AddressNamingScreenConfig(R.string.finish_account_creation),
+                listener = this,
+                viewModel = viewModel
+            )
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.init(args.address)
+    }
+
+    override fun onNamingCompleted() {
+        nav(NewAddressNamingFragmentDirections.actionNewAddressNamingFragmentToHomeNavigation())
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/addressnaming/view/NewAddressNamingFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/addressnaming/view/NewAddressNamingFragment.kt
@@ -28,7 +28,7 @@ import com.algorand.android.ui.compose.extensions.createComposeView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class NewAddressNamingFragment : BaseFragment(R.layout.fragment_address_naming), AddressNamingScreenListener {
+class NewAddressNamingFragment : BaseFragment(0), AddressNamingScreenListener {
 
     private val toolbarConfiguration = ToolbarConfiguration(
         startIconResId = R.drawable.ic_left_arrow,

--- a/app/src/main/kotlin/com/algorand/android/ui/addressnaming/viewmodel/AddressNamingViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/addressnaming/viewmodel/AddressNamingViewModel.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.addressnaming.viewmodel
+
+import com.algorand.android.ui.addressnaming.viewmodel.AddressNamingViewModel.ViewEvent
+import com.algorand.android.ui.addressnaming.viewmodel.AddressNamingViewModel.ViewState
+import com.algorand.wallet.viewmodel.EventViewModel
+import com.algorand.wallet.viewmodel.StateViewModel
+
+interface AddressNamingViewModel : StateViewModel<ViewState>, EventViewModel<ViewEvent> {
+
+    fun init(address: String)
+
+    fun saveCustomName(name: String)
+
+    sealed interface ViewState {
+        data object Idle : ViewState
+        data class Content(val address: String, val currentName: String) : ViewState
+    }
+
+    sealed interface ViewEvent {
+        data object NavToNextScreen : ViewEvent
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/addressnaming/viewmodel/DefaultAddressNamingViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/addressnaming/viewmodel/DefaultAddressNamingViewModel.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.addressnaming.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.algorand.android.ui.addressnaming.viewmodel.AddressNamingViewModel.ViewEvent
+import com.algorand.android.ui.addressnaming.viewmodel.AddressNamingViewModel.ViewState
+import com.algorand.android.ui.addressnaming.viewmodel.AddressNamingViewModel.ViewState.Content
+import com.algorand.android.utils.toShortenedAddress
+import com.algorand.wallet.account.custom.domain.usecase.GetAccountCustomName
+import com.algorand.wallet.account.custom.domain.usecase.SetAccountCustomName
+import com.algorand.wallet.viewmodel.EventDelegate
+import com.algorand.wallet.viewmodel.StateDelegate
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class DefaultAddressNamingViewModel @Inject constructor(
+    private val setAccountCustomName: SetAccountCustomName,
+    private val getAccountCustomName: GetAccountCustomName,
+    private val stateDelegate: StateDelegate<ViewState>,
+    private val eventDelegate: EventDelegate<ViewEvent>
+) : ViewModel(), AddressNamingViewModel {
+
+    override val state: StateFlow<ViewState>
+        get() = stateDelegate.state
+
+    override val viewEvent: Flow<ViewEvent>
+        get() = eventDelegate.viewEvent
+
+    init {
+        stateDelegate.setDefaultState(ViewState.Idle)
+    }
+
+    override fun init(address: String) {
+        viewModelScope.launch {
+            val currentName = getAccountCustomName(address) ?: address.toShortenedAddress()
+            stateDelegate.updateState { Content(address, currentName) }
+        }
+    }
+
+    override fun saveCustomName(name: String) {
+        stateDelegate.onState<Content> { contentState ->
+            viewModelScope.launch {
+                setAccountCustomName(contentState.address, name)
+                eventDelegate.sendEvent(ViewEvent.NavToNextScreen)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraTextField.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraTextField.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.textfield
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.algorand.android.ui.compose.theme.PeraTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PeraTextField(
+    modifier: Modifier = Modifier,
+    text: String,
+    onTextChanged: (String) -> Unit,
+    label: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    singleLine: Boolean = true,
+    enabled: Boolean = true
+) {
+    val textField = text.ifEmpty { " " }
+    BasicTextField(
+        modifier = modifier.defaultMinSize(minHeight = 52.dp),
+        value = text,
+        onValueChange = onTextChanged,
+        decorationBox = @Composable { innerTextField ->
+            TextFieldDefaults.DecorationBox(
+                label = label,
+                value = textField,
+                innerTextField = innerTextField,
+                trailingIcon = trailingIcon,
+                singleLine = singleLine,
+                enabled = enabled,
+                visualTransformation = VisualTransformation.None,
+                contentPadding = PaddingValues(start = 0.dp, top = 0.dp, end = 0.dp, bottom = 4.dp),
+                interactionSource = remember { MutableInteractionSource() },
+                shape = RectangleShape,
+                colors = TextFieldDefaults.colors().copy(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    unfocusedTextColor = PeraTheme.colors.text.main,
+                    focusedTextColor = PeraTheme.colors.text.main,
+                )
+            )
+        }
+    )
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraTextFieldIcon.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraTextFieldIcon.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.textfield
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PeraTextFieldIcon(@DrawableRes iconResId: Int, onClick: () -> Unit = {}) {
+    Icon(
+        modifier = Modifier
+            .size(24.dp)
+            .offset(x = 6.dp)
+            .clickable { onClick() },
+        painter = painterResource(iconResId),
+        contentDescription = null,
+    )
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraTextFieldIconPreview.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraTextFieldIconPreview.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.textfield
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.algorand.android.R
+
+@Preview
+@Composable
+fun PeraTextFieldIconPreview() {
+    PeraTextFieldIcon(R.drawable.ic_close)
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraTextFieldLabel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraTextFieldLabel.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.textfield
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.algorand.android.ui.compose.theme.PeraTheme
+
+@Composable
+fun PeraTextFieldLabel(modifier: Modifier = Modifier, text: String) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = PeraTheme.colors.text.grayLighter,
+        style = PeraTheme.typography.footnote.sans
+    )
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraTextFieldPreview.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraTextFieldPreview.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.textfield
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+
+@PreviewLightDark
+@Preview(showBackground = true)
+@Composable
+fun PeraTextFieldPreview() {
+    PeraTextField(
+        modifier = Modifier,
+        text = "Text Field Input",
+        onTextChanged = {}
+    )
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/onboarding/recoverypassphrase/importregisteredaddresses/RecoverRegisteredAccountsFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/onboarding/recoverypassphrase/importregisteredaddresses/RecoverRegisteredAccountsFragment.kt
@@ -29,7 +29,7 @@ import com.algorand.android.ui.rekeyedaccounts.model.RekeyedAccountSelectionNavA
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class RecoverRegisteredAccountsFragment : BaseFragment(0) {
+class RecoverRegisteredAccountsFragment : BaseFragment(0), RecoverRegisteredAccountsScreenListener {
 
     private val viewModel: RecoverRegisteredAccountsViewModel by viewModels()
 
@@ -43,12 +43,7 @@ class RecoverRegisteredAccountsFragment : BaseFragment(0) {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 PeraTheme {
-                    RecoverRegisteredAccountsScreen(
-                        viewModel,
-                        ::navToHomeNavigation,
-                        ::navBack,
-                        ::navToRekeyedAccountSelection
-                    )
+                    RecoverRegisteredAccountsScreen(viewModel, listener = this@RecoverRegisteredAccountsFragment)
                 }
             }
         }
@@ -59,7 +54,23 @@ class RecoverRegisteredAccountsFragment : BaseFragment(0) {
         configureToolbar()
     }
 
-    private fun navToRekeyedAccountSelection(navArgs: List<RekeyedAccountSelectionNavArg>) {
+    private fun configureToolbar() {
+        getAppToolbar()?.configureStartButton(R.drawable.ic_left_arrow, ::navBack)
+    }
+
+    override fun onNavToHomeNavigation(isNewAccountAdded: Boolean) {
+        nav(
+            RecoverRegisteredAccountsFragmentDirections.actionRecoverRegisteredAccountsFragmentToHomeNavigation(
+                showConfetti = isNewAccountAdded
+            )
+        )
+    }
+
+    override fun onNavBack() {
+        navBack()
+    }
+
+    override fun onNavToRekeyedAccountSelection(navArgs: List<RekeyedAccountSelectionNavArg>) {
         nav(
             RecoverRegisteredAccountsFragmentDirections
                 .actionRecoverRegisteredAccountsFragmentToRecoverHdKeyRekeyedAccountSelectionFragment(
@@ -68,15 +79,10 @@ class RecoverRegisteredAccountsFragment : BaseFragment(0) {
         )
     }
 
-    private fun navToHomeNavigation(isNewAccountAdded: Boolean) {
+    override fun onNavToNewAddressNamingFragment(address: String) {
         nav(
-            RecoverRegisteredAccountsFragmentDirections.actionRecoverRegisteredAccountsFragmentToHomeNavigation(
-                showConfetti = isNewAccountAdded
-            )
+            RecoverRegisteredAccountsFragmentDirections
+                .actionRecoverRegisteredAccountsFragmentToNewAddressNamingFragment(address)
         )
-    }
-
-    private fun configureToolbar() {
-        getAppToolbar()?.configureStartButton(R.drawable.ic_left_arrow, ::navBack)
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/onboarding/recoverypassphrase/importregisteredaddresses/RecoverRegisteredAccountsScreen.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/onboarding/recoverypassphrase/importregisteredaddresses/RecoverRegisteredAccountsScreen.kt
@@ -62,9 +62,7 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun RecoverRegisteredAccountsScreen(
     viewModel: RecoverRegisteredAccountsViewModel,
-    onNavToHomeNavigation: (isNewAccountAdded: Boolean) -> Unit,
-    onNavBack: () -> Unit,
-    onNavToRekeyedAccountSelection: (List<RekeyedAccountSelectionNavArg>) -> Unit
+    listener: RecoverRegisteredAccountsScreenListener
 ) {
     val viewState by viewModel.state.collectAsState()
 
@@ -75,9 +73,10 @@ fun RecoverRegisteredAccountsScreen(
     LaunchedEffect(viewModel.viewEvent) {
         viewModel.viewEvent.collectLatest { event ->
             when (event) {
-                is ViewEvent.NavigateToHome -> onNavToHomeNavigation(event.isNewAccountAdded)
-                is ViewEvent.NavigateBack -> onNavBack()
-                is ViewEvent.NavigateToRekeyedAccountSelection -> onNavToRekeyedAccountSelection(event.args)
+                is ViewEvent.NavigateToHome -> listener.onNavToHomeNavigation(event.isNewAccountAdded)
+                is ViewEvent.NavigateBack -> listener.onNavBack()
+                is ViewEvent.NavigateToRekeyedAccountSelection -> listener.onNavToRekeyedAccountSelection(event.args)
+                is ViewEvent.NavigateToAddressNaming -> listener.onNavToNewAddressNamingFragment(event.address)
             }
         }
     }
@@ -278,4 +277,11 @@ fun AddressItem(
             }
         }
     }
+}
+
+interface RecoverRegisteredAccountsScreenListener {
+    fun onNavToHomeNavigation(isNewAccountAdded: Boolean)
+    fun onNavBack()
+    fun onNavToRekeyedAccountSelection(navArgs: List<RekeyedAccountSelectionNavArg>)
+    fun onNavToNewAddressNamingFragment(address: String)
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/onboarding/recoverypassphrase/importregisteredaddresses/RecoverRegisteredAccountsViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/onboarding/recoverypassphrase/importregisteredaddresses/RecoverRegisteredAccountsViewModel.kt
@@ -141,8 +141,12 @@ class RecoverRegisteredAccountsViewModel @Inject constructor(
                 if (rekeyedAddresses.isNotEmpty()) {
                     eventDelegate.sendEvent(ViewEvent.NavigateToRekeyedAccountSelection(rekeyedAddresses))
                 } else {
-                    val isNewAccountAdded = addressesToImport.isNotEmpty()
-                    eventDelegate.sendEvent(ViewEvent.NavigateToHome(isNewAccountAdded))
+                    if (addressesToImport.size == 1) {
+                        eventDelegate.sendEvent(ViewEvent.NavigateToAddressNaming(addressesToImport.single().address))
+                    } else {
+                        val isNewAccountAdded = addressesToImport.isNotEmpty()
+                        eventDelegate.sendEvent(ViewEvent.NavigateToHome(isNewAccountAdded))
+                    }
                 }
                 entropy.clearFromMemory()
             }
@@ -238,6 +242,7 @@ class RecoverRegisteredAccountsViewModel @Inject constructor(
 
     sealed interface ViewEvent {
         data class NavigateToHome(val isNewAccountAdded: Boolean) : ViewEvent
+        data class NavigateToAddressNaming(val address: String) : ViewEvent
         data object NavigateBack : ViewEvent
         data class NavigateToRekeyedAccountSelection(val args: List<RekeyedAccountSelectionNavArg>) : ViewEvent
     }

--- a/app/src/main/kotlin/com/algorand/android/ui/rekeyedaccounts/hdkey/view/RecoverHdKeyRekeyedAccountSelectionFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/rekeyedaccounts/hdkey/view/RecoverHdKeyRekeyedAccountSelectionFragment.kt
@@ -67,7 +67,16 @@ class RecoverHdKeyRekeyedAccountSelectionFragment : BaseFragment(R.layout.fragme
     }
 
     override fun onSkipClick() {
-        navToNextScreen()
+        if (args.rekeyedAccountSelectionNavArg.size == 1) {
+            nav(
+                RecoverHdKeyRekeyedAccountSelectionFragmentDirections
+                    .actionRecoverHdKeyRekeyedAccountSelectionFragmentToNewAddressNamingFragment(
+                        args.rekeyedAccountSelectionNavArg.first().authAddress
+                    )
+            )
+        } else {
+            navToNextScreen()
+        }
     }
 
     override fun onAccountsAdded() {

--- a/app/src/main/res/navigation/recover_registered_accounts_navigation.xml
+++ b/app/src/main/res/navigation/recover_registered_accounts_navigation.xml
@@ -37,6 +37,9 @@
         <action
             android:id="@+id/action_recoverRegisteredAccountsFragment_to_recoverHdKeyRekeyedAccountSelectionFragment"
             app:destination="@id/recoverHdKeyRekeyedAccountSelectionFragment" />
+        <action
+            android:id="@+id/action_recoverRegisteredAccountsFragment_to_newAddressNamingFragment"
+            app:destination="@id/newAddressNamingFragment" />
     </fragment>
 
     <fragment
@@ -74,6 +77,30 @@
                 android:defaultValue="true"
                 app:argType="boolean" />
         </action>
+        <action
+            android:id="@+id/action_recoverHdKeyRekeyedAccountSelectionFragment_to_newAddressNamingFragment"
+            app:destination="@id/newAddressNamingFragment" />
+
+    </fragment>
+
+
+    <fragment
+        android:id="@+id/newAddressNamingFragment"
+        android:name="com.algorand.android.ui.addressnaming.view.NewAddressNamingFragment"
+        android:label="NewAddressNamingFragment">
+        <action
+            android:id="@+id/action_newAddressNamingFragment_to_homeNavigation"
+            app:destination="@id/homeNavigation"
+            app:popUpTo="@id/loginNavigation"
+            app:popUpToInclusive="true">
+            <argument
+                android:name="showConfetti"
+                android:defaultValue="true"
+                app:argType="boolean" />
+        </action>
+        <argument
+            android:name="address"
+            app:argType="string" />
     </fragment>
 
 </navigation>


### PR DESCRIPTION
## Description
- When user imports a single hd address, we will navigate to new address naming screen.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2331

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?

## Additional Notes
I created new address naming fragment, which doesn't require `AccountCreation` object. `address` is the only required arg. Also screen and fragment are separated, so that we can handle navigation with ease. 
