### PR TITLE
fix: avoid 414 responses by using POST endpoint

### DIFF
--- a/common-sdk/src/main/kotlin/com/algorand/wallet/wealth/wallet/data/model/WalletChartRequest.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/wealth/wallet/data/model/WalletChartRequest.kt
@@ -10,16 +10,11 @@
  * limitations under the License
  */
 
-package com.algorand.wallet.wealth.wallet.data.api
+package com.algorand.wallet.wealth.wallet.data.model
 
-import com.algorand.wallet.wealth.wallet.data.model.WalletChartRequest
-import com.algorand.wallet.wealth.wallet.data.model.WalletChartResponseResults
-import retrofit2.http.Body
-import retrofit2.http.POST
+import com.google.gson.annotations.SerializedName
 
-internal interface WalletWealthApiService {
-    @POST("v1/wallet/wealth/")
-    suspend fun getWalletWealth(
-        @Body wealthRequest: WalletChartRequest,
-    ): WalletChartResponseResults
-}
+internal data class WalletChartRequest(
+    @SerializedName("account_addresses") val accountAddresses: List<String>,
+    @SerializedName("period") val period: String
+)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/wealth/wallet/data/repository/DefaultWalletWealthRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/wealth/wallet/data/repository/DefaultWalletWealthRepository.kt
@@ -16,6 +16,7 @@ import com.algorand.wallet.foundation.PeraResult
 import com.algorand.wallet.wealth.wallet.data.api.WalletWealthApiService
 import com.algorand.wallet.wealth.wallet.data.mapper.WalletWealthMapper
 import com.algorand.wallet.wealth.wallet.data.mapper.WalletWealthPeriodRequestMapper
+import com.algorand.wallet.wealth.wallet.data.model.WalletChartRequest
 import com.algorand.wallet.wealth.wallet.domain.model.WalletWealth
 import com.algorand.wallet.wealth.wallet.domain.model.WalletWealthPeriod
 import com.algorand.wallet.wealth.wallet.domain.repository.WalletWealthRepository
@@ -42,10 +43,10 @@ internal class DefaultWalletWealthRepository @Inject constructor(
         addresses: List<String>,
         period: WalletWealthPeriod
     ): PeraResult<WalletWealth> {
-        val results = walletWealthApiService.getWalletWealth(
-            addresses = addresses.joinToString(","),
-            period = periodRequestMapper(period)
-        )
+        val results =
+            walletWealthApiService.getWalletWealth(
+                WalletChartRequest(addresses, periodRequestMapper(period)),
+            )
         return PeraResult.Success(walletWealthMapper.map(results))
     }
 }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/wealth/wallet/data/repository/DefaultWalletWealthRepositoryTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/wealth/wallet/data/repository/DefaultWalletWealthRepositoryTest.kt
@@ -17,6 +17,7 @@ import com.algorand.wallet.foundation.PeraResult
 import com.algorand.wallet.wealth.wallet.data.api.WalletWealthApiService
 import com.algorand.wallet.wealth.wallet.data.mapper.WalletWealthMapper
 import com.algorand.wallet.wealth.wallet.data.mapper.WalletWealthPeriodRequestMapper
+import com.algorand.wallet.wealth.wallet.data.model.WalletChartRequest
 import com.algorand.wallet.wealth.wallet.data.model.WalletChartResponseResults
 import com.algorand.wallet.wealth.wallet.domain.model.WalletWealth
 import com.algorand.wallet.wealth.wallet.domain.model.WalletWealthPeriod
@@ -40,7 +41,7 @@ class DefaultWalletWealthRepositoryTest {
 
     @Test
     fun `EXPECT Error WHEN fetching wealth fails`() = runTest {
-        coEvery { walletWealthApiService.getWalletWealth(ADDRESSES_QUERY, PERIOD_QUERY) } throws Exception()
+        coEvery { walletWealthApiService.getWalletWealth(WalletChartRequest(ADDRESSES, PERIOD_QUERY)) } throws Exception()
 
         val result = sut.getWalletWealth(ADDRESSES, PERIOD)
 
@@ -49,7 +50,7 @@ class DefaultWalletWealthRepositoryTest {
 
     @Test
     fun `EXPECT mapped result WHEN fetching succeeds`() = runTest {
-        coEvery { walletWealthApiService.getWalletWealth(ADDRESSES_QUERY, PERIOD_QUERY) } returns WALLET_WEALTH_RESPONSE
+        coEvery { walletWealthApiService.getWalletWealth(WalletChartRequest(ADDRESSES, PERIOD_QUERY)) } returns WALLET_WEALTH_RESPONSE
         every { walletWealthMapper.map(WALLET_WEALTH_RESPONSE) } returns WALLET_WEALTH
 
         val result = sut.getWalletWealth(ADDRESSES, PERIOD)
@@ -63,7 +64,6 @@ class DefaultWalletWealthRepositoryTest {
         const val ADDRESS_2 = "address2"
 
         val ADDRESSES = listOf(ADDRESS_1, ADDRESS_2)
-        const val ADDRESSES_QUERY = "address1,address2"
         val PERIOD: WalletWealthPeriod = peraFixture()
         val PERIOD_QUERY: String = peraFixture()
 


### PR DESCRIPTION
# Pull Request Template

## Description
Switches the portfolio charts over to using the POST endpoint to avoid 414 Request URL To Long errors.

## Related Issues
Closes https://algorandfoundation.atlassian.net/browse/PERA-2677

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [ ] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [ ] Have you updated any relevant dependencies?

## Additional Notes
None
