### PR TITLE
Pera 2465 :: Add missing nav graphs to fix navigation crash

### DIFF
--- a/app/src/main/res/navigation/discover_detail_navigation.xml
+++ b/app/src/main/res/navigation/discover_detail_navigation.xml
@@ -16,6 +16,8 @@
     android:id="@+id/discoverDetailNavigation"
     app:startDestination="@id/discoverDetailFragment">
 
+    <include app:graph="@navigation/discover_dapp_navigation" />
+
     <fragment
         android:id="@+id/discoverDetailFragment"
         android:name="com.algorand.android.discover.detail.ui.DiscoverDetailFragment"

--- a/app/src/main/res/navigation/home_navigation.xml
+++ b/app/src/main/res/navigation/home_navigation.xml
@@ -110,6 +110,8 @@
 
     <include app:graph="@navigation/security_navigation" />
 
+    <include app:graph="@navigation/discover_url_viewer_navigation" />
+
     <action
         android:id="@+id/action_global_showQrNavigation"
         app:destination="@id/showQrNavigation">
@@ -1577,7 +1579,7 @@
     <fragment
         android:id="@+id/swapAssetOutSelectionFragment"
         android:name="com.algorand.android.ui.swap.assetselection.view.SwapAssetOutSelectionFragment"
-        android:label="SwapAssetOutSelectionFragment" >
+        android:label="SwapAssetOutSelectionFragment">
         <argument
             android:name="address"
             app:argType="string" />


### PR DESCRIPTION
# Pull Request Template

## Description
- Add missing nav graphs to fix navigation crash. According to the report crash is happening while opening discover dapp and discover url viewer fragments.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2465

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
