### PR TITLE
PERA-2392 :: Map seed id to account creation model

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/onboarding/creation/mapper/DefaultAccountCreationHdKeyTypeMapper.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/onboarding/creation/mapper/DefaultAccountCreationHdKeyTypeMapper.kt
@@ -31,6 +31,7 @@ internal class DefaultAccountCreationHdKeyTypeMapper @Inject constructor(
                 index.changeIndex,
                 index.keyIndex,
                 derivationType.value,
+                seedId
             )
         }
     }


### PR DESCRIPTION
# Pull Request Template

## Description
- Seed id was not mapped to account creation model. It added. Now you can see the wallet number correctly as you seleceted on the prev screen.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2392

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
