### PR TITLE
PERA-2589 Make Cards and Staking deeplink path arg nullable

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/MainActivity.kt
+++ b/app/src/main/kotlin/com/algorand/android/MainActivity.kt
@@ -303,12 +303,12 @@ class MainActivity :
             return true
         }
 
-        override fun onCardsDeepLink(path: String): Boolean {
+        override fun onCardsDeepLink(path: String?): Boolean {
             navToCardsFragment(path)
             return true
         }
 
-        override fun onStakingDeepLink(path: String): Boolean {
+        override fun onStakingDeepLink(path: String?): Boolean {
             navToStakingFragment(path)
             return true
         }

--- a/app/src/main/kotlin/com/algorand/android/modules/deeplink/ui/DeeplinkHandler.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/deeplink/ui/DeeplinkHandler.kt
@@ -184,8 +184,8 @@ class DeeplinkHandler @Inject constructor(
         fun onDiscoverDeepLink(path: String): Boolean = false
         fun onAssetInboxDeepLink(accountAddress: String, notificationGroupType: NotificationGroupType): Boolean = false
         fun onKeyRegDeeplink(deepLink: DeepLink.KeyReg): Boolean = false
-        fun onCardsDeepLink(path: String): Boolean = false
-        fun onStakingDeepLink(path: String): Boolean = false
+        fun onCardsDeepLink(path: String?): Boolean = false
+        fun onStakingDeepLink(path: String?): Boolean = false
         fun onUndefinedDeepLink(deepLink: DeepLink.Undefined)
         fun onDeepLinkNotHandled(deepLink: DeepLink)
     }

--- a/app/src/main/kotlin/com/algorand/android/modules/qrscanning/BaseQrScannerFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/qrscanning/BaseQrScannerFragment.kt
@@ -173,12 +173,12 @@ abstract class BaseQrScannerFragment(
         return true
     }
 
-    override fun onCardsDeepLink(path: String): Boolean {
+    override fun onCardsDeepLink(path: String?): Boolean {
         (activity as? MainActivity)?.navToCardsFragment(path)
         return true
     }
 
-    override fun onStakingDeepLink(path: String): Boolean {
+    override fun onStakingDeepLink(path: String?): Boolean {
         (activity as? MainActivity)?.navToStakingFragment(path)
         return true
     }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/builder/CardsDeepLinkBuilder.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/builder/CardsDeepLinkBuilder.kt
@@ -19,12 +19,12 @@ internal class CardsDeepLinkBuilder : DeepLinkBuilder {
 
     override fun doesDeeplinkMeetTheRequirements(payload: DeepLinkPayload): Boolean {
         return with(payload) {
-            host == CARDS_HOST_NAME && path != null
+            host == CARDS_HOST_NAME
         }
     }
 
     override fun createDeepLink(payload: DeepLinkPayload): DeepLink {
-        return DeepLink.Cards(path = payload.path.orEmpty())
+        return DeepLink.Cards(path = payload.path)
     }
 
     companion object {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/builder/StakingDeepLinkBuilder.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/builder/StakingDeepLinkBuilder.kt
@@ -19,12 +19,12 @@ internal class StakingDeepLinkBuilder : DeepLinkBuilder {
 
     override fun doesDeeplinkMeetTheRequirements(payload: DeepLinkPayload): Boolean {
         return with(payload) {
-            host == STAKING_HOST_NAME && path != null
+            host == STAKING_HOST_NAME
         }
     }
 
     override fun createDeepLink(payload: DeepLinkPayload): DeepLink {
-        return DeepLink.Staking(path = payload.path.orEmpty())
+        return DeepLink.Staking(path = payload.path)
     }
 
     companion object {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/model/DeepLink.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/model/DeepLink.kt
@@ -67,9 +67,9 @@ sealed interface DeepLink {
 
     data class Discover(val path: String) : DeepLink
 
-    data class Cards(val path: String) : DeepLink
+    data class Cards(val path: String?) : DeepLink
 
-    data class Staking(val path: String) : DeepLink
+    data class Staking(val path: String?) : DeepLink
 
     data class Notification(
         val address: String,

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/deeplink/CreateDeepLinkImplTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/deeplink/CreateDeepLinkImplTest.kt
@@ -226,7 +226,7 @@ class CreateDeepLinkImplTest {
 
     @Test
     fun `EXPECT cards deep link`() {
-        val deepLink = DeepLink.Cards("path")
+        val deepLink = DeepLink.Cards(null)
         every { parseDeepLinkPayload("cardsDeepLink") } returns DEEP_LINK_PAYLOAD
         every { cardsDeepLinkBuilder.doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns true
         every { cardsDeepLinkBuilder.createDeepLink(DEEP_LINK_PAYLOAD) } returns deepLink
@@ -238,7 +238,7 @@ class CreateDeepLinkImplTest {
 
     @Test
     fun `EXPECT staking deep link`() {
-        val deepLink = DeepLink.Staking("path")
+        val deepLink = DeepLink.Staking(null)
         every { parseDeepLinkPayload("stakingDeepLink") } returns DEEP_LINK_PAYLOAD
         every { stakingDeepLinkBuilder.doesDeeplinkMeetTheRequirements(DEEP_LINK_PAYLOAD) } returns true
         every { stakingDeepLinkBuilder.createDeepLink(DEEP_LINK_PAYLOAD) } returns deepLink

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/deeplink/builder/CardsDeepLinkBuilderTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/deeplink/builder/CardsDeepLinkBuilderTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.deeplink.builder
+
+import com.algorand.wallet.deeplink.model.DeepLink
+import com.algorand.wallet.deeplink.model.DeepLinkPayload
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CardsDeepLinkBuilderTest {
+
+    private val sut = CardsDeepLinkBuilder()
+
+    @Test
+    fun `EXPECT true WHEN deeplink requirements match`() {
+        val result = sut.doesDeeplinkMeetTheRequirements(VALID_DEEP_LINK)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `EXPECT false WHEN deeplink requirements do not match`() {
+        val invalidDeepLink = VALID_DEEP_LINK.copy(host = "invalidHost")
+
+        val result = sut.doesDeeplinkMeetTheRequirements(invalidDeepLink)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `EXPECT null path WHEN deep link does not have path`() {
+        val deepLinkWithoutPath = VALID_DEEP_LINK.copy(path = null)
+        val result = sut.createDeepLink(deepLinkWithoutPath)
+
+        val expected = DeepLink.Cards(path = null)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `EXPECT path in deep link WHEN deep link has path`() {
+        val deepLinkWithPath = VALID_DEEP_LINK.copy(path = "some/path")
+        val result = sut.createDeepLink(deepLinkWithPath)
+
+        val expected = DeepLink.Cards(path = "some/path")
+        assertEquals(expected, result)
+    }
+
+    private companion object {
+        val VALID_DEEP_LINK = DeepLinkPayload(
+            accountAddress = null,
+            walletConnectUrl = null,
+            assetId = null,
+            amount = null,
+            note = null,
+            xnote = null,
+            url = null,
+            label = null,
+            webImportQrCode = null,
+            notificationGroupType = null,
+            rawDeepLinkUri = "",
+            host = "cards"
+        )
+    }
+}

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/deeplink/builder/StakingDeepLinkBuilderTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/deeplink/builder/StakingDeepLinkBuilderTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.deeplink.builder
+
+import com.algorand.wallet.deeplink.model.DeepLink
+import com.algorand.wallet.deeplink.model.DeepLinkPayload
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StakingDeepLinkBuilderTest {
+
+    private val sut = StakingDeepLinkBuilder()
+
+    @Test
+    fun `EXPECT true WHEN deeplink requirements match`() {
+        val result = sut.doesDeeplinkMeetTheRequirements(VALID_DEEP_LINK)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `EXPECT false WHEN deeplink requirements do not match`() {
+        val invalidDeepLink = VALID_DEEP_LINK.copy(host = "invalidHost")
+
+        val result = sut.doesDeeplinkMeetTheRequirements(invalidDeepLink)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `EXPECT null path WHEN deep link does not have path`() {
+        val deepLinkWithoutPath = VALID_DEEP_LINK.copy(path = null)
+        val result = sut.createDeepLink(deepLinkWithoutPath)
+
+        val expected = DeepLink.Staking(path = null)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `EXPECT path in deep link WHEN deep link has path`() {
+        val deepLinkWithPath = VALID_DEEP_LINK.copy(path = "some/path")
+        val result = sut.createDeepLink(deepLinkWithPath)
+
+        val expected = DeepLink.Staking(path = "some/path")
+        assertEquals(expected, result)
+    }
+
+    private companion object {
+        val VALID_DEEP_LINK = DeepLinkPayload(
+            accountAddress = null,
+            walletConnectUrl = null,
+            assetId = null,
+            amount = null,
+            note = null,
+            xnote = null,
+            url = null,
+            label = null,
+            webImportQrCode = null,
+            notificationGroupType = null,
+            rawDeepLinkUri = "",
+            host = "staking"
+        )
+    }
+}


### PR DESCRIPTION
## Description
- path parameter was mandatory. To be able to use cards and staking deeplinks without any path, they had to be optional. Since navArg params are nullable and their default values are null, no change needed there.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2589

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you added any necessary tests for your changes?


https://github.com/user-attachments/assets/12bd9e7d-bf21-4f2d-8ca3-e7175900f33e


