### PR TITLE
Pera 2398 :: Default block rekey transactions and add toggle in settings

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/repository/SecurityRepository.kt
+++ b/app/src/main/kotlin/com/algorand/android/repository/SecurityRepository.kt
@@ -20,11 +20,14 @@ import com.algorand.android.sharedpref.LockAttemptCountLocalSource
 import com.algorand.android.sharedpref.LockAttemptCountLocalSource.Companion.defaultLockAttemptCountPreference
 import com.algorand.android.sharedpref.LockPenaltyRemainingTimeLocalSource
 import com.algorand.android.sharedpref.LockPreferencesLocalSource
+import com.algorand.android.sharedpref.RekeySupportLocalSource
+import com.algorand.android.sharedpref.RekeySupportLocalSource.Companion.defaultRekeySupportPreference
 import javax.inject.Inject
 
 class SecurityRepository @Inject constructor(
     private val lockPreferencesLocalSource: LockPreferencesLocalSource,
     private val biometricRegistrationLocalSource: BiometricRegistrationLocalSource,
+    private val rekeySupportLocalSource: RekeySupportLocalSource,
     private val lockPenaltyRemainingTimeLocalSource: LockPenaltyRemainingTimeLocalSource,
     private val lockAttemptCountLocalSource: LockAttemptCountLocalSource
 ) {
@@ -39,8 +42,16 @@ class SecurityRepository @Inject constructor(
         biometricRegistrationLocalSource.saveData(isEnabled)
     }
 
+    fun setRekeySupportPreference(isEnabled: Boolean) {
+        rekeySupportLocalSource.saveData(isEnabled)
+    }
+
     fun isBiometricActive(): Boolean {
         return biometricRegistrationLocalSource.getData(defaultBiometricRegistrationPreference)
+    }
+
+    fun isRekeySupportEnabled(): Boolean {
+        return rekeySupportLocalSource.getData(defaultRekeySupportPreference)
     }
 
     fun setLockPenaltyRemainingTime(penaltyRemainingTime: Long) {

--- a/app/src/main/kotlin/com/algorand/android/sharedpref/RekeySupportLocalSource.kt
+++ b/app/src/main/kotlin/com/algorand/android/sharedpref/RekeySupportLocalSource.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.algorand.android.sharedpref
+
+import android.content.SharedPreferences
+import javax.inject.Inject
+
+class RekeySupportLocalSource @Inject constructor(
+    sharedPreferences: SharedPreferences
+) : SharedPrefLocalSource<Boolean>(sharedPreferences) {
+
+    override val key: String
+        get() = REKEY_SUPPORT_KEY
+
+    override fun getData(defaultValue: Boolean): Boolean {
+        return sharedPref.getBoolean(key, defaultValue)
+    }
+
+    override fun getDataOrNull(): Boolean {
+        return sharedPref.getBoolean(key, defaultRekeySupportPreference)
+    }
+
+    override fun saveData(data: Boolean) {
+        saveData { it.putBoolean(key, data) }
+    }
+
+    companion object {
+        private const val REKEY_SUPPORT_KEY = "rekey_support"
+        const val defaultRekeySupportPreference = false
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/settings/SettingsFragment.kt
@@ -37,8 +37,8 @@ import com.algorand.android.utils.viewbinding.viewBinding
 import com.google.crypto.tink.Aead
 import com.google.gson.Gson
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.flow.map
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SettingsFragment : DaggerBaseFragment(R.layout.fragment_settings) {
@@ -162,7 +162,7 @@ class SettingsFragment : DaggerBaseFragment(R.layout.fragment_settings) {
     }
 
     private fun onSecurityClick() {
-        nav(SettingsFragmentDirections.actionSettingsFragmentToSecurityFragment())
+        nav(SettingsFragmentDirections.actionSettingsFragmentToSecurityNavigation())
     }
 
     private fun initDialogSavedStateListener() {

--- a/app/src/main/kotlin/com/algorand/android/ui/settings/security/SecurityFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/settings/security/SecurityFragment.kt
@@ -56,9 +56,17 @@ class SecurityFragment : DaggerBaseFragment(R.layout.fragment_security) {
     private val pinCodeSwitch: SwitchMaterial?
         get() = binding.enablePinCodeListItem.getEndComponentViewStub()
 
+    private val rekeySupportSwitch: SwitchMaterial?
+        get() = binding.enableRekeySupportListItem.getEndComponentViewStub()
+
     private val isBiometricEnabledObserver = Observer<Boolean> { isChecked ->
         securityViewModel.setBiometricRegistrationPreference(isChecked)
         biometricSwitch?.isChecked = isChecked
+    }
+
+    private val isRekeySupportEnabledObserver = Observer<Boolean> { isChecked ->
+        securityViewModel.setRekeySupportPreference(isChecked)
+        rekeySupportSwitch?.isChecked = isChecked
     }
 
     private val isPasswordChosenObserver = Observer<Boolean> { isEnabled ->
@@ -89,6 +97,7 @@ class SecurityFragment : DaggerBaseFragment(R.layout.fragment_security) {
         with(securityViewModel) {
             isPasswordChosenLiveData.observe(viewLifecycleOwner, isPasswordChosenObserver)
             isBiometricEnabledLiveData.observe(viewLifecycleOwner, isBiometricEnabledObserver)
+            isRekeySupportEnabledLiveData.observe(viewLifecycleOwner, isRekeySupportEnabledObserver)
         }
     }
 
@@ -96,6 +105,7 @@ class SecurityFragment : DaggerBaseFragment(R.layout.fragment_security) {
     private fun initSwitchChangeListeners() {
         biometricSwitch?.setOnTouchListener { _, _ -> onEnableBiometricCodeTouch(); true }
         pinCodeSwitch?.setOnTouchListener { _, _ -> onEnablePinCodeTouch(); true }
+        rekeySupportSwitch?.setOnCheckedChangeListener { _, isChecked -> onRekeySupportCheckChanged(isChecked) }
     }
 
     private fun onEnableBiometricCodeTouch() {
@@ -112,6 +122,10 @@ class SecurityFragment : DaggerBaseFragment(R.layout.fragment_security) {
         } else {
             navToSetChangePasswordFragment()
         }
+    }
+
+    private fun onRekeySupportCheckChanged(isChecked: Boolean) {
+        securityViewModel.setRekeySupportPreference(isChecked)
     }
 
     private fun initDialogSavedStateListener() {

--- a/app/src/main/kotlin/com/algorand/android/ui/settings/security/SecurityViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/settings/security/SecurityViewModel.kt
@@ -12,12 +12,12 @@
 
 package com.algorand.android.ui.settings.security
 
-import javax.inject.Inject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.algorand.android.usecase.SecurityUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
 @HiltViewModel
 class SecurityViewModel @Inject constructor(
@@ -30,8 +30,15 @@ class SecurityViewModel @Inject constructor(
     private val _isBiometricEnabledLiveData = MutableLiveData(securityUseCase.isBiometricActive())
     val isBiometricEnabledLiveData: LiveData<Boolean> = _isBiometricEnabledLiveData
 
+    private val _isRekeySupportEnabledLiveData = MutableLiveData(securityUseCase.isRekeySupportEnabled())
+    val isRekeySupportEnabledLiveData: LiveData<Boolean> = _isRekeySupportEnabledLiveData
+
     fun setBiometricRegistrationPreference(isEnabled: Boolean) {
         securityUseCase.setBiometricRegistrationPreference(isEnabled)
+    }
+
+    fun setRekeySupportPreference(isEnabled: Boolean) {
+        securityUseCase.setRekeySupportPreference(isEnabled)
     }
 
     fun setPasswordPreferencesAsDisabled() {
@@ -49,4 +56,6 @@ class SecurityViewModel @Inject constructor(
     fun isPasscodeSet() = _isPasswordChosenLiveData.value ?: false
 
     fun isBiometricAuthEnabled() = _isBiometricEnabledLiveData.value ?: false
+
+    fun isRekeySupportEnabled() = _isRekeySupportEnabledLiveData.value ?: false
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/wctransactionrequest/WalletConnectTransactionRequestFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/wctransactionrequest/WalletConnectTransactionRequestFragment.kt
@@ -205,16 +205,12 @@ class WalletConnectTransactionRequestFragment :
             useSavedStateValue<ConfirmationBottomSheetResult>(RESULT_KEY) { result ->
                 if (result.isAccepted) {
                     when (result.confirmationIdentifier) {
-                        REJECT_CONFIRMATION_ID -> {
+                        FUTURE_TRANSACTION_CONFIRMATION_ID, REKEY_TRANSACTION_CONFIRMATION_ID -> {
                             confirmTransaction()
                         }
 
                         NAV_TO_SETTINGS_ID -> {
                             navToSecurityNavigation()
-                        }
-
-                        REKEY_CONFIRMATION_ID -> {
-                            confirmTransaction()
                         }
                     }
                 }
@@ -303,18 +299,18 @@ class WalletConnectTransactionRequestFragment :
             }
         } else {
             if (currentTransaction.isFutureTransaction()) {
-                showFutureTransactionConfirmationBottomSheet(currentTransaction.requestId)
+                showFutureTransactionConfirmationBottomSheet()
             } else {
                 confirmTransaction()
             }
         }
     }
 
-    private fun showFutureTransactionConfirmationBottomSheet(requestId: Long) {
+    private fun showFutureTransactionConfirmationBottomSheet() {
         val confirmationParams = ConfirmationBottomSheetParameters(
+            confirmationIdentifier = FUTURE_TRANSACTION_CONFIRMATION_ID,
             titleResId = R.string.future_transaction_detected,
-            descriptionText = getString(R.string.this_transaction_will_be),
-            confirmationIdentifier = requestId
+            descriptionText = getString(R.string.this_transaction_will_be)
         )
         nav(MainNavigationDirections.actionGlobalConfirmationBottomSheet(confirmationParams))
     }
@@ -408,7 +404,7 @@ class WalletConnectTransactionRequestFragment :
 
     private fun navToRekeyConfirmationBottomSheet() {
         val parameters = ConfirmationBottomSheetParameters(
-            confirmationIdentifier = REKEY_CONFIRMATION_ID,
+            confirmationIdentifier = REKEY_TRANSACTION_CONFIRMATION_ID,
             titleResId = R.string.are_you_sure,
             descriptionText = getString(R.string.this_signature_includes),
             iconDrawableResId = R.drawable.ic_error,
@@ -461,8 +457,8 @@ class WalletConnectTransactionRequestFragment :
     }
 
     companion object {
-        const val REJECT_CONFIRMATION_ID = 1001L
-        const val REKEY_CONFIRMATION_ID = 1002L
+        const val FUTURE_TRANSACTION_CONFIRMATION_ID = 1001L
+        const val REKEY_TRANSACTION_CONFIRMATION_ID = 1002L
         const val NAV_TO_SETTINGS_ID = 1003L
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/wctransactionrequest/WalletConnectTransactionRequestFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/wctransactionrequest/WalletConnectTransactionRequestFragment.kt
@@ -52,6 +52,7 @@ import com.algorand.android.models.WalletConnectRequest.WalletConnectTransaction
 import com.algorand.android.models.WalletConnectSignResult
 import com.algorand.android.modules.walletconnect.ui.model.WalletConnectSessionIdentifier
 import com.algorand.android.ui.common.walletconnect.WalletConnectAppPreviewCardView
+import com.algorand.android.ui.wctransactionrequest.WalletConnectTransactionRequestFragmentDirections.Companion.actionWalletConnectTransactionRequestFragmentToSecurityNavigation
 import com.algorand.android.utils.BaseDoubleButtonBottomSheet.Companion.RESULT_KEY
 import com.algorand.android.utils.Event
 import com.algorand.android.utils.Resource
@@ -66,6 +67,7 @@ import com.algorand.android.utils.startSavedStateListener
 import com.algorand.android.utils.useSavedStateValue
 import com.algorand.android.utils.viewbinding.viewBinding
 import com.algorand.android.utils.walletconnect.isFutureTransaction
+import com.algorand.android.utils.walletconnect.isRekeyTransaction
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.map
 
@@ -195,9 +197,27 @@ class WalletConnectTransactionRequestFragment :
 
     override fun onResume() {
         super.onResume()
+        initSavedStateListener()
+    }
+
+    private fun initSavedStateListener() {
         startSavedStateListener(R.id.walletConnectTransactionRequestFragment) {
             useSavedStateValue<ConfirmationBottomSheetResult>(RESULT_KEY) { result ->
-                if (result.isAccepted) confirmTransaction()
+                if (result.isAccepted) {
+                    when (result.confirmationIdentifier) {
+                        REJECT_CONFIRMATION_ID -> {
+                            confirmTransaction()
+                        }
+
+                        NAV_TO_SETTINGS_ID -> {
+                            navToSecurityNavigation()
+                        }
+
+                        REKEY_CONFIRMATION_ID -> {
+                            confirmTransaction()
+                        }
+                    }
+                }
             }
         }
     }
@@ -275,10 +295,18 @@ class WalletConnectTransactionRequestFragment :
 
     private fun onConfirmClick() {
         val currentTransaction = transactionRequestViewModel.transaction ?: return
-        if (currentTransaction.isFutureTransaction()) {
-            showFutureTransactionConfirmationBottomSheet(currentTransaction.requestId)
+        if (currentTransaction.isRekeyTransaction()) {
+            if (transactionRequestViewModel.isRekeySupportEnabled()) {
+                navToRekeyConfirmationBottomSheet()
+            } else {
+                navToEnableRekeySupportBottomSheet()
+            }
         } else {
-            confirmTransaction()
+            if (currentTransaction.isFutureTransaction()) {
+                showFutureTransactionConfirmationBottomSheet(currentTransaction.requestId)
+            } else {
+                confirmTransaction()
+            }
         }
     }
 
@@ -378,6 +406,34 @@ class WalletConnectTransactionRequestFragment :
         showGlobalError(errorMessage = errorMessage, title = title, tag = baseActivityTag)
     }
 
+    private fun navToRekeyConfirmationBottomSheet() {
+        val parameters = ConfirmationBottomSheetParameters(
+            confirmationIdentifier = REKEY_CONFIRMATION_ID,
+            titleResId = R.string.are_you_sure,
+            descriptionText = getString(R.string.this_signature_includes),
+            iconDrawableResId = R.drawable.ic_error,
+            confirmButtonTextResId = R.string.continue_text,
+            rejectButtonTextResId = R.string.cancel
+        )
+        nav(MainNavigationDirections.actionGlobalConfirmationBottomSheet(parameters))
+    }
+
+    private fun navToEnableRekeySupportBottomSheet() {
+        val parameters = ConfirmationBottomSheetParameters(
+            confirmationIdentifier = NAV_TO_SETTINGS_ID,
+            titleResId = R.string.enable_rekey_support,
+            descriptionText = getString(R.string.rekey_transactions_can_cause),
+            iconDrawableResId = R.drawable.ic_error,
+            confirmButtonTextResId = R.string.go_to_advanced_settings,
+            rejectButtonTextResId = R.string.cancel
+        )
+        nav(MainNavigationDirections.actionGlobalConfirmationBottomSheet(parameters))
+    }
+
+    private fun navToSecurityNavigation() {
+        nav(actionWalletConnectTransactionRequestFragmentToSecurityNavigation())
+    }
+
     override fun onNavigate(navDirections: NavDirections) {
         walletConnectNavController.navigateSafe(navDirections)
     }
@@ -402,5 +458,11 @@ class WalletConnectTransactionRequestFragment :
 
     override fun motionTransitionToEnd() {
         binding.transactionRequestMotionLayout.transitionToEnd()
+    }
+
+    companion object {
+        const val REJECT_CONFIRMATION_ID = 1001L
+        const val REKEY_CONFIRMATION_ID = 1002L
+        const val NAV_TO_SETTINGS_ID = 1003L
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/wctransactionrequest/WalletConnectTransactionRequestViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/wctransactionrequest/WalletConnectTransactionRequestViewModel.kt
@@ -30,6 +30,7 @@ import com.algorand.android.modules.walletconnect.domain.WalletConnectErrorProvi
 import com.algorand.android.modules.walletconnect.domain.WalletConnectManager
 import com.algorand.android.ui.wctransactionrequest.ui.model.WalletConnectTransactionRequestPreview
 import com.algorand.android.ui.wctransactionrequest.ui.usecase.WalletConnectTransactionRequestPreviewUseCase
+import com.algorand.android.usecase.SecurityUseCase
 import com.algorand.android.utils.Event
 import com.algorand.android.utils.Resource
 import com.algorand.android.utils.getOrElse
@@ -37,10 +38,10 @@ import com.algorand.android.utils.preference.getFirstWalletConnectRequestBottomS
 import com.algorand.android.utils.preference.setFirstWalletConnectRequestBottomSheetShown
 import com.algorand.android.utils.walletconnect.WalletConnectTransactionSignManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 class WalletConnectTransactionRequestViewModel @Inject constructor(
@@ -50,6 +51,7 @@ class WalletConnectTransactionRequestViewModel @Inject constructor(
     private val walletConnectSignManager: WalletConnectTransactionSignManager,
     private val transactionListBuilder: WalletConnectTransactionListBuilder,
     private val walletConnectTransactionRequestPreviewUseCase: WalletConnectTransactionRequestPreviewUseCase,
+    private val securityUseCase: SecurityUseCase,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel() {
 
@@ -157,6 +159,10 @@ class WalletConnectTransactionRequestViewModel @Inject constructor(
 
     private fun getInitialPreview(): WalletConnectTransactionRequestPreview {
         return walletConnectTransactionRequestPreviewUseCase.getInitialWalletConnectTransactionRequestPreview()
+    }
+
+    fun isRekeySupportEnabled(): Boolean {
+        return securityUseCase.isRekeySupportEnabled()
     }
 
     companion object {

--- a/app/src/main/kotlin/com/algorand/android/usecase/SecurityUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/usecase/SecurityUseCase.kt
@@ -24,6 +24,10 @@ class SecurityUseCase @Inject constructor(
         securityRepository.setBiometricRegistrationPreference(isEnabled)
     }
 
+    fun setRekeySupportPreference(isEnabled: Boolean) {
+        securityRepository.setRekeySupportPreference(isEnabled)
+    }
+
     fun setPasswordPreferencesAsDisabled() {
         encryptedPinUseCase.clearEncryptedPin()
     }
@@ -34,5 +38,9 @@ class SecurityUseCase @Inject constructor(
 
     fun isBiometricActive(): Boolean {
         return securityRepository.isBiometricActive()
+    }
+
+    fun isRekeySupportEnabled(): Boolean {
+        return securityRepository.isRekeySupportEnabled()
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/utils/walletconnect/WalletConnectUtils.kt
+++ b/app/src/main/kotlin/com/algorand/android/utils/walletconnect/WalletConnectUtils.kt
@@ -109,6 +109,12 @@ fun WalletConnectTransaction.isFutureTransaction(): Boolean {
     }
 }
 
+fun WalletConnectTransaction.isRekeyTransaction(): Boolean {
+    return transactionList.flatten().any {
+        it.getRekeyToAccountAddress() != null
+    }
+}
+
 fun String.getFallBackBrowserFromWCUrlOrNull(): String? {
     return if (contains(WALLET_CONNECT_FALLBACK_BROWSER_KEY)) {
         split(WALLET_CONNECT_FALLBACK_BROWSER_KEY)

--- a/app/src/main/res/layout/bottom_sheet_collectible_transaction_approve.xml
+++ b/app/src/main/res/layout/bottom_sheet_collectible_transaction_approve.xml
@@ -49,7 +49,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
-            android:text="@string/are_you_sure"
+            android:text="@string/are_you_sure_you_want"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/approveTransactionTextView" />

--- a/app/src/main/res/layout/custom_settings_list_item.xml
+++ b/app/src/main/res/layout/custom_settings_list_item.xml
@@ -19,7 +19,7 @@
     tools:minHeight="@dimen/settings_list_item_min_height"
     tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/settingIconImageView"
         android:layout_width="24dp"
         android:layout_height="24dp"

--- a/app/src/main/res/layout/fragment_security.xml
+++ b/app/src/main/res/layout/fragment_security.xml
@@ -26,6 +26,21 @@
         app:settingIcon="@drawable/ic_shield_check"
         app:settingTitle="@string/enable_pin_code" />
 
+    <com.algorand.android.customviews.SettingsListItem
+        android:id="@+id/enableRekeySupportListItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:endViewLayoutResource="@layout/layout_switch_view"
+        app:settingIcon="@drawable/ic_rekey"
+        app:settingTitle="@string/enable_rekey_support" />
+
+    <TextView
+        style="@style/TextAppearance.Footnote.Sans"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/once_you_enable_this"
+        android:textColor="@color/text_gray" />
+
     <TextView
         android:id="@+id/securityPreferencesTextView"
         style="@style/TextAppearance.Footnote.Description"

--- a/app/src/main/res/navigation/home_navigation.xml
+++ b/app/src/main/res/navigation/home_navigation.xml
@@ -110,6 +110,8 @@
 
     <include app:graph="@navigation/create_account_name_registration_navigation" />
 
+    <include app:graph="@navigation/security_navigation" />
+
     <action
         android:id="@+id/action_global_showQrNavigation"
         app:destination="@id/showQrNavigation">
@@ -723,11 +725,6 @@
             app:destination="@id/assetTransferAmountFragment" />
     </fragment>
 
-    <fragment
-        android:id="@+id/changePasswordFragment"
-        android:name="com.algorand.android.ui.settings.ChangePasswordFragment"
-        android:label="fragment_settings_change_password"
-        tools:layout="@layout/fragment_base_password" />
 
     <fragment
         android:id="@+id/settingsFragment"
@@ -760,33 +757,14 @@
             android:id="@+id/action_settingsFragment_to_walletConnectSessionsFragment"
             app:destination="@id/walletConnectSessionsFragment" />
         <action
-            android:id="@+id/action_settingsFragment_to_securityFragment"
-            app:destination="@id/securityFragment" />
+            android:id="@+id/action_settingsFragment_to_securityNavigation"
+            app:destination="@id/securityNavigation" />
         <action
             android:id="@+id/action_settingsFragment_to_contactsFragment"
             app:destination="@id/contactsFragment" />
         <action
             android:id="@+id/action_settingsFragment_to_asbCreationNavigation"
             app:destination="@id/asbCreationNavigation" />
-    </fragment>
-
-    <fragment
-        android:id="@+id/securityFragment"
-        android:name="com.algorand.android.ui.settings.security.SecurityFragment"
-        android:label="SecurityFragment"
-        tools:layout="@layout/fragment_security">
-        <action
-            android:id="@+id/action_securityFragment_to_changePasswordFragment"
-            app:destination="@id/changePasswordFragment" />
-        <action
-            android:id="@+id/action_securityFragment_to_disablePasswordVerificationFragment"
-            app:destination="@id/disablePasswordVerificationFragment" />
-        <action
-            android:id="@+id/action_securityFragment_to_changePasswordVerificationFragment"
-            app:destination="@id/changePasswordVerificationFragment" />
-        <action
-            android:id="@+id/action_securityFragment_to_disableBiometricAuthPasswordVerificationFragment"
-            app:destination="@id/disableBiometricAuthPasswordVerificationFragment" />
     </fragment>
 
     <fragment
@@ -1341,16 +1319,6 @@
         </action>
     </dialog>
 
-    <fragment
-        android:id="@+id/disablePasswordVerificationFragment"
-        android:name="com.algorand.android.ui.lock.DisablePasswordVerificationFragment"
-        android:label="DisablePasswordVerificationFragment" />
-
-    <fragment
-        android:id="@+id/changePasswordVerificationFragment"
-        android:name="com.algorand.android.ui.lock.ChangePasswordVerificationFragment"
-        android:label="ChangePasswordVerificationFragment" />
-
     <dialog
         android:id="@+id/collectibleTransactionApproveBottomSheet"
         android:name="com.algorand.android.nft.ui.nftapprovetransaction.CollectibleTransactionApproveBottomSheet"
@@ -1379,11 +1347,6 @@
             app:nullable="true" />
     </dialog>
 
-    <fragment
-        android:id="@+id/disableBiometricAuthPasswordVerificationFragment"
-        android:name="com.algorand.android.ui.lock.DisableBiometricAuthPasswordVerificationFragment"
-        android:label="DisableBiometricAuthPasswordVerificationFragment"
-        tools:layout="@layout/fragment_base_password" />
     <dialog
         android:id="@+id/manageAssetsBottomSheet"
         android:name="com.algorand.android.modules.assets.manage.ui.ManageAssetsBottomSheet"

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -232,6 +232,7 @@
         android:name="com.algorand.android.modules.baseledgersearch.instruction.step.openapp.ui.OpenAppOnLedgerBottomSheet"
         android:label="OpenAppOnLedgerInfoBottomSheet"
         tools:layout="@layout/bottom_sheet_ledger_pair_info" />
+    
     <dialog
         android:id="@+id/confirmationBottomSheet"
         android:name="com.algorand.android.ui.confirmation.ConfirmationBottomSheet"

--- a/app/src/main/res/navigation/security_navigation.xml
+++ b/app/src/main/res/navigation/security_navigation.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2022-2025 Pera Wallet, LDA
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~  limitations under the License
+  ~
+  -->
+
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/securityNavigation"
+    app:startDestination="@id/securityFragment">
+
+    <fragment
+        android:id="@+id/securityFragment"
+        android:name="com.algorand.android.ui.settings.security.SecurityFragment"
+        android:label="SecurityFragment"
+        tools:layout="@layout/fragment_security">
+        <action
+            android:id="@+id/action_securityFragment_to_changePasswordFragment"
+            app:destination="@id/changePasswordFragment" />
+        <action
+            android:id="@+id/action_securityFragment_to_disablePasswordVerificationFragment"
+            app:destination="@id/disablePasswordVerificationFragment" />
+        <action
+            android:id="@+id/action_securityFragment_to_changePasswordVerificationFragment"
+            app:destination="@id/changePasswordVerificationFragment" />
+        <action
+            android:id="@+id/action_securityFragment_to_disableBiometricAuthPasswordVerificationFragment"
+            app:destination="@id/disableBiometricAuthPasswordVerificationFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/changePasswordFragment"
+        android:name="com.algorand.android.ui.settings.ChangePasswordFragment"
+        android:label="fragment_settings_change_password"
+        tools:layout="@layout/fragment_base_password" />
+
+    <fragment
+        android:id="@+id/disablePasswordVerificationFragment"
+        android:name="com.algorand.android.ui.lock.DisablePasswordVerificationFragment"
+        android:label="DisablePasswordVerificationFragment" />
+
+    <fragment
+        android:id="@+id/changePasswordVerificationFragment"
+        android:name="com.algorand.android.ui.lock.ChangePasswordVerificationFragment"
+        android:label="ChangePasswordVerificationFragment" />
+
+    <fragment
+        android:id="@+id/disableBiometricAuthPasswordVerificationFragment"
+        android:name="com.algorand.android.ui.lock.DisableBiometricAuthPasswordVerificationFragment"
+        android:label="DisableBiometricAuthPasswordVerificationFragment"
+        tools:layout="@layout/fragment_base_password" />
+
+</navigation>

--- a/app/src/main/res/navigation/wallet_connect_transaction_request_navigation.xml
+++ b/app/src/main/res/navigation/wallet_connect_transaction_request_navigation.xml
@@ -27,6 +27,8 @@
 
     <include app:graph="@navigation/wallet_connect_request_launch_back_navigation" />
 
+    <include app:graph="@navigation/security_navigation" />
+
     <action
         android:id="@+id/action_walletConnectTransactionRequestNavigation_pop"
         app:popUpTo="@id/walletConnectTransactionRequestNavigation"
@@ -81,6 +83,9 @@
                 app:argType="com.algorand.android.models.WalletConnectRequest"
                 app:nullable="true" />
         </action>
+        <action
+            android:id="@+id/action_walletConnectTransactionRequestFragment_to_securityNavigation"
+            app:destination="@id/securityNavigation" />
     </fragment>
 
     <!--  Bottom Sheets  -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1558,4 +1558,7 @@
     <string name="we_will_inform_this">We will inform this device via a push notification when we launch in your country.</string>
     <string name="go_to_cards">Go to Cards</string>
     <string name="create_pera_card">Create Pera Card</string>
+
+    <string name="enable_rekey_support">Enable Rekey Support</string>
+    <string name="once_you_enable_this">Once you enable this, you can confirm transaction request to rekey your account. This will give the control of your account to another address.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -655,7 +655,7 @@
     <string name="search_or_enter_wallet_address">Search or enter wallet address</string>
     <string name="got_it">Got it!</string>
     <string name="approve_transaction">Approve Transaction</string>
-    <string name="are_you_sure">Are you sure you want to proceed?</string>
+    <string name="are_you_sure_you_want">Are you sure you want to proceed?</string>
     <string name="sender_account">Sender Account</string>
     <string name="transacting_fee">Transaction Fee</string>
     <string name="confirm_transfer">Confirm transfer</string>
@@ -1561,4 +1561,9 @@
 
     <string name="enable_rekey_support">Enable Rekey Support</string>
     <string name="once_you_enable_this">Once you enable this, you can confirm transaction request to rekey your account. This will give the control of your account to another address.</string>
+    <string name="rekey_transactions_can_cause">Rekey transactions can cause you to lose control of your account. In order to confirm this transaction, you need to enable the \"Rekey Support\" via app settings.</string>
+    <string name="go_to_advanced_settings">Go to Advanced Settings</string>
+    <string name="are_you_sure">Are you sure?</string>
+    <string name="this_signature_includes">This signature includes rekey transaction, giving control over your accounts to another address. Please make sure that you understand the implications before proceeding.</string>
+
 </resources>


### PR DESCRIPTION
# Pull Request Template

## Description
-  Block rekey transactions settings is added to the security settings page. This check is only running for wc requests with rekey transactions containing rekey. You can see the flow in the video.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2398

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
