### PR TITLE
PERA-2656 :: Make path parameter optional for discover deeplinks

### DIFF
--- a/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/builder/DiscoverPathNewDeepLinkBuilder.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/deeplink/builder/DiscoverPathNewDeepLinkBuilder.kt
@@ -18,8 +18,6 @@ import com.algorand.wallet.deeplink.model.DeepLinkPayload
 internal class DiscoverPathNewDeepLinkBuilder : NewDeepLinkBuilder {
 
     override fun createDeepLink(payload: DeepLinkPayload): DeepLink? {
-        return payload.path?.let {
-            DeepLink.Discover(it)
-        }
+        return DeepLink.Discover(payload.path.orEmpty())
     }
 }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/deeplink/builder/DiscoverPathNewDeepLinkBuilderTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/deeplink/builder/DiscoverPathNewDeepLinkBuilderTest.kt
@@ -15,7 +15,6 @@ package com.algorand.wallet.deeplink.builder
 import com.algorand.wallet.deeplink.model.DeepLink
 import com.algorand.wallet.deeplink.model.DeepLinkPayload
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 class DiscoverPathNewDeepLinkBuilderTest {
@@ -38,6 +37,7 @@ class DiscoverPathNewDeepLinkBuilderTest {
 
         val result = sut.createDeepLink(payload)
 
-        assertNull(result)
+        val expected = DeepLink.Discover("")
+        assertEquals(expected, result)
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
- Now path parameter is optional for discover deeplinks. You can find test QR's in the  excell.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2656

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
