### PR TITLE
Pera 2514 ::  Add swap support to discover home page

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,15 +139,14 @@ android {
             buildConfigField "String", "ARC59_APP_ADDR_MAINNET", arc59Props["ARC59_APP_ADDR_MAINNET"]
             buildConfigField "long", "ARC59_APP_ID_MAINNET", arc59Props["ARC59_APP_ID_MAINNET"]
 
+            buildConfigField "String", "DISCOVER_URL", '"https://discover-mobile-staging.perawallet.app/"'
+            buildConfigField "String", "STAKING_URL", '"https://staking-mobile-staging.perawallet.app"'
+
             buildConfigField "String", "MELD_TESTNET_URL", '"https://testnet.api.perawallet.app"'
-            buildConfigField "String", "DISCOVER_TESTNET_URL", '"https://discover-mobile-testnet.perawallet.app"'
             buildConfigField "String", "CARDS_TESTNET_URL", '"https://cards-mobile-staging-testnet.perawallet.app"'
-            buildConfigField "String", "STAKING_TESTNET_URL", '"https://staking-mobile-testnet.perawallet.app"'
 
             buildConfigField "String", "MELD_MAINNET_URL", '"https://mainnet.staging.api.perawallet.app"'
-            buildConfigField "String", "DISCOVER_MAINNET_URL", '"https://discover-mobile-staging.perawallet.app"'
             buildConfigField "String", "CARDS_MAINNET_URL", '"https://cards-mobile-staging-mainnet.perawallet.app"'
-            buildConfigField "String", "STAKING_MAINNET_URL", '"https://staking-mobile-staging.perawallet.app"'
         }
 
         prod {
@@ -176,15 +175,14 @@ android {
             buildConfigField "String", "ARC59_APP_ADDR_MAINNET", arc59Props["ARC59_APP_ADDR_MAINNET"]
             buildConfigField "long", "ARC59_APP_ID_MAINNET", arc59Props["ARC59_APP_ID_MAINNET"]
 
+            buildConfigField "String", "DISCOVER_URL", '"https://discover-mobile.perawallet.app"'
+            buildConfigField "String", "STAKING_URL", '"https://staking-mobile.perawallet.app"'
+
             buildConfigField "String", "MELD_TESTNET_URL", '"https://testnet.api.perawallet.app"'
-            buildConfigField "String", "DISCOVER_TESTNET_URL", '"https://discover-mobile-testnet.perawallet.app"'
-            buildConfigField "String", "CARDS_TESTNET_URL", '"https://cards-mobile-prod-testnet.perawallet.app"'
-            buildConfigField "String", "STAKING_TESTNET_URL", '"https://staking-mobile-testnet.perawallet.app"'
+            buildConfigField "String", "CARDS_TESTNET_URL", '"https://cards-mobile.perawallet.app"'
 
             buildConfigField "String", "MELD_MAINNET_URL", '"https://mainnet.api.perawallet.app"'
-            buildConfigField "String", "DISCOVER_MAINNET_URL", '"https://discover-mobile.perawallet.app"'
             buildConfigField "String", "CARDS_MAINNET_URL", '"https://cards-mobile.perawallet.app"'
-            buildConfigField "String", "STAKING_MAINNET_URL", '"https://staking-mobile.perawallet.app"'
         }
     }
 

--- a/app/src/main/kotlin/com/algorand/android/CoreActionsTabBarViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/CoreActionsTabBarViewModel.kt
@@ -13,8 +13,7 @@
 package com.algorand.android
 
 import androidx.lifecycle.ViewModel
-import com.algorand.android.BuildConfig.DISCOVER_MAINNET_URL
-import com.algorand.android.BuildConfig.DISCOVER_TESTNET_URL
+import com.algorand.android.BuildConfig.DISCOVER_URL
 import com.algorand.android.usecase.GetIsActiveNodeTestnetUseCase
 import com.algorand.android.usecase.GetIsProductionBuildUseCase
 import com.algorand.wallet.remoteconfig.domain.usecase.IsFeatureToggleEnabled
@@ -46,9 +45,8 @@ class CoreActionsTabBarViewModel @Inject constructor(
     }
 
     fun getDiscoverUrlWithPath(path: String): String {
-        val baseDiscoverUrl = if (isConnectedToTestnet()) DISCOVER_TESTNET_URL else DISCOVER_MAINNET_URL
         val normalizedPath = if (path.startsWith("/")) path else "/$path"
-        return baseDiscoverUrl + normalizedPath
+        return DISCOVER_URL + normalizedPath
     }
 
     fun isConnectedToTestnet(): Boolean {

--- a/app/src/main/kotlin/com/algorand/android/CoreActionsTabBarViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/CoreActionsTabBarViewModel.kt
@@ -15,7 +15,6 @@ package com.algorand.android
 import androidx.lifecycle.ViewModel
 import com.algorand.android.BuildConfig.DISCOVER_URL
 import com.algorand.android.usecase.GetIsActiveNodeTestnetUseCase
-import com.algorand.android.usecase.GetIsProductionBuildUseCase
 import com.algorand.wallet.remoteconfig.domain.usecase.IsFeatureToggleEnabled
 import com.algorand.wallet.remoteconfig.domain.usecase.STAKING_BUTTON_TOGGLE
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,7 +24,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class CoreActionsTabBarViewModel @Inject constructor(
-    private val getIsProductionBuildUseCase: GetIsProductionBuildUseCase,
     private val getIsActiveNodeTestnetUseCase: GetIsActiveNodeTestnetUseCase,
     private val isFeatureToggleEnabled: IsFeatureToggleEnabled
 ) : ViewModel() {
@@ -49,12 +47,8 @@ class CoreActionsTabBarViewModel @Inject constructor(
         return DISCOVER_URL + normalizedPath
     }
 
-    fun isConnectedToTestnet(): Boolean {
+    private fun isConnectedToTestnet(): Boolean {
         return getIsActiveNodeTestnetUseCase.invoke()
-    }
-
-    fun isProductionBuild(): Boolean {
-        return getIsProductionBuildUseCase.invoke()
     }
 
     sealed interface ViewState {

--- a/app/src/main/kotlin/com/algorand/android/CoreMainActivity.kt
+++ b/app/src/main/kotlin/com/algorand/android/CoreMainActivity.kt
@@ -44,14 +44,15 @@ import com.algorand.android.utils.coremanager.ParityManager
 import com.algorand.android.utils.extensions.collectLatestOnLifecycle
 import com.algorand.android.utils.extensions.hide
 import com.algorand.android.utils.extensions.show
+import com.algorand.android.utils.isStagingApp
 import com.algorand.android.utils.navigateSafe
 import com.algorand.android.utils.setupWithNavController
 import com.algorand.android.utils.showDarkStatusBarIcons
 import com.algorand.android.utils.showLightStatusBarIcons
 import com.algorand.android.utils.viewbinding.viewBinding
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.properties.Delegates
-import kotlinx.coroutines.launch
 
 abstract class CoreMainActivity : BaseActivity() {
 
@@ -238,7 +239,7 @@ abstract class CoreMainActivity : BaseActivity() {
     private fun handleBottomBarNavigationForChosenNetwork() {
         binding.bottomNavigationView.menu.forEach { menuItem ->
             if (menuItem.itemId == R.id.discoverHomeNavigation) {
-                menuItem.isEnabled = isConnectedToTestNet.not()
+                menuItem.isEnabled = isConnectedToTestNet.not() || isStagingApp()
             }
         }
     }

--- a/app/src/main/kotlin/com/algorand/android/discover/common/domain/DiscoverActionRequest.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/common/domain/DiscoverActionRequest.kt
@@ -10,17 +10,17 @@
  * limitations under the License
  */
 
-package com.algorand.android.discover.detail.domain.model
+package com.algorand.android.discover.common.domain
 
 import android.os.Parcelable
-import com.algorand.android.discover.detail.ui.model.DiscoverDetailAction
+import com.algorand.android.discover.common.ui.model.DiscoverAction
 import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class DetailActionRequest(
+data class DiscoverActionRequest(
     @SerializedName("action")
-    val action: DiscoverDetailAction?,
+    val action: DiscoverAction?,
     @SerializedName("asset_in")
     val assetIn: String?,
     @SerializedName("asset_out")

--- a/app/src/main/kotlin/com/algorand/android/discover/common/ui/model/DiscoverAction.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/common/ui/model/DiscoverAction.kt
@@ -10,7 +10,7 @@
  * limitations under the License
  */
 
-package com.algorand.android.discover.detail.ui.model
+package com.algorand.android.discover.common.ui.model
 
 import com.google.gson.annotations.SerializedName
 
@@ -19,7 +19,7 @@ private const val SWAP_FROM_ALGO_SERIALIZATION_VALUE = "swap-from-algo"
 private const val SWAP_FROM_TOKEN_SERIALIZATION_VALUE = "swap-from-token"
 private const val SWAP_TO_TOKEN_SERIALIZATION_VALUE = "swap-to-token"
 
-enum class DiscoverDetailAction(val value: String?) {
+enum class DiscoverAction(val value: String?) {
     @SerializedName(BUY_ALGO_SERIALIZATION_VALUE)
     BUY_ALGO(BUY_ALGO_SERIALIZATION_VALUE),
 

--- a/app/src/main/kotlin/com/algorand/android/discover/detail/ui/DiscoverDetailFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/detail/ui/DiscoverDetailFragment.kt
@@ -133,8 +133,7 @@ class DiscoverDetailFragment :
                             tokenId = tokenId,
                             poolId = preview.tokenDetail.poolId,
                             currency = discoverViewModel.getPrimaryCurrencyId(),
-                            locale = Locale.getDefault().language,
-                            isConnectedToTestnet = discoverViewModel.isConnectedToTestnet()
+                            locale = Locale.getDefault().language
                         ),
                         getDiscoverAuthHeader()
                     )
@@ -153,6 +152,7 @@ class DiscoverDetailFragment :
                     errorTitleTextView.text = getString(R.string.well_this_is_unexpected)
                     errorDescriptionTextView.text = getString(R.string.we_are_not_able_to_find)
                 }
+
                 WebViewError.NO_CONNECTION -> {
                     errorTitleTextView.text = getString(R.string.no_internet_connection)
                     errorDescriptionTextView.text = getString(R.string.you_dont_seem_to_be_connected)

--- a/app/src/main/kotlin/com/algorand/android/discover/detail/ui/DiscoverDetailViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/detail/ui/DiscoverDetailViewModel.kt
@@ -19,18 +19,16 @@ import com.algorand.android.discover.detail.ui.model.DiscoverDetailPreview
 import com.algorand.android.discover.detail.ui.usecase.DiscoverDetailPreviewUseCase
 import com.algorand.android.discover.home.domain.model.TokenDetailInfo
 import com.algorand.android.modules.currency.domain.usecase.CurrencyUseCase
-import com.algorand.android.usecase.GetIsActiveNodeTestnetUseCase
 import com.algorand.android.utils.getOrThrow
 import com.algorand.android.utils.preference.ThemePreference
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 class DiscoverDetailViewModel @Inject constructor(
-    private val getIsActiveNodeTestnetUseCase: GetIsActiveNodeTestnetUseCase,
     private val discoverDetailPreviewUseCase: DiscoverDetailPreviewUseCase,
     private val currencyUseCase: CurrencyUseCase,
     savedStateHandle: SavedStateHandle
@@ -117,10 +115,6 @@ class DiscoverDetailViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    fun isConnectedToTestnet(): Boolean {
-        return getIsActiveNodeTestnetUseCase.invoke()
     }
 
     override fun getDiscoverThemePreference(): ThemePreference {

--- a/app/src/main/kotlin/com/algorand/android/discover/detail/ui/decider/BuySellActionDestinationDecider.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/detail/ui/decider/BuySellActionDestinationDecider.kt
@@ -12,18 +12,18 @@
 
 package com.algorand.android.discover.detail.ui.decider
 
+import com.algorand.android.discover.common.ui.model.DiscoverAction
+import com.algorand.android.discover.common.ui.model.DiscoverAction.BUY_ALGO
+import com.algorand.android.discover.common.ui.model.DiscoverAction.SWAP_FROM_ALGO
+import com.algorand.android.discover.common.ui.model.DiscoverAction.SWAP_FROM_TOKEN
+import com.algorand.android.discover.common.ui.model.DiscoverAction.SWAP_TO_TOKEN
 import com.algorand.android.discover.detail.ui.model.BuySellActionRequest
-import com.algorand.android.discover.detail.ui.model.DiscoverDetailAction
-import com.algorand.android.discover.detail.ui.model.DiscoverDetailAction.BUY_ALGO
-import com.algorand.android.discover.detail.ui.model.DiscoverDetailAction.SWAP_FROM_ALGO
-import com.algorand.android.discover.detail.ui.model.DiscoverDetailAction.SWAP_FROM_TOKEN
-import com.algorand.android.discover.detail.ui.model.DiscoverDetailAction.SWAP_TO_TOKEN
 import javax.inject.Inject
 
 class BuySellActionDestinationDecider @Inject constructor() {
 
-    fun getBuySellActionDestination(discoverDetailAction: DiscoverDetailAction?): BuySellActionRequest.Destination? {
-        return when (discoverDetailAction) {
+    fun getBuySellActionDestination(discoverAction: DiscoverAction?): BuySellActionRequest.Destination? {
+        return when (discoverAction) {
             BUY_ALGO -> BuySellActionRequest.Destination.MELD
             SWAP_FROM_ALGO, SWAP_FROM_TOKEN, SWAP_TO_TOKEN -> BuySellActionRequest.Destination.SWAP
             else -> null

--- a/app/src/main/kotlin/com/algorand/android/discover/detail/ui/mapper/BuySellActionRequestMapper.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/detail/ui/mapper/BuySellActionRequestMapper.kt
@@ -12,9 +12,9 @@
 
 package com.algorand.android.discover.detail.ui.mapper
 
+import com.algorand.android.discover.common.ui.model.DiscoverAction
 import com.algorand.android.discover.detail.ui.decider.BuySellActionDestinationDecider
 import com.algorand.android.discover.detail.ui.model.BuySellActionRequest
-import com.algorand.android.discover.detail.ui.model.DiscoverDetailAction
 import javax.inject.Inject
 
 class BuySellActionRequestMapper @Inject constructor(
@@ -24,7 +24,7 @@ class BuySellActionRequestMapper @Inject constructor(
     fun mapToBuySellActionRequest(
         assetInId: Long,
         assetOutId: Long,
-        detailAction: DiscoverDetailAction?
+        detailAction: DiscoverAction?
     ): BuySellActionRequest {
         return BuySellActionRequest(
             destination = buySellActionDestinationDecider.getBuySellActionDestination(detailAction),

--- a/app/src/main/kotlin/com/algorand/android/discover/detail/ui/usecase/DiscoverDetailPreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/detail/ui/usecase/DiscoverDetailPreviewUseCase.kt
@@ -15,13 +15,13 @@ package com.algorand.android.discover.detail.ui.usecase
 import android.content.SharedPreferences
 import androidx.navigation.NavDirections
 import com.algorand.android.deviceregistration.domain.usecase.DeviceIdUseCase
+import com.algorand.android.discover.common.domain.DiscoverActionRequest
+import com.algorand.android.discover.common.ui.model.DiscoverAction
 import com.algorand.android.discover.common.ui.model.OpenSystemBrowserRequest
 import com.algorand.android.discover.common.ui.model.WebViewError
-import com.algorand.android.discover.detail.domain.model.DetailActionRequest
 import com.algorand.android.discover.detail.ui.DiscoverDetailFragmentDirections
 import com.algorand.android.discover.detail.ui.mapper.BuySellActionRequestMapper
 import com.algorand.android.discover.detail.ui.model.BuySellActionRequest
-import com.algorand.android.discover.detail.ui.model.DiscoverDetailAction
 import com.algorand.android.discover.detail.ui.model.DiscoverDetailPreview
 import com.algorand.android.discover.home.domain.model.DappInfo
 import com.algorand.android.discover.home.domain.model.TokenDetailInfo
@@ -84,7 +84,7 @@ class DiscoverDetailPreviewUseCase @Inject constructor(
 
         detailActionRequest?.let {
             logDetailAction(
-                detailActionRequest = it,
+                discoverActionRequest = it,
                 assetIn = getSafeAssetIdForResponse(it.assetIn?.toLongOrNull()) ?: -1,
                 assetOut = getSafeAssetIdForResponse(it.assetOut?.toLongOrNull()) ?: -1
             )
@@ -107,6 +107,7 @@ class DiscoverDetailPreviewUseCase @Inject constructor(
             BuySellActionRequest.Destination.MELD -> {
                 swapNavDirection = DiscoverDetailFragmentDirections.actionDiscoverDetailFragmentToMeldNavigation()
             }
+
             BuySellActionRequest.Destination.SWAP -> {
                 discoverSwapNavigationDestinationHelper.getSwapNavigationDestination(
                     onNavToIntroduction = {
@@ -125,6 +126,7 @@ class DiscoverDetailPreviewUseCase @Inject constructor(
                     }
                 )
             }
+
             BuySellActionRequest.Destination.ONRAMP -> {}
             else -> {}
         }
@@ -133,7 +135,7 @@ class DiscoverDetailPreviewUseCase @Inject constructor(
         } ?: previousState
     }
 
-    suspend fun getSendDeviceIdJSFunctionOrNull(callingUrl: String): String? {
+    fun getSendDeviceIdJSFunctionOrNull(callingUrl: String): String? {
         val deviceId = deviceIdUseCase.getSelectedNodeDeviceId()
         return if (deviceId != null && isValidDiscoverURL(callingUrl)) {
             getSendDeviceId(deviceId, gson)
@@ -142,29 +144,31 @@ class DiscoverDetailPreviewUseCase @Inject constructor(
         }
     }
 
-    private fun getDetailActionRequestFromJson(jsonEncodedPayload: String): DetailActionRequest? {
-        return gson.fromJson<DetailActionRequest>(jsonEncodedPayload)
+    private fun getDetailActionRequestFromJson(jsonEncodedPayload: String): DiscoverActionRequest? {
+        return gson.fromJson<DiscoverActionRequest>(jsonEncodedPayload)
     }
 
     private suspend fun logDetailAction(
-        detailActionRequest: DetailActionRequest,
+        discoverActionRequest: DiscoverActionRequest,
         assetIn: Long,
         assetOut: Long
     ) {
-        when (detailActionRequest.action) {
-            DiscoverDetailAction.BUY_ALGO, DiscoverDetailAction.SWAP_TO_TOKEN -> {
+        when (discoverActionRequest.action) {
+            DiscoverAction.BUY_ALGO, DiscoverAction.SWAP_TO_TOKEN -> {
                 discoverDetailEventTracker.logTokenDetailBuyEvent(
                     assetIn = assetIn,
                     assetOut = assetOut
                 )
             }
-            DiscoverDetailAction.SWAP_FROM_ALGO, DiscoverDetailAction.SWAP_FROM_TOKEN -> {
+
+            DiscoverAction.SWAP_FROM_ALGO, DiscoverAction.SWAP_FROM_TOKEN -> {
                 discoverDetailEventTracker.logTokenDetailSellEvent(
                     assetIn = assetIn,
                     assetOut = assetOut
                 )
             }
-            DiscoverDetailAction.UNKNOWN, null -> {
+
+            DiscoverAction.UNKNOWN, null -> {
                 // No log action defined here
             }
         }

--- a/app/src/main/kotlin/com/algorand/android/discover/home/ui/DiscoverHomeFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/home/ui/DiscoverHomeFragment.kt
@@ -295,8 +295,7 @@ class DiscoverHomeFragment : BaseDiscoverFragment(R.layout.fragment_discover_hom
         val homeUrl = getDiscoverHomeUrl(
             themePreference = getWebViewThemeFromThemePreference(themePreference),
             currency = discoverViewModel.getPrimaryCurrencyId(),
-            locale = Locale.getDefault().language,
-            isConnectedToTestnet = discoverViewModel.isConnectedToTestnet()
+            locale = Locale.getDefault().language
         )
         loadWebViewUrl(homeUrl)
     }

--- a/app/src/main/kotlin/com/algorand/android/discover/home/ui/DiscoverHomeFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/home/ui/DiscoverHomeFragment.kt
@@ -36,10 +36,12 @@ import com.algorand.android.discover.home.domain.model.TokenDetailInfo
 import com.algorand.android.discover.home.ui.adapter.DiscoverAssetSearchAdapter
 import com.algorand.android.discover.home.ui.model.DiscoverAssetItem
 import com.algorand.android.discover.home.ui.model.DiscoverHomePreview
+import com.algorand.android.discover.utils.JAVASCRIPT_PERACONNECT
 import com.algorand.android.discover.utils.getDiscoverAuthHeader
 import com.algorand.android.discover.utils.getDiscoverCustomUrl
 import com.algorand.android.discover.utils.getDiscoverHomeUrl
 import com.algorand.android.models.FragmentConfiguration
+import com.algorand.android.utils.Event
 import com.algorand.android.utils.browser.openExternalBrowserApp
 import com.algorand.android.utils.delegation.bottomnavfragment.BottomNavBarFragmentDelegation
 import com.algorand.android.utils.delegation.bottomnavfragment.BottomNavBarFragmentDelegationImpl
@@ -51,6 +53,8 @@ import com.algorand.android.utils.listenToNavigationResult
 import com.algorand.android.utils.preference.ThemePreference
 import com.algorand.android.utils.scrollToTop
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
 import java.util.Locale
 
 @AndroidEntryPoint
@@ -66,6 +70,7 @@ class DiscoverHomeFragment : BaseDiscoverFragment(R.layout.fragment_discover_hom
 
     private val discoverHomePreviewCollector: suspend (DiscoverHomePreview) -> Unit = { preview ->
         with(preview) {
+            binding.webView.evaluateJavascript(JAVASCRIPT_PERACONNECT, null)
             updateUi(preview)
             loadingErrorEvent?.consume()?.run {
                 handleLoadingError(this)
@@ -95,6 +100,9 @@ class DiscoverHomeFragment : BaseDiscoverFragment(R.layout.fragment_discover_hom
             }
             sendMessageEvent?.consume()?.let { message ->
                 sendWebMessage(message)
+            }
+            buySellActionEvent?.consume()?.run {
+                nav(this)
             }
         }
     }
@@ -288,6 +296,7 @@ class DiscoverHomeFragment : BaseDiscoverFragment(R.layout.fragment_discover_hom
             webView.addJavascriptInterface(peraWebInterface, WEB_INTERFACE_NAME)
             webView.webViewClient = PeraWebViewClient(peraWebViewClientListener)
             webView.webChromeClient = PeraWebChromeClient(peraWebViewClientListener)
+            webView.evaluateJavascript(JAVASCRIPT_PERACONNECT, null)
         }
     }
 
@@ -337,6 +346,10 @@ class DiscoverHomeFragment : BaseDiscoverFragment(R.layout.fragment_discover_hom
             discoverAssetSearchAdapter.loadStateFlow,
             loadStateFlowCollector
         )
+        viewLifecycleOwner.collectLatestOnLifecycle(
+            discoverViewModel.discoverHomePreviewFlow.mapNotNull { it.sendMessageEvent }.distinctUntilChanged(),
+            sendMessageEventCollector
+        )
     }
 
     private fun navigateToTokenDetailScreen(tokenDetail: TokenDetailInfo) {
@@ -345,6 +358,10 @@ class DiscoverHomeFragment : BaseDiscoverFragment(R.layout.fragment_discover_hom
                 tokenDetail = tokenDetail
             )
         )
+    }
+
+    override fun handleTokenDetailActionButtonClick(jsonEncodedPayload: String) {
+        discoverViewModel.handleTokenDetailActionButtonClick(jsonEncodedPayload)
     }
 
     private fun navigateToDappUrl(
@@ -368,6 +385,12 @@ class DiscoverHomeFragment : BaseDiscoverFragment(R.layout.fragment_discover_hom
                 webUrl = url
             )
         )
+    }
+
+    private val sendMessageEventCollector: suspend (Event<String>) -> Unit = {
+        it.consume()?.let { message ->
+            sendWebMessage(message)
+        }
     }
 
     private fun sendWebMessage(message: String) {

--- a/app/src/main/kotlin/com/algorand/android/discover/home/ui/DiscoverHomeViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/home/ui/DiscoverHomeViewModel.kt
@@ -23,7 +23,6 @@ import com.algorand.android.discover.home.ui.usecase.DiscoverHomePreviewUseCase
 import com.algorand.android.discover.home.ui.usecase.DiscoverHomeUseCase
 import com.algorand.android.modules.perawebview.GetAuthorizedAddressesWebMessage
 import com.algorand.android.modules.tracking.discover.home.DiscoverHomeEventTracker
-import com.algorand.android.usecase.GetIsActiveNodeTestnetUseCase
 import com.algorand.android.utils.Event
 import com.algorand.android.utils.preference.ThemePreference
 import com.algorand.wallet.remoteconfig.domain.usecase.DISCOVER_V5_TOGGLE
@@ -42,7 +41,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class DiscoverHomeViewModel @Inject constructor(
-    private val getIsActiveNodeTestnetUseCase: GetIsActiveNodeTestnetUseCase,
     private val discoverHomePreviewUseCase: DiscoverHomePreviewUseCase,
     private val discoverHomeEventTracker: DiscoverHomeEventTracker,
     private val discoverHomeUseCase: DiscoverHomeUseCase,
@@ -231,10 +229,6 @@ class DiscoverHomeViewModel @Inject constructor(
 
     override fun getDiscoverThemePreference(): ThemePreference {
         return discoverHomePreviewFlow.value.themePreference
-    }
-
-    fun isConnectedToTestnet(): Boolean {
-        return getIsActiveNodeTestnetUseCase.invoke()
     }
 
     fun isV5Enabled(): Boolean {

--- a/app/src/main/kotlin/com/algorand/android/discover/home/ui/DiscoverHomeViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/home/ui/DiscoverHomeViewModel.kt
@@ -21,7 +21,7 @@ import com.algorand.android.discover.common.ui.model.DappFavoriteElement
 import com.algorand.android.discover.home.ui.model.DiscoverHomePreview
 import com.algorand.android.discover.home.ui.usecase.DiscoverHomePreviewUseCase
 import com.algorand.android.discover.home.ui.usecase.DiscoverHomeUseCase
-import com.algorand.android.modules.perawebview.GetAuthorizedAddressesWebMessage
+import com.algorand.android.modules.perawebview.GetAuthorizedAddressesInfoWebMessages
 import com.algorand.android.modules.tracking.discover.home.DiscoverHomeEventTracker
 import com.algorand.android.utils.Event
 import com.algorand.android.utils.preference.ThemePreference
@@ -45,7 +45,7 @@ class DiscoverHomeViewModel @Inject constructor(
     private val discoverHomeEventTracker: DiscoverHomeEventTracker,
     private val discoverHomeUseCase: DiscoverHomeUseCase,
     private val isFeatureToggleEnabled: IsFeatureToggleEnabled,
-    private val getAuthorizedAddressesWebMessage: GetAuthorizedAddressesWebMessage,
+    private val getAuthorizedAddressesInfoWebMessages: GetAuthorizedAddressesInfoWebMessages,
     savedStateHandle: SavedStateHandle
 ) : BaseDiscoverViewModel() {
 
@@ -237,7 +237,7 @@ class DiscoverHomeViewModel @Inject constructor(
 
     fun getAuthorizedAddresses() {
         viewModelScope.launch {
-            val authAddressesMessage = getAuthorizedAddressesWebMessage()
+            val authAddressesMessage = getAuthorizedAddressesInfoWebMessages()
             _discoverHomePreviewFlow.update {
                 it.copy(sendMessageEvent = Event(authAddressesMessage))
             }

--- a/app/src/main/kotlin/com/algorand/android/discover/home/ui/DiscoverHomeViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/home/ui/DiscoverHomeViewModel.kt
@@ -244,6 +244,19 @@ class DiscoverHomeViewModel @Inject constructor(
         }
     }
 
+    fun handleTokenDetailActionButtonClick(jsonEncodedPayload: String) {
+        viewModelScope.launch {
+            discoverHomePreviewUseCase.logTokenDetailActionButtonClick(jsonEncodedPayload)
+            _discoverHomePreviewFlow
+                .emit(
+                    discoverHomePreviewUseCase.handleTokenDetailActionButtonClick(
+                        jsonEncodedPayload,
+                        _discoverHomePreviewFlow.value
+                    )
+                )
+        }
+    }
+
     companion object {
         private const val QUERY_DEBOUNCE = 400L
         private const val URL_KEY = "url"

--- a/app/src/main/kotlin/com/algorand/android/discover/home/ui/model/DiscoverHomePreview.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/home/ui/model/DiscoverHomePreview.kt
@@ -12,6 +12,7 @@
 
 package com.algorand.android.discover.home.ui.model
 
+import androidx.navigation.NavDirections
 import com.algorand.android.discover.common.ui.model.DappFavoriteElement
 import com.algorand.android.discover.common.ui.model.WebViewError
 import com.algorand.android.discover.home.domain.model.DappInfo
@@ -34,4 +35,5 @@ data class DiscoverHomePreview(
     val loadHomeEvent: Event<Unit>? = null,
     val loadCustomUrlEvent: Event<String>? = null,
     val sendMessageEvent: Event<String>? = null,
+    val buySellActionEvent: Event<NavDirections>? = null,
 )

--- a/app/src/main/kotlin/com/algorand/android/discover/home/ui/usecase/DiscoverHomePreviewUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/home/ui/usecase/DiscoverHomePreviewUseCase.kt
@@ -13,20 +13,29 @@
 package com.algorand.android.discover.home.ui.usecase
 
 import android.content.SharedPreferences
+import androidx.navigation.NavDirections
 import androidx.paging.PagingData
 import androidx.paging.map
 import com.algorand.android.assetsearch.domain.mapper.AssetSearchQueryMapper
 import com.algorand.android.assetsearch.domain.pagination.AssetSearchPagerBuilder
+import com.algorand.android.discover.common.domain.DiscoverActionRequest
+import com.algorand.android.discover.common.ui.model.DiscoverAction
 import com.algorand.android.discover.common.ui.model.OpenSystemBrowserRequest
 import com.algorand.android.discover.common.ui.model.WebViewError
+import com.algorand.android.discover.detail.ui.mapper.BuySellActionRequestMapper
+import com.algorand.android.discover.detail.ui.model.BuySellActionRequest
 import com.algorand.android.discover.home.domain.model.DappInfo
 import com.algorand.android.discover.home.domain.model.TokenDetailInfo
 import com.algorand.android.discover.home.domain.model.UrlElement
 import com.algorand.android.discover.home.domain.usecase.DiscoverSearchAssetUseCase
+import com.algorand.android.discover.home.ui.DiscoverHomeFragmentDirections
 import com.algorand.android.discover.home.ui.mapper.DiscoverAssetItemMapper
 import com.algorand.android.discover.home.ui.mapper.DiscoverDappFavoritesMapper
 import com.algorand.android.discover.home.ui.model.DiscoverAssetItem
 import com.algorand.android.discover.home.ui.model.DiscoverHomePreview
+import com.algorand.android.modules.swap.assetswap.data.utils.getSafeAssetIdForResponse
+import com.algorand.android.modules.swap.utils.DiscoverSwapNavigationDestinationHelper
+import com.algorand.android.modules.tracking.discover.home.DiscoverHomeEventTracker
 import com.algorand.android.utils.Event
 import com.algorand.android.utils.fromJson
 import com.algorand.android.utils.preference.getSavedThemePreference
@@ -42,7 +51,10 @@ class DiscoverHomePreviewUseCase @Inject constructor(
     private val discoverAssetItemMapper: DiscoverAssetItemMapper,
     private val sharedPreferences: SharedPreferences,
     private val discoverDappFavoritesMapper: DiscoverDappFavoritesMapper,
-    private val gson: Gson
+    private val gson: Gson,
+    private val discoverHomeEventTracker: DiscoverHomeEventTracker,
+    private val buySellActionRequestMapper: BuySellActionRequestMapper,
+    private val discoverSwapNavigationDestinationHelper: DiscoverSwapNavigationDestinationHelper,
 ) {
 
     fun getSearchPaginationFlow(
@@ -103,9 +115,9 @@ class DiscoverHomePreviewUseCase @Inject constructor(
             if (isLoading.not()) previousState.handleQueryChangeForScrollEvent?.consume()?.run { Event(Unit) } else null
         return previousState.copy(
             isListEmpty = isListEmpty &&
-                !isCurrentStateError &&
-                !isLoading &&
-                previousState.isSearchActivated,
+                    !isCurrentStateError &&
+                    !isLoading &&
+                    previousState.isSearchActivated,
             scrollToTopEvent = scrollToTopEvent
         )
     }
@@ -178,5 +190,91 @@ class DiscoverHomePreviewUseCase @Inject constructor(
 
     fun getOpenSystemBrowserRequestFromJson(json: String): OpenSystemBrowserRequest? {
         return gson.fromJson<OpenSystemBrowserRequest>(json)
+    }
+
+    suspend fun handleTokenDetailActionButtonClick(
+        data: String,
+        previousState: DiscoverHomePreview
+    ): DiscoverHomePreview {
+        val detailActionRequest = getDetailActionRequestFromJson(data)
+
+        val buySellActionRequest = buySellActionRequestMapper.mapToBuySellActionRequest(
+            assetInId = getSafeAssetIdForResponse(detailActionRequest?.assetIn?.toLongOrNull()) ?: -1,
+            assetOutId = getSafeAssetIdForResponse(detailActionRequest?.assetOut?.toLongOrNull()) ?: -1,
+            detailAction = detailActionRequest?.action
+        )
+        var swapNavDirection: NavDirections? = null
+        when (buySellActionRequest.destination) {
+            BuySellActionRequest.Destination.MELD -> {
+                swapNavDirection = DiscoverHomeFragmentDirections.actionDiscoverHomeFragmentToMeldNavigation()
+            }
+
+            BuySellActionRequest.Destination.SWAP -> {
+                discoverSwapNavigationDestinationHelper.getSwapNavigationDestination(
+                    onNavToIntroduction = {
+                        swapNavDirection = DiscoverHomeFragmentDirections
+                            .actionDiscoverHomeFragmentToSwapIntroductionNavigation(
+                                fromAssetId = buySellActionRequest.assetInId ?: -1L,
+                                toAssetId = buySellActionRequest.assetOutId ?: -1L
+                            )
+                    },
+                    onNavToAccountSelection = {
+                        swapNavDirection = DiscoverHomeFragmentDirections
+                            .actionDiscoverHomeFragmentToSwapAccountSelectionNavigation(
+                                fromAssetId = buySellActionRequest.assetInId ?: -1L,
+                                toAssetId = buySellActionRequest.assetOutId ?: -1L
+                            )
+                    }
+                )
+            }
+
+            BuySellActionRequest.Destination.ONRAMP -> {}
+            else -> {}
+        }
+        return swapNavDirection?.let { direction ->
+            previousState.copy(buySellActionEvent = Event(direction))
+        } ?: previousState
+    }
+
+    private fun getDetailActionRequestFromJson(jsonEncodedPayload: String): DiscoverActionRequest? {
+        return gson.fromJson<DiscoverActionRequest>(jsonEncodedPayload)
+    }
+
+    suspend fun logTokenDetailActionButtonClick(jsonEncodedPayload: String) {
+        val detailActionRequest = getDetailActionRequestFromJson(jsonEncodedPayload)
+
+        detailActionRequest?.let {
+            logDetailAction(
+                discoverActionRequest = it,
+                assetIn = getSafeAssetIdForResponse(it.assetIn?.toLongOrNull()) ?: -1,
+                assetOut = getSafeAssetIdForResponse(it.assetOut?.toLongOrNull()) ?: -1
+            )
+        }
+    }
+
+    private suspend fun logDetailAction(
+        discoverActionRequest: DiscoverActionRequest,
+        assetIn: Long,
+        assetOut: Long
+    ) {
+        when (discoverActionRequest.action) {
+            DiscoverAction.BUY_ALGO, DiscoverAction.SWAP_TO_TOKEN -> {
+                discoverHomeEventTracker.logTokenDetailBuyEvent(
+                    assetIn = assetIn,
+                    assetOut = assetOut
+                )
+            }
+
+            DiscoverAction.SWAP_FROM_ALGO, DiscoverAction.SWAP_FROM_TOKEN -> {
+                discoverHomeEventTracker.logTokenDetailSellEvent(
+                    assetIn = assetIn,
+                    assetOut = assetOut
+                )
+            }
+
+            DiscoverAction.UNKNOWN, null -> {
+                // No log action defined here
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/discover/utils/DiscoverUtils.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/utils/DiscoverUtils.kt
@@ -14,8 +14,7 @@ package com.algorand.android.discover.utils
 
 import android.util.Base64
 import com.algorand.android.BuildConfig
-import com.algorand.android.BuildConfig.DISCOVER_MAINNET_URL
-import com.algorand.android.BuildConfig.DISCOVER_TESTNET_URL
+import com.algorand.android.BuildConfig.DISCOVER_URL
 import com.algorand.android.discover.common.ui.model.WebViewTheme
 
 private const val WEBVIEW_AUTH_USERNAME = BuildConfig.DISCOVER_WEBVIEW_USERNAME
@@ -32,8 +31,7 @@ fun getDiscoverHomeUrl(
     locale: String,
     isConnectedToTestnet: Boolean,
 ): String {
-    val url = if (isConnectedToTestnet) DISCOVER_TESTNET_URL else DISCOVER_MAINNET_URL
-    return DiscoverUrlBuilder.create(url)
+    return DiscoverUrlBuilder.create(DISCOVER_URL)
         .addTheme(themePreference)
         .addVersion(BuildConfig.DISCOVER_VERSION)
         .addPlatform()
@@ -50,8 +48,7 @@ fun getDiscoverTokenDetailUrl(
     locale: String,
     isConnectedToTestnet: Boolean,
 ): String {
-    val url = if (isConnectedToTestnet) DISCOVER_TESTNET_URL else DISCOVER_MAINNET_URL
-    return DiscoverUrlBuilder.create(url)
+    return DiscoverUrlBuilder.create(DISCOVER_URL)
         .addTheme(themePreference)
         .addVersion(BuildConfig.DISCOVER_VERSION)
         .addPlatform()

--- a/app/src/main/kotlin/com/algorand/android/discover/utils/DiscoverUtils.kt
+++ b/app/src/main/kotlin/com/algorand/android/discover/utils/DiscoverUtils.kt
@@ -28,8 +28,7 @@ val regexPatternPeraURL = """^https://([\da-z-]+\.)*(?<!web\.)perawallet\.app((?
 fun getDiscoverHomeUrl(
     themePreference: WebViewTheme,
     currency: String,
-    locale: String,
-    isConnectedToTestnet: Boolean,
+    locale: String
 ): String {
     return DiscoverUrlBuilder.create(DISCOVER_URL)
         .addTheme(themePreference)
@@ -45,8 +44,7 @@ fun getDiscoverTokenDetailUrl(
     tokenId: String,
     poolId: String?,
     currency: String,
-    locale: String,
-    isConnectedToTestnet: Boolean,
+    locale: String
 ): String {
     return DiscoverUrlBuilder.create(DISCOVER_URL)
         .addTheme(themePreference)

--- a/app/src/main/kotlin/com/algorand/android/modules/card/CardsViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/card/CardsViewModel.kt
@@ -19,7 +19,7 @@ import com.algorand.android.BuildConfig.CARDS_TESTNET_URL
 import com.algorand.android.discover.common.ui.model.WebViewError
 import com.algorand.android.modules.card.model.CardsPreview
 import com.algorand.android.modules.currency.domain.usecase.CurrencyUseCase
-import com.algorand.android.modules.perawebview.GetAuthorizedAddressesWebMessage
+import com.algorand.android.modules.perawebview.GetAuthorizedAddressesNamesWebMessages
 import com.algorand.android.modules.perawebview.GetDeviceIdWebMessage
 import com.algorand.android.modules.perawebview.ParseOpenSystemBrowserUrl
 import com.algorand.android.modules.perawebview.ui.BasePeraWebViewViewModel
@@ -36,7 +36,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CardsViewModel @Inject constructor(
     private val getIsActiveNodeTestnetUseCase: GetIsActiveNodeTestnetUseCase,
-    private val getAuthorizedAddressesWebMessage: GetAuthorizedAddressesWebMessage,
+    private val getAuthorizedAddressesNamesWebMessages: GetAuthorizedAddressesNamesWebMessages,
     private val getDeviceIdWebMessage: GetDeviceIdWebMessage,
     private val parseOpenSystemBrowserUrl: ParseOpenSystemBrowserUrl,
     private val currencyUseCase: CurrencyUseCase,
@@ -56,7 +56,7 @@ class CardsViewModel @Inject constructor(
 
     fun getAuthorizedAddresses() {
         viewModelScope.launch {
-            val authAddressesMessage = getAuthorizedAddressesWebMessage()
+            val authAddressesMessage = getAuthorizedAddressesNamesWebMessages()
             _cardsPreviewFlow.update {
                 it.copy(sendMessageEvent = Event(authAddressesMessage))
             }

--- a/app/src/main/kotlin/com/algorand/android/modules/card/di/CardModule.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/card/di/CardModule.kt
@@ -12,8 +12,10 @@
 
 package com.algorand.android.modules.card.di
 
-import com.algorand.android.modules.perawebview.GetAuthorizedAddressesWebMessage
-import com.algorand.android.modules.perawebview.GetAuthorizedAddressesWebMessagesUseCase
+import com.algorand.android.modules.perawebview.GetAuthorizedAddressesInfoWebMessages
+import com.algorand.android.modules.perawebview.GetAuthorizedAddressesInfoWebMessagesUseCase
+import com.algorand.android.modules.perawebview.GetAuthorizedAddressesNamesWebMessages
+import com.algorand.android.modules.perawebview.GetAuthorizedAddressesNamesWebMessagesUseCase
 import com.algorand.android.modules.perawebview.GetDeviceIdWebMessage
 import com.algorand.android.modules.perawebview.GetDeviceIdWebMessageUseCase
 import com.algorand.android.modules.perawebview.ParseOpenSystemBrowserUrl
@@ -32,9 +34,15 @@ object CardModule {
 
     @Provides
     @Singleton
-    fun provideGetAuthorizedAddressesWebMessage(
-        useCase: GetAuthorizedAddressesWebMessagesUseCase
-    ): GetAuthorizedAddressesWebMessage = useCase
+    fun provideGetAuthorizedAddressesInfoWebMessagesUseCase(
+        useCase: GetAuthorizedAddressesInfoWebMessagesUseCase
+    ): GetAuthorizedAddressesInfoWebMessages = useCase
+
+    @Provides
+    @Singleton
+    fun provideGetAuthorizedAddressesNamesWebMessagesUseCase(
+        useCase: GetAuthorizedAddressesNamesWebMessagesUseCase
+    ): GetAuthorizedAddressesNamesWebMessages = useCase
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/algorand/android/modules/perawebview/GetAuthorizedAddressesInfoWebMessages.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/perawebview/GetAuthorizedAddressesInfoWebMessages.kt
@@ -12,6 +12,6 @@
 
 package com.algorand.android.modules.perawebview
 
-fun interface GetAuthorizedAddressesWebMessage {
+fun interface GetAuthorizedAddressesInfoWebMessages {
     suspend operator fun invoke(): String
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/perawebview/GetAuthorizedAddressesInfoWebMessagesUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/perawebview/GetAuthorizedAddressesInfoWebMessagesUseCase.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.modules.perawebview
+
+import com.algorand.android.modules.peraserializer.PeraSerializer
+import com.algorand.android.modules.perawebview.model.AddressInfoMessage
+import com.algorand.wallet.account.detail.domain.model.AccountType.Companion.canSignTransaction
+import com.algorand.wallet.account.detail.domain.usecase.GetAccountsDetails
+import com.algorand.wallet.account.info.domain.usecase.GetAccountAlgoBalance
+import com.google.crypto.tink.subtle.Base64
+import javax.inject.Inject
+
+class GetAuthorizedAddressesInfoWebMessagesUseCase @Inject constructor(
+    private val getAccountsDetails: GetAccountsDetails,
+    private val peraSerializer: PeraSerializer,
+    private val peraWebMessageBuilder: PeraWebMessageBuilder,
+    private val getAccountAlgoBalance: GetAccountAlgoBalance
+) : GetAuthorizedAddressesInfoWebMessages {
+
+    override suspend fun invoke(): String {
+        val addressNameMap = getAddressesInfoList()
+        val messagePayload = getMessagePayload(addressNameMap)
+        return peraWebMessageBuilder.buildMessage(PeraWebMessageAction.GET_AUTHORIZED_ADDRESSES, messagePayload)
+    }
+
+    private suspend fun getAddressesInfoList(): List<AddressInfoMessage> {
+        val localAccounts = getAccountsDetails().filter { it.accountType?.canSignTransaction() == true }
+        val sortedAddressAlgoBalanceMap = localAccounts.map {
+            it to getAccountAlgoBalance(it.address)
+        }.sortedByDescending { (_, algoBalance) -> algoBalance }
+        return sortedAddressAlgoBalanceMap.map { (account, _) ->
+            AddressInfoMessage(
+                address = account.address,
+                name = account.customAccountInfo?.customName.orEmpty(),
+                type = account.accountType.toString()
+            )
+        }
+    }
+
+    private fun getMessagePayload(addressNameMap: List<AddressInfoMessage>): String {
+        return Base64.encode(peraSerializer.toJson(addressNameMap).toByteArray())
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/modules/perawebview/GetAuthorizedAddressesNamesWebMessages.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/perawebview/GetAuthorizedAddressesNamesWebMessages.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.modules.perawebview
+
+fun interface GetAuthorizedAddressesNamesWebMessages {
+    suspend operator fun invoke(): String
+}

--- a/app/src/main/kotlin/com/algorand/android/modules/perawebview/GetAuthorizedAddressesNamesWebMessagesUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/perawebview/GetAuthorizedAddressesNamesWebMessagesUseCase.kt
@@ -13,18 +13,18 @@
 package com.algorand.android.modules.perawebview
 
 import com.algorand.android.modules.peraserializer.PeraSerializer
-import com.algorand.wallet.account.info.domain.usecase.GetAccountAlgoBalance
 import com.algorand.wallet.account.detail.domain.model.AccountType.Companion.canSignTransaction
 import com.algorand.wallet.account.detail.domain.usecase.GetAccountsDetails
+import com.algorand.wallet.account.info.domain.usecase.GetAccountAlgoBalance
 import com.google.crypto.tink.subtle.Base64
 import javax.inject.Inject
 
-class GetAuthorizedAddressesWebMessagesUseCase @Inject constructor(
+class GetAuthorizedAddressesNamesWebMessagesUseCase @Inject constructor(
     private val getAccountsDetails: GetAccountsDetails,
     private val peraSerializer: PeraSerializer,
     private val peraWebMessageBuilder: PeraWebMessageBuilder,
     private val getAccountAlgoBalance: GetAccountAlgoBalance
-) : GetAuthorizedAddressesWebMessage {
+) : GetAuthorizedAddressesNamesWebMessages {
 
     override suspend fun invoke(): String {
         val addressNameMap = getAddressNameMap()

--- a/app/src/main/kotlin/com/algorand/android/modules/perawebview/model/AddressInfoMessage.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/perawebview/model/AddressInfoMessage.kt
@@ -1,16 +1,13 @@
 /*
- *
- *  *  Copyright 2022 Pera Wallet, LDA
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License
- *
- *
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
  */
 
 package com.algorand.android.modules.perawebview.model

--- a/app/src/main/kotlin/com/algorand/android/modules/perawebview/model/AddressInfoMessage.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/perawebview/model/AddressInfoMessage.kt
@@ -1,0 +1,22 @@
+/*
+ *
+ *  *  Copyright 2022 Pera Wallet, LDA
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License
+ *
+ *
+ */
+
+package com.algorand.android.modules.perawebview.model
+
+data class AddressInfoMessage(
+    val address: String,
+    val name: String,
+    val type: String
+)

--- a/app/src/main/kotlin/com/algorand/android/modules/staking/StakingViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/staking/StakingViewModel.kt
@@ -19,7 +19,7 @@ import com.algorand.android.discover.common.ui.model.WebViewError
 import com.algorand.android.discover.home.domain.model.DappInfo
 import com.algorand.android.modules.card.CardsFragmentArgs
 import com.algorand.android.modules.currency.domain.usecase.CurrencyUseCase
-import com.algorand.android.modules.perawebview.GetAuthorizedAddressesWebMessage
+import com.algorand.android.modules.perawebview.GetAuthorizedAddressesInfoWebMessages
 import com.algorand.android.modules.perawebview.GetDeviceIdWebMessage
 import com.algorand.android.modules.perawebview.ParseOpenSystemBrowserUrl
 import com.algorand.android.modules.perawebview.ui.BasePeraWebViewViewModel
@@ -36,7 +36,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class StakingViewModel @Inject constructor(
-    private val getAuthorizedAddressesWebMessage: GetAuthorizedAddressesWebMessage,
+    private val getAuthorizedAddressesInfoWebMessages: GetAuthorizedAddressesInfoWebMessages,
     private val getDeviceIdWebMessage: GetDeviceIdWebMessage,
     private val parseOpenSystemBrowserUrl: ParseOpenSystemBrowserUrl,
     private val currencyUseCase: CurrencyUseCase,
@@ -56,7 +56,7 @@ class StakingViewModel @Inject constructor(
 
     fun getAuthorizedAddresses() {
         viewModelScope.launch {
-            val authAddressesMessage = getAuthorizedAddressesWebMessage()
+            val authAddressesMessage = getAuthorizedAddressesInfoWebMessages()
             _stakingPreviewFlow.update {
                 it.copy(sendMessageEvent = Event(authAddressesMessage))
             }

--- a/app/src/main/kotlin/com/algorand/android/modules/staking/StakingViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/staking/StakingViewModel.kt
@@ -24,7 +24,6 @@ import com.algorand.android.modules.perawebview.GetDeviceIdWebMessage
 import com.algorand.android.modules.perawebview.ParseOpenSystemBrowserUrl
 import com.algorand.android.modules.perawebview.ui.BasePeraWebViewViewModel
 import com.algorand.android.modules.staking.model.StakingPreview
-import com.algorand.android.usecase.GetIsActiveNodeTestnetUseCase
 import com.algorand.android.utils.Event
 import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -37,7 +36,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class StakingViewModel @Inject constructor(
-    private val getIsActiveNodeTestnetUseCase: GetIsActiveNodeTestnetUseCase,
     private val getAuthorizedAddressesWebMessage: GetAuthorizedAddressesWebMessage,
     private val getDeviceIdWebMessage: GetDeviceIdWebMessage,
     private val parseOpenSystemBrowserUrl: ParseOpenSystemBrowserUrl,
@@ -53,12 +51,7 @@ class StakingViewModel @Inject constructor(
         get() = _stakingPreviewFlow.asStateFlow()
 
     fun getStakingUrl(): String {
-        val stakingBaseUrl = if (isConnectedToTestnet())
-            STAKING_URL
-        else
-            STAKING_URL
-
-        return "$stakingBaseUrl/${args.path.orEmpty()}"
+        return "$STAKING_URL/${args.path.orEmpty()}"
     }
 
     fun getAuthorizedAddresses() {
@@ -110,9 +103,5 @@ class StakingViewModel @Inject constructor(
 
     fun getPrimaryCurrencyId(): String {
         return currencyUseCase.getPrimaryCurrencyId()
-    }
-
-    fun isConnectedToTestnet(): Boolean {
-        return getIsActiveNodeTestnetUseCase.invoke()
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/staking/StakingViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/staking/StakingViewModel.kt
@@ -14,8 +14,7 @@ package com.algorand.android.modules.staking
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.algorand.android.BuildConfig.STAKING_MAINNET_URL
-import com.algorand.android.BuildConfig.STAKING_TESTNET_URL
+import com.algorand.android.BuildConfig.STAKING_URL
 import com.algorand.android.discover.common.ui.model.WebViewError
 import com.algorand.android.discover.home.domain.model.DappInfo
 import com.algorand.android.modules.card.CardsFragmentArgs
@@ -55,9 +54,9 @@ class StakingViewModel @Inject constructor(
 
     fun getStakingUrl(): String {
         val stakingBaseUrl = if (isConnectedToTestnet())
-            STAKING_TESTNET_URL
+            STAKING_URL
         else
-            STAKING_MAINNET_URL
+            STAKING_URL
 
         return "$stakingBaseUrl/${args.path.orEmpty()}"
     }

--- a/app/src/main/kotlin/com/algorand/android/modules/tracking/discover/common/DiscoverCommonEventTracker.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/tracking/discover/common/DiscoverCommonEventTracker.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.modules.tracking.discover.common
+
+import com.algorand.android.modules.tracking.core.BaseEventTracker
+import com.algorand.android.modules.tracking.discover.DiscoverEventTrackerConstants.ASSET_IN_PAYLOAD_KEY
+import com.algorand.android.modules.tracking.discover.DiscoverEventTrackerConstants.ASSET_OUT_PAYLOAD_KEY
+import com.algorand.wallet.analytics.domain.service.PeraEventTracker
+import javax.inject.Inject
+
+open class DiscoverCommonEventTracker @Inject constructor(
+    peraEventTracker: PeraEventTracker
+) : BaseEventTracker(peraEventTracker) {
+
+    suspend fun logTokenDetailBuyEvent(
+        assetIn: Long,
+        assetOut: Long
+    ) {
+        val eventPayload = getEventPayload(
+            assetIn = assetIn,
+            assetOut = assetOut
+        )
+        logEvent(TOKEN_BUY_EVENT_KEY, eventPayload)
+    }
+
+    suspend fun logTokenDetailSellEvent(
+        assetIn: Long,
+        assetOut: Long
+    ) {
+        val eventPayload = getEventPayload(
+            assetIn = assetIn,
+            assetOut = assetOut
+        )
+        logEvent(TOKEN_SELL_EVENT_KEY, eventPayload)
+    }
+
+    private fun getEventPayload(
+        assetIn: Long,
+        assetOut: Long
+    ): Map<String, Any> {
+        return mapOf(
+            ASSET_IN_PAYLOAD_KEY to assetIn,
+            ASSET_OUT_PAYLOAD_KEY to assetOut
+        )
+    }
+
+    companion object {
+        private const val TOKEN_BUY_EVENT_KEY = "discover_token_detail_buy"
+        private const val TOKEN_SELL_EVENT_KEY = "discover_token_detail_sell"
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/modules/tracking/discover/detail/DiscoverDetailEventTracker.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/tracking/discover/detail/DiscoverDetailEventTracker.kt
@@ -12,51 +12,11 @@
 
 package com.algorand.android.modules.tracking.discover.detail
 
-import com.algorand.android.modules.tracking.core.BaseEventTracker
+import com.algorand.android.modules.tracking.discover.common.DiscoverCommonEventTracker
 import com.algorand.wallet.analytics.domain.service.PeraEventTracker
-import com.algorand.android.modules.tracking.discover.DiscoverEventTrackerConstants.ASSET_IN_PAYLOAD_KEY
-import com.algorand.android.modules.tracking.discover.DiscoverEventTrackerConstants.ASSET_OUT_PAYLOAD_KEY
 import javax.inject.Inject
 
 // TODO use this class when the swap integration is completed to track buy/sell events
 class DiscoverDetailEventTracker @Inject constructor(
     peraEventTracker: PeraEventTracker
-) : BaseEventTracker(peraEventTracker) {
-
-    suspend fun logTokenDetailBuyEvent(
-        assetIn: Long,
-        assetOut: Long
-    ) {
-        val eventPayload = getEventPayload(
-            assetIn = assetIn,
-            assetOut = assetOut
-        )
-        logEvent(TOKEN_BUY_EVENT_KEY, eventPayload)
-    }
-
-    suspend fun logTokenDetailSellEvent(
-        assetIn: Long,
-        assetOut: Long
-    ) {
-        val eventPayload = getEventPayload(
-            assetIn = assetIn,
-            assetOut = assetOut
-        )
-        logEvent(TOKEN_SELL_EVENT_KEY, eventPayload)
-    }
-
-    private fun getEventPayload(
-        assetIn: Long,
-        assetOut: Long
-    ): Map<String, Any> {
-        return mapOf(
-            ASSET_IN_PAYLOAD_KEY to assetIn,
-            ASSET_OUT_PAYLOAD_KEY to assetOut
-        )
-    }
-
-    companion object {
-        private const val TOKEN_BUY_EVENT_KEY = "discover_token_detail_buy"
-        private const val TOKEN_SELL_EVENT_KEY = "discover_token_detail_sell"
-    }
-}
+) : DiscoverCommonEventTracker(peraEventTracker)

--- a/app/src/main/kotlin/com/algorand/android/modules/tracking/discover/home/DiscoverHomeEventTracker.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/tracking/discover/home/DiscoverHomeEventTracker.kt
@@ -12,15 +12,15 @@
 
 package com.algorand.android.modules.tracking.discover.home
 
-import com.algorand.android.modules.tracking.core.BaseEventTracker
-import com.algorand.wallet.analytics.domain.service.PeraEventTracker
 import com.algorand.android.modules.tracking.discover.DiscoverEventTrackerConstants.ASSET_ID_PAYLOAD_KEY
 import com.algorand.android.modules.tracking.discover.DiscoverEventTrackerConstants.QUERY_PAYLOAD_KEY
+import com.algorand.android.modules.tracking.discover.common.DiscoverCommonEventTracker
+import com.algorand.wallet.analytics.domain.service.PeraEventTracker
 import javax.inject.Inject
 
 class DiscoverHomeEventTracker @Inject constructor(
     peraEventTracker: PeraEventTracker
-) : BaseEventTracker(peraEventTracker) {
+) : DiscoverCommonEventTracker(peraEventTracker) {
 
     suspend fun logQueryEvent(
         query: String,

--- a/app/src/main/kotlin/com/algorand/android/ui/common/listhelper/viewholders/PagingPlaceholderViewHolder.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/common/listhelper/viewholders/PagingPlaceholderViewHolder.kt
@@ -1,16 +1,13 @@
 /*
- *
- *  *  Copyright 2022 Pera Wallet, LDA
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License
- *
- *
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
  */
 
 package com.algorand.android.ui.common.listhelper.viewholders

--- a/app/src/main/res/navigation/discover_home_navigation.xml
+++ b/app/src/main/res/navigation/discover_home_navigation.xml
@@ -95,6 +95,35 @@
                 app:argType="string" />
         </action>
 
+        <action
+            android:id="@+id/action_discoverHomeFragment_to_meldNavigation"
+            app:destination="@id/meldNavigation" />
+
+        <action
+            android:id="@+id/action_discoverHomeFragment_to_swapAccountSelectionNavigation"
+            app:destination="@id/swapAccountSelectionNavigation">
+            <argument
+                android:name="fromAssetId"
+                android:defaultValue="-1L"
+                app:argType="long" />
+            <argument
+                android:name="toAssetId"
+                android:defaultValue="-1L"
+                app:argType="long" />
+        </action>
+        
+        <action
+            android:id="@+id/action_discoverHomeFragment_to_swapIntroductionNavigation"
+            app:destination="@id/swapIntroductionNavigation">
+            <argument
+                android:name="fromAssetId"
+                android:defaultValue="-1L"
+                app:argType="long" />
+            <argument
+                android:name="toAssetId"
+                android:defaultValue="-1L"
+                app:argType="long" />
+        </action>
     </fragment>
 
 </navigation>


### PR DESCRIPTION
# Pull Request Template

## Description
- Swap functionality was only available in discover detail page. With the latest discover update asa detail moved to discover home page. With this pr we added swap support to discover home page too. 

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2514

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
