### PR TITLE
PERA-2586 ::  Filter collectibles with null primary image

### DIFF
--- a/common-sdk/src/main/kotlin/com/algorand/wallet/asset/data/database/dao/CollectibleDao.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/asset/data/database/dao/CollectibleDao.kt
@@ -59,6 +59,7 @@ internal interface CollectibleDao {
         FROM asset_holding_table AS asset_holding
         INNER JOIN collectible AS collectible ON asset_holding.asset_id = collectible.collectible_asset_id
         WHERE asset_holding.opted_in_at_round IS NOT NULL
+        AND collectible.primary_image_url IS NOT NULL
         ORDER BY asset_holding.opted_in_at_round DESC
         LIMIT :count
     """


### PR DESCRIPTION
# Pull Request Template

## Description
- When collectible primary image url is null app was crashing. Now we are filtering 

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2586

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
