### PR TITLE
PERA-2638 :: Execute dao operation in chunks

### DIFF
--- a/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/dao/AssetHoldingDao.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/account/info/data/database/dao/AssetHoldingDao.kt
@@ -19,6 +19,7 @@ import androidx.room.Upsert
 import com.algorand.wallet.account.info.data.database.model.AssetHoldingDto
 import com.algorand.wallet.account.info.data.database.model.AssetHoldingEntity
 import com.algorand.wallet.account.info.data.database.model.AssetStatusEntity
+import com.algorand.wallet.foundation.database.util.DaoUtils.executeChunked
 import com.algorand.wallet.foundation.database.util.DaoUtils.smartUpsert
 import java.math.BigInteger
 import kotlinx.coroutines.flow.Flow
@@ -44,7 +45,9 @@ internal interface AssetHoldingDao {
 
     @Transaction
     suspend fun insertAll(algoAddress: String, assetHoldingEntities: List<AssetHoldingEntity>) {
-        deleteAssetsNotInList(algoAddress, assetHoldingEntities.map { it.assetId })
+        executeChunked(assetHoldingEntities.map { it.assetId }) { assetIds ->
+            deleteAssetsNotInList(algoAddress, assetIds)
+        }
         smartUpsert(
             newEntities = assetHoldingEntities,
             getKey = { it.assetId },

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/foundation/database/util/DaoUtils.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/foundation/database/util/DaoUtils.kt
@@ -2,7 +2,7 @@ package com.algorand.wallet.foundation.database.util
 
 internal object DaoUtils {
 
-    private const val DEFAULT_CHUNK_SIZE = 1000
+    private const val DEFAULT_CHUNK_SIZE = 900
 
     internal suspend fun <K, T> smartUpsert(
         newEntity: T,
@@ -33,5 +33,15 @@ internal object DaoUtils {
             }
         }
         if (entitiesToUpdate.isNotEmpty()) upsert(entitiesToUpdate)
+    }
+
+    internal suspend fun <T> executeChunked(
+        items: List<T>,
+        chunkSize: Int = DEFAULT_CHUNK_SIZE,
+        action: suspend (List<T>) -> Unit
+    ) {
+        items.chunked(chunkSize).forEach { chunk ->
+            action(chunk)
+        }
     }
 }


### PR DESCRIPTION
## Description
I wasn't able to reproduce the issue with given addresses. I even tried manipulating the code, but no luck.

Crash happened because of Room query limit which is 999. Created a utility function to execute the operation in chunks, also decreased default chunk size from 1000 to 900.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2638

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
