### PR TITLE
PERA-2721 :: Implement swap asset in selection

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -290,6 +290,7 @@ dependencies {
     implementation libs.browser
 
     implementation libs.paging.runtime.ktx
+    implementation libs.paging.compose
 
     implementation libs.tink.android
 

--- a/app/src/main/kotlin/com/algorand/android/ui/asset/di/AssetUiModule.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/asset/di/AssetUiModule.kt
@@ -14,6 +14,10 @@ package com.algorand.android.ui.asset.di
 
 import com.algorand.android.ui.asset.detail.usecase.GetAssetLineChartData
 import com.algorand.android.ui.asset.detail.usecase.GetAssetLineChartDataUseCase
+import com.algorand.android.ui.asset.lite.usecase.GetPaginatedAssetListItems
+import com.algorand.android.ui.asset.lite.usecase.GetPaginatedAssetListItemsUseCase
+import com.algorand.android.ui.compose.widget.asset.icon.mapper.AssetIconDrawableMapper
+import com.algorand.android.ui.compose.widget.asset.icon.mapper.DefaultAssetIconDrawableMapper
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,4 +29,12 @@ internal object AssetUiModule {
 
     @Provides
     fun provideGetAssetLineChartData(useCase: GetAssetLineChartDataUseCase): GetAssetLineChartData = useCase
+
+    @Provides
+    fun provideAssetIconDrawableMapper(mapper: DefaultAssetIconDrawableMapper): AssetIconDrawableMapper = mapper
+
+    @Provides
+    fun provideGetPaginatedAssetListItems(
+        useCase: GetPaginatedAssetListItemsUseCase
+    ): GetPaginatedAssetListItems = useCase
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/asset/lite/usecase/GetPaginatedAssetListItems.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/asset/lite/usecase/GetPaginatedAssetListItems.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.asset.lite.usecase
+
+import androidx.paging.PagingData
+import com.algorand.android.ui.compose.widget.asset.AssetListItem
+import com.algorand.wallet.asset.domain.model.AssetCollectibleLiteQuery
+import kotlinx.coroutines.flow.Flow
+
+fun interface GetPaginatedAssetListItems {
+    operator fun invoke(query: AssetCollectibleLiteQuery): Flow<PagingData<AssetListItem>>
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/asset/lite/usecase/GetPaginatedAssetListItemsUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/asset/lite/usecase/GetPaginatedAssetListItemsUseCase.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.asset.lite.usecase
+
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.algorand.android.modules.currency.domain.model.Currency
+import com.algorand.android.modules.currency.domain.usecase.IsPrimaryCurrencyAlgo
+import com.algorand.android.modules.parity.domain.usecase.GetPrimaryCurrencyAssetParityValue
+import com.algorand.android.modules.parity.domain.usecase.GetSecondaryCurrencyAssetParityValue
+import com.algorand.android.modules.verificationtier.ui.decider.VerificationTierConfigurationDecider
+import com.algorand.android.ui.common.amount.AmountRenderer
+import com.algorand.android.ui.common.amount.CompactFormattedAmount
+import com.algorand.android.ui.common.amount.CompactFormattedAmount.FractionalType
+import com.algorand.android.ui.common.amount.PeraAmount
+import com.algorand.android.ui.compose.widget.asset.AssetListItem
+import com.algorand.android.ui.compose.widget.asset.icon.mapper.AssetIconDrawableMapper
+import com.algorand.wallet.asset.domain.model.AssetCollectibleLiteQuery
+import com.algorand.wallet.asset.domain.model.AssetLite
+import com.algorand.wallet.asset.domain.model.AssetLite.Type
+import com.algorand.wallet.asset.domain.usecase.GetAssetCollectibleLitesFlow
+import com.algorand.wallet.asset.domain.util.AssetConstants.ALGO_ID
+import java.math.BigDecimal
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class GetPaginatedAssetListItemsUseCase @Inject constructor(
+    private val getAssetCollectibleLitesFlow: GetAssetCollectibleLitesFlow,
+    private val verificationTierMapper: VerificationTierConfigurationDecider,
+    private val assetIconDrawableMapper: AssetIconDrawableMapper,
+    private val getPrimaryCurrencyAssetParityValue: GetPrimaryCurrencyAssetParityValue,
+    private val getSecondaryCurrencyAssetParityValue: GetSecondaryCurrencyAssetParityValue,
+    private val isPrimaryCurrencyAlgo: IsPrimaryCurrencyAlgo
+) : GetPaginatedAssetListItems {
+
+    override fun invoke(query: AssetCollectibleLiteQuery): Flow<PagingData<AssetListItem>> {
+        return getAssetCollectibleLitesFlow(query).map { pagingData ->
+            pagingData.map { assetLite ->
+                assetLite.toAssetListItem()
+            }
+        }
+    }
+
+    private fun AssetLite.toAssetListItem(): AssetListItem {
+        return AssetListItem(
+            assetId = this.assetId,
+            name = this.name,
+            unitName = this.shortName,
+            balance = getBalance(this),
+            verificationTier = verificationTierMapper.decideVerificationTierConfiguration(verificationTier),
+            assetIcon = assetIconDrawableMapper.map(this)
+        )
+    }
+
+    private fun getBalance(assetLite: AssetLite): AssetListItem.Balance {
+        return AssetListItem.Balance(
+            amount = PeraAmount(assetLite.amount, assetLite.decimal),
+            primaryAmountRenderer = getPrimaryAmountRenderer(assetLite),
+            secondaryAmountRenderer = getSecondaryAmountRenderer(assetLite),
+            usdValue = assetLite.usdValue?.let { PeraAmount(it) }
+        )
+    }
+
+    private fun getPrimaryAmountRenderer(assetLite: AssetLite): AmountRenderer {
+        return with(assetLite) {
+            val amount = PeraAmount(amount, decimal)
+            val fractionalType = if (assetLite.type is Type.Asset) FractionalType.Asset else FractionalType.Collectible
+            val formattedAmount = CompactFormattedAmount(amount, fractionalType)
+            AmountRenderer(
+                formattedAmount,
+                type = AmountRenderer.RenderType.Plain,
+                prefix = Currency.ALGO.symbol.takeIf { assetId == ALGO_ID }
+            )
+        }
+    }
+
+    private fun getSecondaryAmountRenderer(assetLite: AssetLite): AmountRenderer {
+        return with(assetLite) {
+            val safeUsdValue = usdValue ?: BigDecimal.ZERO
+            val parityValue = if (isAlgo && isPrimaryCurrencyAlgo()) {
+                getSecondaryCurrencyAssetParityValue(amount, safeUsdValue, decimal)
+            } else {
+                getPrimaryCurrencyAssetParityValue(amount, safeUsdValue, decimal)
+            }
+            val amount = PeraAmount(parityValue.amountAsCurrency)
+            val fractionalType = if (isPrimaryCurrencyAlgo()) FractionalType.Fiat else FractionalType.Asset
+            val formattedAmount = CompactFormattedAmount(amount, fractionalType)
+            AmountRenderer(
+                formattedAmount,
+                type = AmountRenderer.RenderType.Plain,
+                prefix = parityValue.selectedCurrencySymbol
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/AssetListItem.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/AssetListItem.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.asset
+
+import com.algorand.android.assetsearch.ui.model.VerificationTierConfiguration
+import com.algorand.android.ui.common.amount.AmountRenderer
+import com.algorand.android.ui.common.amount.PeraAmount
+import com.algorand.android.ui.compose.widget.asset.icon.AssetIconDrawable
+
+data class AssetListItem(
+    val assetId: Long,
+    val name: String?,
+    val unitName: String?,
+    val balance: Balance,
+    val verificationTier: VerificationTierConfiguration,
+    val assetIcon: AssetIconDrawable
+) {
+
+    data class Balance(
+        val amount: PeraAmount,
+        val usdValue: PeraAmount?,
+        val primaryAmountRenderer: AmountRenderer,
+        val secondaryAmountRenderer: AmountRenderer
+    )
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/PeraAssetListItem.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/PeraAssetListItem.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.asset
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.algorand.android.R
+import com.algorand.android.assetsearch.ui.model.VerificationTierConfiguration
+import com.algorand.android.ui.common.amount.AmountRenderer
+import com.algorand.android.ui.compose.theme.PeraTheme
+import com.algorand.android.ui.compose.widget.asset.icon.AssetIcon
+
+@Composable
+fun PeraAssetListItem(modifier: Modifier = Modifier, item: AssetListItem) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        AssetIcon(modifier = Modifier.size(40.dp), item.assetIcon)
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    AssetName(modifier = Modifier.weight(1f, false), item.name)
+                    Spacer(modifier = Modifier.width(6.dp))
+                    VerificationTierIcon(item.verificationTier)
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                PrimaryAmount(item.balance.primaryAmountRenderer)
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                AssetUnitName(modifier = Modifier.weight(1f), item.unitName)
+                Spacer(modifier = Modifier.width(12.dp))
+                SecondaryAmount(item.balance.secondaryAmountRenderer)
+            }
+        }
+    }
+}
+
+@Composable
+private fun AssetName(modifier: Modifier, name: String?) {
+    Text(
+        modifier = modifier,
+        text = name ?: stringResource(R.string.unnamed),
+        style = PeraTheme.typography.body.regular.sans,
+        color = PeraTheme.colors.text.main,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+@Composable
+private fun AssetUnitName(modifier: Modifier, unitName: String?) {
+    Text(
+        modifier = modifier,
+        text = unitName ?: stringResource(R.string.unnamed),
+        style = PeraTheme.typography.footnote.sans,
+        color = PeraTheme.colors.text.grayLighter,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+@Composable
+private fun PrimaryAmount(amountRenderer: AmountRenderer) {
+    Text(
+        text = amountRenderer.getDisplayValue(),
+        style = PeraTheme.typography.body.regular.sansBold,
+        color = PeraTheme.colors.text.main
+    )
+}
+
+@Composable
+private fun SecondaryAmount(amountRenderer: AmountRenderer) {
+    Text(
+        text = amountRenderer.getDisplayValue(),
+        style = PeraTheme.typography.footnote.sans,
+        color = PeraTheme.colors.text.gray
+    )
+}
+
+@Composable
+private fun VerificationTierIcon(verificationTier: VerificationTierConfiguration) {
+    verificationTier.drawableResId?.let { drawableResId ->
+        Image(
+            modifier = Modifier.size(16.dp),
+            imageVector = ImageVector.vectorResource(drawableResId),
+            contentDescription = null
+        )
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/PeraPagingAssetList.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/PeraPagingAssetList.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.asset
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.paging.PagingData
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.algorand.android.ui.compose.theme.PeraTheme
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+fun PeraPagingAssetList(
+    modifier: Modifier = Modifier,
+    pagingList: Flow<PagingData<AssetListItem>>,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    onAssetClick: ((AssetListItem) -> Unit)? = null
+) {
+    val assetList = pagingList.collectAsLazyPagingItems()
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = contentPadding
+    ) {
+        items(assetList.itemCount) { index ->
+            assetList[index]?.let { assetListItem ->
+                PeraAssetListItem(
+                    modifier = Modifier
+                        .padding(vertical = 16.dp)
+                        .clickable(
+                            interactionSource = null,
+                            indication = null,
+                            onClick = { onAssetClick?.invoke(assetListItem) }
+                        ),
+                    item = assetListItem
+                )
+                if (index in 0 until assetList.itemCount - 1) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(start = 56.dp),
+                        thickness = 1.dp,
+                        color = PeraTheme.colors.layer.grayLighter
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/AssetIcon.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/AssetIcon.kt
@@ -12,7 +12,7 @@
 
 @file:OptIn(ExperimentalGlideComposeApi::class)
 
-package com.algorand.android.ui.compose.widget.asset
+package com.algorand.android.ui.compose.widget.asset.icon
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.algorand.android.R
 import com.algorand.android.ui.compose.theme.PeraTheme
+import com.algorand.android.utils.PrismUrlBuilder
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.bumptech.glide.integration.compose.placeholder
@@ -46,7 +47,15 @@ private const val SIZE_PADDING_RATIO = 5f
 
 sealed interface AssetIconDrawable {
     data object AlgoDrawable : AssetIconDrawable
-    data class AssetDrawable(val url: String, val unitName: String?) : AssetIconDrawable
+    data class AssetDrawable(private val url: String, val unitName: String?) : AssetIconDrawable {
+
+        fun getImageUrl(containerWidthPx: Int): String {
+            return PrismUrlBuilder.create(url)
+                .addWidth(containerWidthPx)
+                .addQuality(PrismUrlBuilder.DEFAULT_IMAGE_QUALITY)
+                .build()
+        }
+    }
 }
 
 @Composable
@@ -75,10 +84,11 @@ private fun BoxWithConstraintsScope.AlgoIcon() {
 }
 
 @Composable
-private fun AssetDrawableIcon(drawable: AssetIconDrawable.AssetDrawable) {
+private fun BoxWithConstraintsScope.AssetDrawableIcon(drawable: AssetIconDrawable.AssetDrawable) {
     val placeholder = placeholder { AssetNameIcon(drawable.unitName) }
+    val widthAsPx = with(LocalDensity.current) { maxWidth.toPx().toInt() }
     GlideImage(
-        model = drawable.url,
+        model = drawable.getImageUrl(widthAsPx),
         contentDescription = null,
         contentScale = ContentScale.Crop,
         failure = placeholder,

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/mapper/AssetIconDrawableMapper.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/mapper/AssetIconDrawableMapper.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.asset.icon.mapper
+
+import com.algorand.android.ui.compose.widget.asset.icon.AssetIconDrawable
+import com.algorand.wallet.asset.domain.model.AssetLite
+
+interface AssetIconDrawableMapper {
+    fun map(assetLite: AssetLite): AssetIconDrawable
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/mapper/DefaultAssetIconDrawableMapper.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/mapper/DefaultAssetIconDrawableMapper.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.asset.icon.mapper
+
+import com.algorand.android.ui.compose.widget.asset.icon.AssetIconDrawable
+import com.algorand.wallet.asset.domain.model.AssetLite
+import com.algorand.wallet.asset.domain.util.AssetConstants.ALGO_ID
+import javax.inject.Inject
+
+internal class DefaultAssetIconDrawableMapper @Inject constructor() : AssetIconDrawableMapper {
+
+    override fun map(assetLite: AssetLite): AssetIconDrawable {
+        return when (assetLite.assetId) {
+            ALGO_ID -> AssetIconDrawable.AlgoDrawable
+            else -> AssetIconDrawable.AssetDrawable(assetLite.logoUrl.orEmpty(), assetLite.shortName)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/preview/PeraAssetListItemPreview.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/preview/PeraAssetListItemPreview.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.asset.preview
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.algorand.android.assetsearch.ui.model.VerificationTierConfiguration
+import com.algorand.android.modules.currency.domain.model.Currency
+import com.algorand.android.ui.common.amount.AmountRenderer
+import com.algorand.android.ui.common.amount.PeraAmount
+import com.algorand.android.ui.common.amount.SimpleFormattedAmount
+import com.algorand.android.ui.compose.theme.PeraTheme
+import com.algorand.android.ui.compose.widget.asset.AssetListItem
+import com.algorand.android.ui.compose.widget.asset.PeraAssetListItem
+import com.algorand.android.ui.compose.widget.asset.icon.AssetIconDrawable
+import java.math.BigDecimal
+
+@Preview(showBackground = true)
+@Composable
+fun PeraAssetListItemPreview(
+    @PreviewParameter(PeraAssetListItemPreviewParameterProvider::class) assetListItem: AssetListItem
+) {
+    PeraTheme {
+        PeraAssetListItem(item = assetListItem)
+    }
+}
+
+private class PeraAssetListItemPreviewParameterProvider : PreviewParameterProvider<AssetListItem> {
+
+    private val longText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do"
+
+    val assetListItem = createAssetListItem()
+
+    override val values: Sequence<AssetListItem>
+        get() = listOf(
+            assetListItem,
+            assetListItem.copy(name = longText),
+            assetListItem.copy(unitName = longText)
+        ).asSequence()
+
+    private fun createAssetListItem(): AssetListItem {
+        val primaryAmount = SimpleFormattedAmount("${Currency.ALGO.symbol}0.00")
+        val secondaryAmount = SimpleFormattedAmount("0.00")
+        return AssetListItem(
+            assetId = 12345L,
+            name = "ALGO",
+            unitName = "ALGO",
+            verificationTier = VerificationTierConfiguration.VERIFIED,
+            assetIcon = AssetIconDrawable.AlgoDrawable,
+            balance = AssetListItem.Balance(
+                amount = PeraAmount(BigDecimal.ZERO),
+                usdValue = PeraAmount(BigDecimal.ZERO),
+                primaryAmountRenderer = AmountRenderer(primaryAmount, AmountRenderer.RenderType.Plain),
+                secondaryAmountRenderer = AmountRenderer(secondaryAmount, AmountRenderer.RenderType.Plain)
+            )
+        )
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/modifier/ClickableModifier.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/modifier/ClickableModifier.kt
@@ -17,9 +17,9 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.ui.Modifier
 
 fun Modifier.clickableNoRipple(
-    onClick: () -> Unit,
     enabled: Boolean = true,
-    interactionSource: MutableInteractionSource? = null
+    interactionSource: MutableInteractionSource? = null,
+    onClick: () -> Unit
 ): Modifier {
     return this.clickable(
         onClick = onClick,

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/modifier/ClickableModifier.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/modifier/ClickableModifier.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.modifier
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.ui.Modifier
+
+fun Modifier.clickableNoRipple(
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource? = null
+): Modifier {
+    return this.clickable(
+        onClick = onClick,
+        enabled = enabled,
+        indication = null,
+        interactionSource = interactionSource
+    )
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraSlimTextField.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/PeraSlimTextField.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.algorand.android.ui.compose.widget.textfield
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.algorand.android.ui.compose.theme.PeraTheme
+
+@Composable
+fun PeraSlimTextField(
+    modifier: Modifier = Modifier,
+    text: String,
+    onTextChanged: (String) -> Unit,
+    hint: String? = null,
+    startIconContainer: @Composable (() -> Unit)? = null,
+    endIconContainer: @Composable (() -> Unit)? = null,
+    singleLine: Boolean = true,
+    enabled: Boolean = true
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+    ) {
+        val textField = text.ifEmpty { " " }
+
+        startIconContainer?.invoke()
+        Box(Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
+            if (text.isEmpty() && !hint.isNullOrBlank()) {
+                Text(
+                    text = hint,
+                    style = PeraTheme.typography.footnote.sans,
+                    color = PeraTheme.colors.text.gray,
+                    maxLines = if (singleLine) 1 else Int.MAX_VALUE
+                )
+            }
+            BasicTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = text,
+                singleLine = singleLine,
+                onValueChange = onTextChanged,
+                decorationBox = @Composable { innerTextField ->
+                    TextFieldDefaults.DecorationBox(
+                        value = textField,
+                        innerTextField = innerTextField,
+                        singleLine = singleLine,
+                        enabled = enabled,
+                        visualTransformation = VisualTransformation.None,
+                        contentPadding = PaddingValues(start = 0.dp, top = 0.dp, end = 0.dp, bottom = 0.dp),
+                        interactionSource = remember { MutableInteractionSource() },
+                        shape = RectangleShape,
+                        colors = TextFieldDefaults.colors().copy(
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            unfocusedTextColor = PeraTheme.colors.text.main,
+                            focusedTextColor = PeraTheme.colors.text.main,
+                            errorIndicatorColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            disabledIndicatorColor = Color.Transparent
+                        )
+                    )
+                }
+            )
+        }
+        endIconContainer?.invoke()
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/preview/PeraSlimTextFieldPreview.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/textfield/preview/PeraSlimTextFieldPreview.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.textfield.preview
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.algorand.android.R
+import com.algorand.android.ui.compose.widget.textfield.PeraSlimTextField
+
+@Preview(showBackground = true)
+@Composable
+fun PeraSlimTextFieldPreview() {
+
+    val longText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut"
+
+    Column {
+        PeraSlimTextField(
+            text = "Text Field Input",
+            hint = "Hint",
+            onTextChanged = {}
+        )
+
+        PreviewSeparator()
+
+        PeraSlimTextField(
+            text = "",
+            hint = "Hint",
+            onTextChanged = {}
+        )
+
+        PreviewSeparator()
+
+        PeraSlimTextField(
+            text = longText,
+            onTextChanged = {}
+        )
+
+        PreviewSeparator()
+
+        PeraSlimTextField(
+            text = "",
+            hint = longText,
+            onTextChanged = {},
+            startIconContainer = { IconPlaceholder() }
+        )
+
+        PreviewSeparator()
+
+        PeraSlimTextField(
+            text = "",
+            hint = longText,
+            onTextChanged = {},
+            endIconContainer = { IconPlaceholder() }
+        )
+
+        PreviewSeparator()
+
+        PeraSlimTextField(
+            text = "",
+            hint = longText,
+            onTextChanged = {},
+            startIconContainer = { IconPlaceholder() },
+            endIconContainer = { IconPlaceholder() }
+        )
+    }
+}
+
+@Composable
+private fun PreviewSeparator() {
+    Spacer(
+        modifier = Modifier
+            .background(color = Color.Black)
+            .height(12.dp)
+            .fillMaxWidth()
+    )
+}
+
+@Composable
+private fun IconPlaceholder() {
+    Icon(
+        modifier = Modifier.size(24.dp),
+        contentDescription = null,
+        painter = painterResource(R.drawable.ic_close)
+    )
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/assetselection/view/SwapAssetInSelectionFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/assetselection/view/SwapAssetInSelectionFragment.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.swap.assetselection.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.navArgs
+import com.algorand.android.core.BaseFragment
+import com.algorand.android.models.FragmentConfiguration
+import com.algorand.android.ui.compose.extensions.createComposeView
+import com.algorand.android.ui.compose.widget.asset.AssetListItem
+import com.algorand.android.ui.swap.assetselection.viewmodel.SwapAssetInSelectionViewModel
+import com.algorand.android.utils.setFragmentNavigationResult
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SwapAssetInSelectionFragment : BaseFragment(0), SwapAssetInSelectionScreenListener {
+
+    override val fragmentConfiguration: FragmentConfiguration = FragmentConfiguration()
+
+    private val assetInSelectionViewModel: SwapAssetInSelectionViewModel by viewModels()
+
+    private val args by navArgs<SwapAssetInSelectionFragmentArgs>()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return createComposeView {
+            SwapAssetInSelectionScreen(assetInSelectionViewModel, listener = this)
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        assetInSelectionViewModel.init(args.address)
+    }
+
+    override fun onAssetSelected(assetListItem: AssetListItem) {
+        setFragmentNavigationResult(SWAP_ASSET_IN_ID_KEY, assetListItem.assetId)
+        navBack()
+    }
+
+    override fun onBackButtonClick() {
+        navBack()
+    }
+
+    companion object {
+        const val SWAP_ASSET_IN_ID_KEY = "swapAssetInIdKey"
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/assetselection/view/SwapAssetInSelectionScreen.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/assetselection/view/SwapAssetInSelectionScreen.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.swap.assetselection.view
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.algorand.android.R
+import com.algorand.android.ui.compose.widget.PeraToolbar
+import com.algorand.android.ui.compose.widget.PeraToolbarIcon
+import com.algorand.android.ui.compose.widget.asset.AssetListItem
+import com.algorand.android.ui.compose.widget.asset.PeraPagingAssetList
+import com.algorand.android.ui.compose.widget.modifier.clickableNoRipple
+import com.algorand.android.ui.swap.assetselection.viewmodel.SwapAssetInSelectionViewModel
+import com.algorand.android.ui.swap.assetselection.viewmodel.SwapAssetInSelectionViewModel.ViewState.Content
+import com.algorand.android.ui.swap.assetselection.viewmodel.SwapAssetInSelectionViewModel.ViewState.Idle
+
+@Composable
+fun SwapAssetInSelectionScreen(viewModel: SwapAssetInSelectionViewModel, listener: SwapAssetInSelectionScreenListener) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        val viewState = viewModel.state.collectAsStateWithLifecycle().value
+
+        PeraToolbar(
+            text = stringResource(R.string.swap_from),
+            startContainer = {
+                PeraToolbarIcon(
+                    iconResId = R.drawable.ic_left_arrow,
+                    modifier = Modifier.clickableNoRipple(listener::onBackButtonClick)
+                )
+            }
+        )
+        when (viewState) {
+            Idle -> Unit
+            is Content -> PeraPagingAssetList(
+                modifier = Modifier.padding(horizontal = 24.dp),
+                contentPadding = PaddingValues(vertical = 16.dp),
+                pagingList = viewState.assetList,
+                onAssetClick = listener::onAssetSelected
+            )
+        }
+    }
+}
+
+interface SwapAssetInSelectionScreenListener {
+    fun onAssetSelected(assetListItem: AssetListItem)
+    fun onBackButtonClick()
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/assetselection/view/SwapAssetInSelectionScreen.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/assetselection/view/SwapAssetInSelectionScreen.kt
@@ -12,21 +12,35 @@
 
 package com.algorand.android.ui.swap.assetselection.view
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.algorand.android.R
+import com.algorand.android.ui.compose.theme.PeraTheme
 import com.algorand.android.ui.compose.widget.PeraToolbar
 import com.algorand.android.ui.compose.widget.PeraToolbarIcon
 import com.algorand.android.ui.compose.widget.asset.AssetListItem
 import com.algorand.android.ui.compose.widget.asset.PeraPagingAssetList
 import com.algorand.android.ui.compose.widget.modifier.clickableNoRipple
+import com.algorand.android.ui.compose.widget.textfield.PeraSlimTextField
 import com.algorand.android.ui.swap.assetselection.viewmodel.SwapAssetInSelectionViewModel
 import com.algorand.android.ui.swap.assetselection.viewmodel.SwapAssetInSelectionViewModel.ViewState.Content
 import com.algorand.android.ui.swap.assetselection.viewmodel.SwapAssetInSelectionViewModel.ViewState.Idle
@@ -41,10 +55,48 @@ fun SwapAssetInSelectionScreen(viewModel: SwapAssetInSelectionViewModel, listene
             startContainer = {
                 PeraToolbarIcon(
                     iconResId = R.drawable.ic_left_arrow,
-                    modifier = Modifier.clickableNoRipple(listener::onBackButtonClick)
+                    modifier = Modifier.clickableNoRipple(onClick = listener::onBackButtonClick)
                 )
             }
         )
+
+        var searchKeyword by remember { mutableStateOf("") }
+
+        LaunchedEffect(searchKeyword) {
+            viewModel.updateQuery(searchKeyword)
+        }
+
+        PeraSlimTextField(
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+                .background(color = PeraTheme.colors.layer.grayLighter, RoundedCornerShape(4.dp)),
+            text = searchKeyword,
+            hint = stringResource(R.string.search_assets_id),
+            onTextChanged = { searchKeyword = it },
+            startIconContainer = {
+                Icon(
+                    modifier = Modifier.size(24.dp),
+                    painter = painterResource(R.drawable.ic_search),
+                    tint = PeraTheme.colors.text.gray,
+                    contentDescription = null
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+            },
+            endIconContainer = {
+                if (searchKeyword.isNotEmpty()) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Icon(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .clickableNoRipple { searchKeyword = "" },
+                        painter = painterResource(R.drawable.ic_close),
+                        tint = PeraTheme.colors.text.gray,
+                        contentDescription = null
+                    )
+                }
+            }
+        )
+
         when (viewState) {
             Idle -> Unit
             is Content -> PeraPagingAssetList(

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/assetselection/viewmodel/SwapAssetInSelectionViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/assetselection/viewmodel/SwapAssetInSelectionViewModel.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+@file:OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+
+package com.algorand.android.ui.swap.assetselection.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import com.algorand.android.ui.asset.lite.usecase.GetPaginatedAssetListItems
+import com.algorand.android.ui.compose.widget.asset.AssetListItem
+import com.algorand.android.ui.swap.assetselection.viewmodel.SwapAssetInSelectionViewModel.ViewState
+import com.algorand.wallet.asset.domain.model.AssetCollectibleLiteQuery
+import com.algorand.wallet.asset.domain.model.AssetCollectibleLiteQueryFilter.FilterOutZeroAmount
+import com.algorand.wallet.asset.domain.model.AssetCollectibleLiteQueryFilter.SearchKeyword
+import com.algorand.wallet.asset.domain.model.AssetCollectibleLiteSortType.NameAscending
+import com.algorand.wallet.viewmodel.StateDelegate
+import com.algorand.wallet.viewmodel.StateViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+
+@HiltViewModel
+class SwapAssetInSelectionViewModel @Inject constructor(
+    private val stateDelegate: StateDelegate<ViewState>,
+    private val getPaginatedAssetListItems: GetPaginatedAssetListItems
+) : ViewModel(), StateViewModel<ViewState> {
+
+    init {
+        stateDelegate.setDefaultState(ViewState.Idle)
+    }
+
+    private val queryFlow = MutableStateFlow<String>("")
+    private val addressFlow = MutableStateFlow<String?>(null)
+
+    private val assetPagingItems: Flow<PagingData<AssetListItem>> =
+        combine(addressFlow.filterNotNull(), queryFlow) { address, query ->
+            AssetCollectibleLiteQuery(
+                address,
+                sortType = NameAscending,
+                filters = listOf(FilterOutZeroAmount, SearchKeyword(query))
+            )
+        }.flatMapLatest { assetQuery ->
+            getPaginatedAssetListItems(assetQuery)
+        }.cachedIn(viewModelScope)
+
+    override val state: StateFlow<ViewState>
+        get() = stateDelegate.state
+
+    fun init(address: String) {
+        stateDelegate.onState<ViewState.Idle> {
+            addressFlow.value = address
+            stateDelegate.updateState { ViewState.Content(assetPagingItems) }
+        }
+    }
+
+    fun updateQuery(query: String) {
+        queryFlow.value = query
+    }
+
+    sealed interface ViewState {
+        data object Idle : ViewState
+        data class Content(val assetList: Flow<PagingData<AssetListItem>>) : ViewState
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/view/SwapFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/view/SwapFragment.kt
@@ -19,10 +19,10 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import com.algorand.android.core.BaseFragment
 import com.algorand.android.models.FragmentConfiguration
-import com.algorand.android.modules.swap.assetselection.fromasset.ui.SwapFromAssetSelectionFragment.Companion.SWAP_FROM_ASSET_ID_KEY
 import com.algorand.android.modules.swap.assetselection.toasset.ui.SwapToAssetSelectionFragment.Companion.SWAP_TO_ASSET_ID_KEY
 import com.algorand.android.ui.compose.extensions.createComposeView
 import com.algorand.android.ui.compose.theme.PeraTheme
+import com.algorand.android.ui.swap.assetselection.view.SwapAssetInSelectionFragment.Companion.SWAP_ASSET_IN_ID_KEY
 import com.algorand.android.ui.swap.viewmodel.SwapViewModel
 import com.algorand.android.utils.useFragmentResultListenerValue
 import dagger.hilt.android.AndroidEntryPoint
@@ -48,7 +48,7 @@ class SwapFragment : BaseFragment(0), SwapScreenListener {
     }
 
     private fun initSavedStateListener() {
-        useFragmentResultListenerValue<Long>(SWAP_FROM_ASSET_ID_KEY) { assetId ->
+        useFragmentResultListenerValue<Long>(SWAP_ASSET_IN_ID_KEY) { assetId ->
             swapViewModel.setAssetInId(assetId)
         }
         useFragmentResultListenerValue<Long>(SWAP_TO_ASSET_ID_KEY) { assetId ->
@@ -69,7 +69,7 @@ class SwapFragment : BaseFragment(0), SwapScreenListener {
     }
 
     override fun onAssetInChipClick() {
-        // TODO
+        nav(SwapFragmentDirections.actionSwapFragmentToSwapAssetInSelectionFragment(swapViewModel.addressFlow.value!!))
     }
 
     override fun onAssetOutChipClick() {

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/widget/view/SwapAssetSelectionChipButton.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/widget/view/SwapAssetSelectionChipButton.kt
@@ -33,12 +33,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.algorand.android.R
 import com.algorand.android.ui.compose.theme.PeraTheme
-import com.algorand.android.ui.compose.widget.asset.AssetIcon
-import com.algorand.android.ui.compose.widget.asset.AssetIconDrawable.AlgoDrawable
-import com.algorand.android.ui.compose.widget.asset.AssetIconDrawable.AssetDrawable
+import com.algorand.android.ui.compose.widget.asset.icon.AssetIcon
+import com.algorand.android.ui.compose.widget.asset.icon.AssetIconDrawable.AlgoDrawable
+import com.algorand.android.ui.compose.widget.asset.icon.AssetIconDrawable.AssetDrawable
 import com.algorand.android.ui.swap.widget.viewmodel.SwapAssetSelectionViewModel.ViewState
 import com.algorand.wallet.asset.domain.util.AssetConstants.ALGO_ID
 import com.algorand.wallet.swap.domain.model.SwapSelectedAssetDetail
+
+private const val MAX_UNIT_NAME_LENGTH = 6
 
 @Composable
 fun SwapAssetSelectionChipButton(viewState: ViewState, backgroundColor: Color, onClick: () -> Unit) {
@@ -72,7 +74,7 @@ private fun AssetContent(assetDetail: SwapSelectedAssetDetail) {
     )
     Spacer(modifier = Modifier.width(6.dp))
     Text(
-        text = assetDetail.unitName.orEmpty(),
+        text = assetDetail.unitName?.take(MAX_UNIT_NAME_LENGTH).orEmpty(),
         style = PeraTheme.typography.body.regular.sans,
         color = PeraTheme.colors.text.main
     )

--- a/app/src/main/res/navigation/home_navigation.xml
+++ b/app/src/main/res/navigation/home_navigation.xml
@@ -1551,6 +1551,23 @@
         android:id="@+id/inviteFriendsBottomSheet"
         android:name="com.algorand.android.ui.invite.view.InviteFriendsBottomSheet"
         android:label="InviteFriendsBottomSheet" />
+    <fragment
+        android:id="@+id/swapFragment"
+        android:name="com.algorand.android.ui.swap.view.SwapFragment"
+        android:label="SwapFragment">
+        <action
+            android:id="@+id/action_swapFragment_to_swapAssetInSelectionFragment"
+            app:destination="@id/swapAssetInSelectionFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/swapAssetInSelectionFragment"
+        android:name="com.algorand.android.ui.swap.assetselection.view.SwapAssetInSelectionFragment"
+        android:label="SwapAssetInSelectionFragment">
+
+        <argument
+            android:name="address"
+            app:argType="string" />
+    </fragment>
 
 
 </navigation>

--- a/app/src/test/kotlin/com/algorand/android/ui/compose/widget/asset/icon/mapper/DefaultAssetIconDrawableMapperTest.kt
+++ b/app/src/test/kotlin/com/algorand/android/ui/compose/widget/asset/icon/mapper/DefaultAssetIconDrawableMapperTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.asset.icon.mapper
+
+import com.algorand.android.ui.compose.widget.asset.icon.AssetIconDrawable
+import com.algorand.test.peraFixture
+import com.algorand.wallet.asset.domain.model.AssetLite
+import com.algorand.wallet.asset.domain.util.AssetConstants.ALGO_ID
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class DefaultAssetIconDrawableMapperTest {
+
+    private val sut = DefaultAssetIconDrawableMapper()
+
+    @Test
+    fun `EXPECT ALGO drawable WHEN asset lite is ALGO`() {
+        val assetLite = peraFixture<AssetLite>().copy(assetId = ALGO_ID)
+
+        val result = sut.map(assetLite)
+
+        assertEquals(AssetIconDrawable.AlgoDrawable, result)
+    }
+
+    @Test
+    fun `EXPECT ASSET drawable WHEN asset lite is not ALGO`() {
+        val assetLite = peraFixture<AssetLite>().copy(
+            assetId = 123L,
+            shortName = "unit name",
+            type = AssetLite.Type.Asset(logoUrl = "logo url")
+        )
+
+        val result = sut.map(assetLite)
+
+        val expected = AssetIconDrawable.AssetDrawable(url = "logo url", unitName = "unit name")
+        assertEquals(expected, result)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -166,6 +166,7 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit
 # Database / ORM
 datastore-preferences = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastore" }
 paging-runtime-ktx = { module = "androidx.paging:paging-runtime-ktx", version.ref = "paging" }
+paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }
 sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
 room-gradle-plugin = { module = "androidx.room:room-gradle-plugin", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }


### PR DESCRIPTION
## Description
I created `AssetListItem` model to make paginated asset listing reusable. Our pagination resource returns `AssetLite` and new usecase maps it to `AssetListItem` which has all the necessary fields like formatted primary amount, secondary amount, verification tier etc.

I also created `PeraAssetListItem` and `PeraPagingAssetList` composables. We can use list item composable separately, or we can paging composable directly.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2721

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?
    - Added paging composable dependency


https://github.com/user-attachments/assets/45f2caa5-3bb7-4925-bf86-898450009aa6

