### PR TITLE
PERA-2873 :: Use v2 endpoint to create quotes and update swap status

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/swap/confirmation/viewmodel/SwapConfirmationViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/confirmation/viewmodel/SwapConfirmationViewModel.kt
@@ -22,7 +22,6 @@ import com.algorand.android.modules.accountcore.ui.model.AccountDisplayName
 import com.algorand.android.modules.accounticon.ui.model.AccountIconDrawablePreview
 import com.algorand.android.modules.swap.confirmswap.domain.SwapTransactionSignManager
 import com.algorand.android.modules.swap.confirmswap.domain.model.SwapQuoteTransaction
-import com.algorand.android.modules.swap.confirmswap.domain.usecase.CreateSwapQuoteTransactionsUseCase
 import com.algorand.android.modules.swap.ledger.signwithledger.ui.model.LedgerDialogPayload
 import com.algorand.android.modules.swap.transactionstatus.domain.SendSwapTransactionsManager
 import com.algorand.android.modules.transaction.signmanager.ExternalTransactionSignResult
@@ -44,9 +43,14 @@ import com.algorand.android.ui.swap.confirmation.viewmodel.SwapConfirmationViewM
 import com.algorand.android.ui.swap.confirmation.viewmodel.SwapConfirmationViewModel.ViewState
 import com.algorand.android.ui.swap.confirmation.viewmodel.SwapConfirmationViewModel.ViewState.Content.ContentState
 import com.algorand.android.ui.swap.confirmation.viewmodel.SwapConfirmationViewModel.ViewState.Idle
-import com.algorand.android.utils.DataResource
+import com.algorand.android.ui.swap.domain.model.SwapQuoteTransactions
+import com.algorand.android.ui.swap.domain.usecase.CreateSwapV2QuoteTransactions
 import com.algorand.wallet.swap.domain.model.SwapQuoteV2
+import com.algorand.wallet.swap.domain.model.SwapStatusFailureReason.OTHER
+import com.algorand.wallet.swap.domain.model.SwapStatusFailureReason.USER_CANCELLED
 import com.algorand.wallet.swap.domain.usecase.SetLastUsedSwapAddress
+import com.algorand.wallet.swap.domain.usecase.SetSwapStatusFailed
+import com.algorand.wallet.swap.domain.usecase.SetSwapStatusInProgress
 import com.algorand.wallet.viewmodel.EventDelegate
 import com.algorand.wallet.viewmodel.EventViewModel
 import com.algorand.wallet.viewmodel.StateDelegate
@@ -62,10 +66,12 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class SwapConfirmationViewModel @Inject constructor(
     private val contentMapper: SwapConfirmationContentMapper,
-    private val createSwapQuoteTransactions: CreateSwapQuoteTransactionsUseCase,
     private val swapTransactionSignManager: SwapTransactionSignManager,
     private val sendSwapTransactionsManager: SendSwapTransactionsManager,
     private val setLastUsedSwapAddress: SetLastUsedSwapAddress,
+    private val setSwapStatusInProgress: SetSwapStatusInProgress,
+    private val setSwapStatusFailed: SetSwapStatusFailed,
+    private val createSwapV2QuoteTransactions: CreateSwapV2QuoteTransactions,
     private val stateDelegate: StateDelegate<ViewState>,
     private val eventDelegate: EventDelegate<ViewEvent>
 ) : ViewModel(), StateViewModel<ViewState> by stateDelegate, EventViewModel<ViewEvent> by eventDelegate {
@@ -95,8 +101,10 @@ class SwapConfirmationViewModel @Inject constructor(
             confirmTransactionJob = viewModelScope.launch {
                 val quoteId = contentState.quote.quoteId
                 val accountAddress = contentState.quote.accountAddress
-                createSwapQuoteTransactions.createQuoteTransactions(quoteId, accountAddress)
-                    .useSuspended(onSuccess = ::signTransactions, onFailed = ::displayFailedToCreateTxnError)
+                createSwapV2QuoteTransactions(quoteId, accountAddress).use(
+                    onSuccess = ::signTransactions,
+                    onFailed = ::displayFailedToCreateTxnError
+                )
             }
         }
     }
@@ -109,21 +117,31 @@ class SwapConfirmationViewModel @Inject constructor(
         swapTransactionSignManager.stopAllResources()
     }
 
-    private suspend fun signTransactions(transactions: List<SwapQuoteTransaction>) {
-        swapTransactionSignManager.signSwapQuoteTransaction(transactions)
+    private suspend fun signTransactions(transactions: SwapQuoteTransactions) {
+        swapTransactionSignManager.signSwapQuoteTransaction(transactions.transactions)
         swapTransactionSignManager.swapTransactionSignResultFlow.collectLatest { result ->
             when (result) {
-                is Success<*> -> sendSignTransactions(result)
-                LedgerScanFailed -> displayLedgerNotFoundDialog()
+                is Success<*> -> sendSignTransactions(transactions, result)
+                LedgerScanFailed -> {
+                    setSwapStatusFailed(transactions.swapId, USER_CANCELLED)
+                    displayLedgerNotFoundDialog()
+                }
                 is LedgerWaitingForApproval -> displayLedgerWaitingForApprovalDialog(result)
                 Loading -> stateDelegate.onState<ViewState.Content> { contentState ->
                     if (contentState.contentState != ContentState.Loading) {
                         stateDelegate.updateState { contentState.copy(contentState = ContentState.Loading) }
                     }
                 }
-                is ExternalTransactionSignResult.Error.Api -> displayError(Api(result.errorMessage))
-                is ExternalTransactionSignResult.Error.Defined -> displayError(Local(result.description))
+                is ExternalTransactionSignResult.Error.Api -> {
+                    setSwapStatusFailed(transactions.swapId, USER_CANCELLED)
+                    displayError(Api(result.errorMessage))
+                }
+                is ExternalTransactionSignResult.Error.Defined -> {
+                    setSwapStatusFailed(transactions.swapId, USER_CANCELLED)
+                    displayError(Local(result.description))
+                }
                 is TransactionCancelled -> {
+                    setSwapStatusFailed(transactions.swapId, USER_CANCELLED)
                     val error = (result.error as? ExternalTransactionSignResult.Error.Defined)?.description
                     val errorType = if (error != null) Local(error) else Generic
                     displayError(errorType)
@@ -138,13 +156,14 @@ class SwapConfirmationViewModel @Inject constructor(
         eventDelegate.sendEvent(DisplayError(errorType))
     }
 
-    private suspend fun sendSignTransactions(result: Success<*>) {
+    private suspend fun sendSignTransactions(transactions: SwapQuoteTransactions, result: Success<*>) {
         stateDelegate.onState<ViewState.Content> { content ->
             val signedTxns = result.signedTransaction as? List<SwapQuoteTransaction>
             if (signedTxns != null) {
                 sendSwapTransactionsManager.sendSwapTransactions(
                     signedTransactions = signedTxns.toMutableList(),
                     onSendTransactionsSuccess = {
+                        setSwapStatusInProgress(transactions.swapId)
                         setLastUsedSwapAddress(content.accountDisplayName.accountAddress)
                         displaySuccessState(content)
                         val assetInShortName = content.quote.assetInDetail.shortName.orEmpty()
@@ -152,6 +171,7 @@ class SwapConfirmationViewModel @Inject constructor(
                         eventDelegate.sendEvent(ViewEvent.NavigateToSwapScreen(assetInShortName, assetOutShortName))
                     },
                     onSendTransactionsFailed = {
+                        setSwapStatusFailed(transactions.swapId, OTHER)
                         displayErrorState()
                         eventDelegate.sendEvent(DisplayError(Generic))
                     }
@@ -163,9 +183,9 @@ class SwapConfirmationViewModel @Inject constructor(
         }
     }
 
-    private suspend fun displayFailedToCreateTxnError(error: DataResource.Error<List<SwapQuoteTransaction>>) {
+    private suspend fun displayFailedToCreateTxnError(exception: Exception, code: Int?) {
         displayErrorState()
-        val errorType = if (error.exception is IOException) {
+        val errorType = if (exception is IOException) {
             Local(AnnotatedString(R.string.the_internet_connection))
         } else {
             Generic

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/data/network/SwapQuoteTransactionsApiService.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/data/network/SwapQuoteTransactionsApiService.kt
@@ -10,13 +10,17 @@
  * limitations under the License
  */
 
-package com.algorand.android.modules.swap.confirmswap.data.model
+package com.algorand.android.ui.swap.data.network
 
-import com.google.gson.annotations.SerializedName
+import com.algorand.android.modules.swap.confirmswap.data.model.CreateSwapQuoteTransactionsRequestBody
+import com.algorand.android.modules.swap.confirmswap.data.model.CreateSwapQuoteTransactionsResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
 
-data class CreateSwapQuoteTransactionsResponse(
-    @SerializedName("transaction_groups")
-    val transactionGroups: List<SwapQuoteTransactionResponse>?,
-    @SerializedName("swap_id")
-    val swapId: Long?
-)
+internal interface SwapQuoteTransactionsApiService {
+
+    @POST("v2/dex-swap/prepare-transactions/")
+    suspend fun getQuoteTransactions(
+        @Body requestBody: CreateSwapQuoteTransactionsRequestBody
+    ): CreateSwapQuoteTransactionsResponse
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/data/repository/DefaultSwapQuoteTransactionsRepository.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/data/repository/DefaultSwapQuoteTransactionsRepository.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.swap.data.repository
+
+import com.algorand.android.modules.swap.confirmswap.data.mapper.SwapQuoteTransactionDTOMapper
+import com.algorand.android.modules.swap.confirmswap.data.model.CreateSwapQuoteTransactionsRequestBody
+import com.algorand.android.modules.swap.confirmswap.data.model.CreateSwapQuoteTransactionsResponse
+import com.algorand.android.ui.swap.data.network.SwapQuoteTransactionsApiService
+import com.algorand.android.ui.swap.domain.model.SwapQuoteTransactionsDto
+import com.algorand.android.ui.swap.domain.repository.SwapQuoteTransactionsRepository
+import com.algorand.wallet.foundation.PeraResult
+import javax.inject.Inject
+
+internal class DefaultSwapQuoteTransactionsRepository @Inject constructor(
+    private val swapQuoteTransactionsApiService: SwapQuoteTransactionsApiService,
+    private val swapQuoteTransactionDTOMapper: SwapQuoteTransactionDTOMapper,
+) : SwapQuoteTransactionsRepository {
+
+    override suspend fun createQuoteTransactions(quoteId: Long): PeraResult<SwapQuoteTransactionsDto> {
+        return try {
+            val requestBody = CreateSwapQuoteTransactionsRequestBody(quoteId)
+            val transactionsResponse = swapQuoteTransactionsApiService.getQuoteTransactions(requestBody)
+            getSwapQuoteTransactionsResult(transactionsResponse)
+        } catch (e: Exception) {
+            PeraResult.Error(e)
+        }
+    }
+
+    private fun getSwapQuoteTransactionsResult(
+        response: CreateSwapQuoteTransactionsResponse
+    ): PeraResult<SwapQuoteTransactionsDto> {
+        val txns = response.transactionGroups?.map { swapQuoteTransactionDTOMapper.mapToSwapQuoteTransactionDTO(it) }
+        return if (txns == null || txns.isEmpty() || response.swapId == null) {
+            PeraResult.Error(IllegalStateException())
+        } else {
+            PeraResult.Success(SwapQuoteTransactionsDto(txns, response.swapId))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/di/SwapQuoteTransactionsModule.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/di/SwapQuoteTransactionsModule.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.swap.di
+
+import com.algorand.android.ui.swap.data.network.SwapQuoteTransactionsApiService
+import com.algorand.android.ui.swap.data.repository.DefaultSwapQuoteTransactionsRepository
+import com.algorand.android.ui.swap.domain.repository.SwapQuoteTransactionsRepository
+import com.algorand.android.ui.swap.domain.usecase.CreateSwapV2QuoteTransactions
+import com.algorand.android.ui.swap.domain.usecase.CreateSwapV2QuoteTransactionsUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import javax.inject.Named
+import retrofit2.Retrofit
+
+@Module
+@InstallIn(ViewModelComponent::class)
+internal object SwapQuoteTransactionsModule {
+
+    @Provides
+    fun provideSwapQuoteTransactionsRepository(
+        repository: DefaultSwapQuoteTransactionsRepository
+    ): SwapQuoteTransactionsRepository = repository
+
+    @Provides
+    fun provideSwapQuoteTransactionsApiService(
+        @Named("mobileAlgorandRetrofitInterface") retrofit: Retrofit
+    ): SwapQuoteTransactionsApiService {
+        return retrofit.create(SwapQuoteTransactionsApiService::class.java)
+    }
+
+    @Provides
+    fun provideCreateSwapV2QuoteTransactions(
+        useCase: CreateSwapV2QuoteTransactionsUseCase
+    ): CreateSwapV2QuoteTransactions = useCase
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/domain/model/SwapQuoteTransactions.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/domain/model/SwapQuoteTransactions.kt
@@ -10,13 +10,11 @@
  * limitations under the License
  */
 
-package com.algorand.android.modules.swap.confirmswap.data.model
+package com.algorand.android.ui.swap.domain.model
 
-import com.google.gson.annotations.SerializedName
+import com.algorand.android.modules.swap.confirmswap.domain.model.SwapQuoteTransaction
 
-data class CreateSwapQuoteTransactionsResponse(
-    @SerializedName("transaction_groups")
-    val transactionGroups: List<SwapQuoteTransactionResponse>?,
-    @SerializedName("swap_id")
-    val swapId: Long?
+data class SwapQuoteTransactions(
+    val transactions: List<SwapQuoteTransaction>,
+    val swapId: Long
 )

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/domain/model/SwapQuoteTransactionsDto.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/domain/model/SwapQuoteTransactionsDto.kt
@@ -10,13 +10,11 @@
  * limitations under the License
  */
 
-package com.algorand.android.modules.swap.confirmswap.data.model
+package com.algorand.android.ui.swap.domain.model
 
-import com.google.gson.annotations.SerializedName
+import com.algorand.android.modules.swap.confirmswap.domain.model.SwapQuoteTransactionDTO
 
-data class CreateSwapQuoteTransactionsResponse(
-    @SerializedName("transaction_groups")
-    val transactionGroups: List<SwapQuoteTransactionResponse>?,
-    @SerializedName("swap_id")
-    val swapId: Long?
+data class SwapQuoteTransactionsDto(
+    val transactions: List<SwapQuoteTransactionDTO>,
+    val swapId: Long
 )

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/domain/repository/SwapQuoteTransactionsRepository.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/domain/repository/SwapQuoteTransactionsRepository.kt
@@ -10,13 +10,11 @@
  * limitations under the License
  */
 
-package com.algorand.android.modules.swap.confirmswap.data.model
+package com.algorand.android.ui.swap.domain.repository
 
-import com.google.gson.annotations.SerializedName
+import com.algorand.android.ui.swap.domain.model.SwapQuoteTransactionsDto
+import com.algorand.wallet.foundation.PeraResult
 
-data class CreateSwapQuoteTransactionsResponse(
-    @SerializedName("transaction_groups")
-    val transactionGroups: List<SwapQuoteTransactionResponse>?,
-    @SerializedName("swap_id")
-    val swapId: Long?
-)
+internal interface SwapQuoteTransactionsRepository {
+    suspend fun createQuoteTransactions(quoteId: Long): PeraResult<SwapQuoteTransactionsDto>
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/domain/usecase/CreateSwapV2QuoteTransactions.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/domain/usecase/CreateSwapV2QuoteTransactions.kt
@@ -10,13 +10,11 @@
  * limitations under the License
  */
 
-package com.algorand.android.modules.swap.confirmswap.data.model
+package com.algorand.android.ui.swap.domain.usecase
 
-import com.google.gson.annotations.SerializedName
+import com.algorand.android.ui.swap.domain.model.SwapQuoteTransactions
+import com.algorand.wallet.foundation.PeraResult
 
-data class CreateSwapQuoteTransactionsResponse(
-    @SerializedName("transaction_groups")
-    val transactionGroups: List<SwapQuoteTransactionResponse>?,
-    @SerializedName("swap_id")
-    val swapId: Long?
-)
+fun interface CreateSwapV2QuoteTransactions {
+    suspend operator fun invoke(quoteId: Long, accountAddress: String): PeraResult<SwapQuoteTransactions>
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/domain/usecase/CreateSwapV2QuoteTransactionsUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/domain/usecase/CreateSwapV2QuoteTransactionsUseCase.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.swap.domain.usecase
+
+import com.algorand.android.modules.algosdk.domain.usecase.ParseTransactionMsgPackUseCase
+import com.algorand.android.modules.swap.confirmswap.domain.factory.SwapTransactionItemFactory
+import com.algorand.android.modules.swap.confirmswap.domain.mapper.SignedSwapSingleTransactionDataMapper
+import com.algorand.android.modules.swap.confirmswap.domain.mapper.UnsignedSwapSingleTransactionDataMapper
+import com.algorand.android.modules.swap.confirmswap.domain.model.SignedSwapSingleTransactionData
+import com.algorand.android.modules.swap.confirmswap.domain.model.SwapQuoteTransactionDTO
+import com.algorand.android.modules.swap.confirmswap.domain.model.UnsignedSwapSingleTransactionData
+import com.algorand.android.ui.swap.domain.model.SwapQuoteTransactions
+import com.algorand.android.ui.swap.domain.model.SwapQuoteTransactionsDto
+import com.algorand.android.ui.swap.domain.repository.SwapQuoteTransactionsRepository
+import com.algorand.android.usecase.NetworkSlugUseCase
+import com.algorand.android.utils.decodeBase64
+import com.algorand.wallet.account.info.domain.usecase.GetAccountRekeyAdminAddress
+import com.algorand.wallet.foundation.PeraResult
+import javax.inject.Inject
+
+internal class CreateSwapV2QuoteTransactionsUseCase @Inject constructor(
+    private val swapQuoteTransactionsRepository: SwapQuoteTransactionsRepository,
+    private val unsignedSwapQuoteTransactionMapper: UnsignedSwapSingleTransactionDataMapper,
+    private val signedSwapQuoteTransactionMapper: SignedSwapSingleTransactionDataMapper,
+    private val swapTransactionItemFactory: SwapTransactionItemFactory,
+    private val networkSlugUseCase: NetworkSlugUseCase,
+    private val parseTransactionMsgPackUseCase: ParseTransactionMsgPackUseCase,
+    private val getAccountRekeyAdminAddress: GetAccountRekeyAdminAddress
+) : CreateSwapV2QuoteTransactions {
+
+    override suspend fun invoke(quoteId: Long, accountAddress: String): PeraResult<SwapQuoteTransactions> {
+        return swapQuoteTransactionsRepository.createQuoteTransactions(quoteId).use(
+            onSuccess = { txns ->
+                val swapQuoteTransactions = createSwapQuoteTransactions(accountAddress, txns)
+                PeraResult.Success(swapQuoteTransactions)
+            },
+            onFailed = { exception, _ ->
+                PeraResult.Error(exception)
+            }
+        )
+    }
+
+    private suspend fun createSwapQuoteTransactions(
+        accountAddress: String,
+        transactionsDto: SwapQuoteTransactionsDto
+    ): SwapQuoteTransactions {
+        val transactions = transactionsDto.transactions.mapIndexed { parentListIndex, swapQuoteTransactionDTO ->
+            val signedSingleTransactions = createSingleSignedTransactions(swapQuoteTransactionDTO, parentListIndex)
+            val unsignedSingleTransactions = createUnsignedSingleTransactions(
+                swapQuoteTransactionDTO = swapQuoteTransactionDTO,
+                parentListIndex = parentListIndex,
+                accountAddress = accountAddress
+            )
+            swapTransactionItemFactory.createTransaction(
+                purpose = swapQuoteTransactionDTO.purpose,
+                transactionGroupId = swapQuoteTransactionDTO.transactionGroupId,
+                unsignedTransactions = unsignedSingleTransactions,
+                signedTransactions = signedSingleTransactions,
+                transactionNetworkSlug = networkSlugUseCase.getActiveNodeSlug().orEmpty()
+            )
+        }
+        return SwapQuoteTransactions(transactions, transactionsDto.swapId)
+    }
+
+    private fun createSingleSignedTransactions(
+        swapQuoteTransactionDTO: SwapQuoteTransactionDTO,
+        parentListIndex: Int
+    ): MutableList<SignedSwapSingleTransactionData> {
+        return swapQuoteTransactionDTO.signedTransactions
+            ?.mapIndexed { index, signedTransaction ->
+                signedSwapQuoteTransactionMapper.mapToSignedSwapSingleTransactionData(
+                    parentListIndex = parentListIndex,
+                    transactionListIndex = index,
+                    signedTransactionMsgPack = signedTransaction?.decodeBase64()
+                )
+            }.orEmpty().toMutableList()
+    }
+
+    private suspend fun createUnsignedSingleTransactions(
+        swapQuoteTransactionDTO: SwapQuoteTransactionDTO,
+        parentListIndex: Int,
+        accountAddress: String
+    ): List<UnsignedSwapSingleTransactionData> {
+        return swapQuoteTransactionDTO.transactions
+            ?.mapIndexed { index, unsignedTransaction ->
+                unsignedSwapQuoteTransactionMapper.mapToUnsignedSwapSingleTransactionData(
+                    parentListIndex = parentListIndex,
+                    transactionListIndex = index,
+                    transactionMsgPack = unsignedTransaction,
+                    accountAddress = accountAddress,
+                    accountAuthAddress = getAccountRekeyAdminAddress(accountAddress),
+                    rawTransaction = unsignedTransaction?.decodeBase64()
+                        ?.run { parseTransactionMsgPackUseCase.parse(this) }
+                )
+            }.orEmpty()
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/DefaultSwapQuoteRequestBodyMapper.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/DefaultSwapQuoteRequestBodyMapper.kt
@@ -15,13 +15,12 @@ package com.algorand.wallet.swap.data.mapper
 import com.algorand.wallet.asset.domain.util.getSafeAssetIdForRequest
 import com.algorand.wallet.swap.data.model.SwapQuoteRequestBody
 import com.algorand.wallet.swap.data.model.SwapTypeResponse
-import com.algorand.wallet.swap.domain.model.SwapQuoteProvider
 import com.algorand.wallet.swap.domain.model.SwapQuoteRequestPayload
 import javax.inject.Inject
 
 internal class DefaultSwapQuoteRequestBodyMapper @Inject constructor() : SwapQuoteRequestBodyMapper {
 
-    override fun invoke(payload: SwapQuoteRequestPayload, providers: List<SwapQuoteProvider>): SwapQuoteRequestBody {
+    override fun invoke(payload: SwapQuoteRequestPayload): SwapQuoteRequestBody {
         return with(payload) {
             SwapQuoteRequestBody(
                 swapperAddress = address,
@@ -30,7 +29,6 @@ internal class DefaultSwapQuoteRequestBodyMapper @Inject constructor() : SwapQuo
                 assetOutId = getSafeAssetIdForRequest(assetOutId),
                 amount = amount,
                 slippage = slippage,
-                providers = providers.map { it.name },
                 swapType = SwapTypeResponse.FIXED_INPUT
             )
         }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/DefaultSwapUpdateStatusRequestBodyMapper.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/DefaultSwapUpdateStatusRequestBodyMapper.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.swap.data.mapper
+
+import com.algorand.wallet.swap.data.model.SwapStatusFailureReasonResponse
+import com.algorand.wallet.swap.data.model.SwapStatusResponse
+import com.algorand.wallet.swap.data.model.SwapUpdateStatusRequestBody
+import com.algorand.wallet.swap.domain.model.SwapStatusFailureReason
+import javax.inject.Inject
+
+internal class DefaultSwapUpdateStatusRequestBodyMapper @Inject constructor() : SwapUpdateStatusRequestBodyMapper {
+
+    override fun mapToInProgress(submittedTxnIds: List<String>): SwapUpdateStatusRequestBody {
+        return SwapUpdateStatusRequestBody(
+            status = SwapStatusResponse.IN_PROGRESS,
+            submittedTransactionIds = submittedTxnIds
+        )
+    }
+
+    override fun mapToFailed(reason: SwapStatusFailureReason): SwapUpdateStatusRequestBody {
+        return SwapUpdateStatusRequestBody(
+            status = SwapStatusResponse.FAILED,
+            reason = getFailureReasonResponse(reason)
+        )
+    }
+
+    private fun getFailureReasonResponse(reason: SwapStatusFailureReason): SwapStatusFailureReasonResponse {
+        return when (reason) {
+            SwapStatusFailureReason.OTHER -> SwapStatusFailureReasonResponse.OTHER
+            SwapStatusFailureReason.USER_CANCELLED -> SwapStatusFailureReasonResponse.USER_CANCELLED
+            SwapStatusFailureReason.INVALID_SUBMISSION -> SwapStatusFailureReasonResponse.INVALID_SUBMISSION
+            SwapStatusFailureReason.BLOCKCHAIN_ERROR -> SwapStatusFailureReasonResponse.BLOCKCHAIN_ERROR
+        }
+    }
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/DefaultSwapUpdateStatusRequestBodyMapper.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/DefaultSwapUpdateStatusRequestBodyMapper.kt
@@ -20,11 +20,8 @@ import javax.inject.Inject
 
 internal class DefaultSwapUpdateStatusRequestBodyMapper @Inject constructor() : SwapUpdateStatusRequestBodyMapper {
 
-    override fun mapToInProgress(submittedTxnIds: List<String>): SwapUpdateStatusRequestBody {
-        return SwapUpdateStatusRequestBody(
-            status = SwapStatusResponse.IN_PROGRESS,
-            submittedTransactionIds = submittedTxnIds
-        )
+    override fun mapToInProgress(): SwapUpdateStatusRequestBody {
+        return SwapUpdateStatusRequestBody(status = SwapStatusResponse.IN_PROGRESS)
     }
 
     override fun mapToFailed(reason: SwapStatusFailureReason): SwapUpdateStatusRequestBody {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/SwapMappers.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/SwapMappers.kt
@@ -41,7 +41,7 @@ internal fun interface SwapQuoteMapper {
 }
 
 internal fun interface SwapQuoteRequestBodyMapper {
-    operator fun invoke(payload: SwapQuoteRequestPayload, providers: List<SwapQuoteProvider>): SwapQuoteRequestBody
+    operator fun invoke(payload: SwapQuoteRequestPayload): SwapQuoteRequestBody
 }
 
 internal fun interface SwapQuoteTransactionMapper {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/SwapMappers.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/SwapMappers.kt
@@ -93,6 +93,6 @@ internal fun interface SwapPairHistoryMapper {
 }
 
 internal interface SwapUpdateStatusRequestBodyMapper {
-    fun mapToInProgress(submittedTxnIds: List<String>): SwapUpdateStatusRequestBody
+    fun mapToInProgress(): SwapUpdateStatusRequestBody
     fun mapToFailed(reason: SwapStatusFailureReason): SwapUpdateStatusRequestBody
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/SwapMappers.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/mapper/SwapMappers.kt
@@ -23,6 +23,7 @@ import com.algorand.wallet.swap.data.model.SwapQuoteResponse
 import com.algorand.wallet.swap.data.model.SwapQuoteTransactionResponse
 import com.algorand.wallet.swap.data.model.SwapSelectedAssetDto
 import com.algorand.wallet.swap.data.model.SwapTransactionPurposeResponse
+import com.algorand.wallet.swap.data.model.SwapUpdateStatusRequestBody
 import com.algorand.wallet.swap.data.model.TopSwapPairsResponse
 import com.algorand.wallet.swap.domain.model.AvailableSwapAsset
 import com.algorand.wallet.swap.domain.model.SwapHistory
@@ -33,6 +34,7 @@ import com.algorand.wallet.swap.domain.model.SwapQuoteRequestPayload
 import com.algorand.wallet.swap.domain.model.SwapQuoteTransaction
 import com.algorand.wallet.swap.domain.model.SwapQuoteV2
 import com.algorand.wallet.swap.domain.model.SwapSelectedAssetDetail
+import com.algorand.wallet.swap.domain.model.SwapStatusFailureReason
 import com.algorand.wallet.swap.domain.model.SwapTransactionPurpose
 import com.algorand.wallet.swap.domain.model.TopSwapPairs
 
@@ -88,4 +90,9 @@ internal interface SwapHistoryStatusMapper {
 
 internal fun interface SwapPairHistoryMapper {
     operator fun invoke(response: SwapPairHistoryResponse): SwapPairHistory?
+}
+
+internal interface SwapUpdateStatusRequestBodyMapper {
+    fun mapToInProgress(submittedTxnIds: List<String>): SwapUpdateStatusRequestBody
+    fun mapToFailed(reason: SwapStatusFailureReason): SwapUpdateStatusRequestBody
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapQuoteRequestBody.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapQuoteRequestBody.kt
@@ -16,8 +16,6 @@ import com.google.gson.annotations.SerializedName
 import java.math.BigInteger
 
 internal data class SwapQuoteRequestBody(
-    @SerializedName("providers")
-    val providers: List<String>,
     @SerializedName("swapper_address")
     val swapperAddress: String,
     @SerializedName("swap_type")

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapStatusFailureReasonResponse.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapStatusFailureReasonResponse.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.swap.data.model
+
+import com.google.gson.annotations.SerializedName
+
+internal enum class SwapStatusFailureReasonResponse {
+    @SerializedName("other")
+    OTHER,
+
+    @SerializedName("user_cancelled")
+    USER_CANCELLED,
+
+    @SerializedName("invalid_submission")
+    INVALID_SUBMISSION,
+
+    @SerializedName("blockchain_error")
+    BLOCKCHAIN_ERROR
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapStatusResponse.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapStatusResponse.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.swap.data.model
+
+import com.google.gson.annotations.SerializedName
+
+internal enum class SwapStatusResponse {
+    @SerializedName("pending")
+    PENDING,
+    @SerializedName("in_progress")
+    IN_PROGRESS,
+    @SerializedName("completed")
+    COMPLETED,
+    @SerializedName("failed")
+    FAILED
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapUpdateStatusRequestBody.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapUpdateStatusRequestBody.kt
@@ -17,16 +17,8 @@ import com.google.gson.annotations.SerializedName
 internal data class SwapUpdateStatusRequestBody(
     @SerializedName("status")
     val status: SwapStatusResponse,
-    @SerializedName("submitted_transaction_ids")
-    val submittedTransactionIds: List<String>? = null,
     @SerializedName("reason")
     val reason: SwapStatusFailureReasonResponse? = null,
-    @SerializedName("app_version")
-    val appVersion: String? = null,
-    @SerializedName("platform")
-    val platform: String? = null,
-    @SerializedName("country_code")
-    val countryCode: String? = null,
     @SerializedName("swap_version")
     val swapVersion: String = "v2"
 )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapUpdateStatusRequestBody.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapUpdateStatusRequestBody.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.swap.data.model
+
+import com.google.gson.annotations.SerializedName
+
+internal data class SwapUpdateStatusRequestBody(
+    @SerializedName("status")
+    val status: SwapStatusResponse,
+    @SerializedName("submitted_transaction_ids")
+    val submittedTransactionIds: List<String>? = null,
+    @SerializedName("reason")
+    val reason: SwapStatusFailureReasonResponse? = null,
+    @SerializedName("app_version")
+    val appVersion: String? = null,
+    @SerializedName("platform")
+    val platform: String? = null,
+    @SerializedName("country_code")
+    val countryCode: String? = null,
+    @SerializedName("swap_version")
+    val swapVersion: String = "v2"
+)

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepository.kt
@@ -82,9 +82,9 @@ internal class DefaultSwapRepository @Inject constructor(
         }
     }
 
-    override suspend fun setSwapStatusInProgress(quoteId: Long, submittedTxnIds: List<String>) {
+    override suspend fun setSwapStatusInProgress(quoteId: Long) {
         try {
-            val body = swapUpdateStatusRequestBodyMapper.mapToInProgress(submittedTxnIds)
+            val body = swapUpdateStatusRequestBodyMapper.mapToInProgress()
             swapApiService.updateSwapStatus(quoteId, body)
         } catch (e: Exception) {
             // Fire and forget request, no need to handle the exception

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepository.kt
@@ -53,7 +53,7 @@ internal class DefaultSwapRepository @Inject constructor(
     override suspend fun getSwapQuotes(payload: SwapQuoteRequestPayload): PeraResult<List<SwapQuoteV2>> {
         return try {
             val providers = getSwapQuoteProviders().getDataOrNull() ?: return PeraResult.Error(Exception())
-            val response = swapApiService.getSwapQuote(quoteRequestMapper(payload, providers))
+            val response = swapApiService.getSwapQuote(quoteRequestMapper(payload))
             val quotes = response.swapQuoteResponseList.mapNotNull { quoteMapper(it, providers) }
             if (quotes.isEmpty()) PeraResult.Error(Exception()) else PeraResult.Success(quotes)
         } catch (exception: Exception) {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepository.kt
@@ -21,10 +21,10 @@ import com.algorand.wallet.swap.data.mapper.SwapQuoteMapper
 import com.algorand.wallet.swap.data.mapper.SwapQuoteProviderMapper
 import com.algorand.wallet.swap.data.mapper.SwapQuoteRequestBodyMapper
 import com.algorand.wallet.swap.data.mapper.SwapQuoteTransactionMapper
+import com.algorand.wallet.swap.data.mapper.SwapUpdateStatusRequestBodyMapper
 import com.algorand.wallet.swap.data.mapper.TopSwapPairsMapper
 import com.algorand.wallet.swap.data.model.CreateSwapQuoteTransactionsRequestBody
 import com.algorand.wallet.swap.data.model.SwapPeraFeeRequestBody
-import com.algorand.wallet.swap.data.model.SwapQuoteExceptionRequestBody
 import com.algorand.wallet.swap.data.service.SwapApiService
 import com.algorand.wallet.swap.domain.model.AvailableSwapAsset
 import com.algorand.wallet.swap.domain.model.SwapPeraFee
@@ -32,6 +32,7 @@ import com.algorand.wallet.swap.domain.model.SwapQuoteProvider
 import com.algorand.wallet.swap.domain.model.SwapQuoteRequestPayload
 import com.algorand.wallet.swap.domain.model.SwapQuoteTransaction
 import com.algorand.wallet.swap.domain.model.SwapQuoteV2
+import com.algorand.wallet.swap.domain.model.SwapStatusFailureReason
 import com.algorand.wallet.swap.domain.model.TopSwapPairs
 import com.algorand.wallet.swap.domain.repository.SwapRepository
 import java.math.BigInteger
@@ -47,6 +48,7 @@ internal class DefaultSwapRepository @Inject constructor(
     private val availableSwapAssetMapper: AvailableSwapAssetMapper,
     private val providersCache: InMemoryCachedObject<List<SwapQuoteProvider>>,
     private val topSwapPairsMapper: TopSwapPairsMapper,
+    private val swapUpdateStatusRequestBodyMapper: SwapUpdateStatusRequestBodyMapper,
     private val useLocalCurrencyCache: PersistentCache<Boolean>,
 ) : SwapRepository {
 
@@ -80,10 +82,20 @@ internal class DefaultSwapRepository @Inject constructor(
         }
     }
 
-    override suspend fun updateSwapQuoteException(quoteId: Long, exceptionText: String) {
+    override suspend fun setSwapStatusInProgress(quoteId: Long, submittedTxnIds: List<String>) {
         try {
-            swapApiService.updateSwapQuoteException(quoteId, SwapQuoteExceptionRequestBody(exceptionText))
-        } catch (_: Exception) {
+            val body = swapUpdateStatusRequestBodyMapper.mapToInProgress(submittedTxnIds)
+            swapApiService.updateSwapStatus(quoteId, body)
+        } catch (e: Exception) {
+            // Fire and forget request, no need to handle the exception
+        }
+    }
+
+    override suspend fun setSwapStatusFailed(quoteId: Long, reason: SwapStatusFailureReason) {
+        try {
+            val body = swapUpdateStatusRequestBodyMapper.mapToFailed(reason)
+            swapApiService.updateSwapStatus(quoteId, body)
+        } catch (e: Exception) {
             // Fire and forget request, no need to handle the exception
         }
     }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/service/SwapApiService.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/service/SwapApiService.kt
@@ -40,13 +40,13 @@ internal interface SwapApiService {
         @Query("q") query: String?
     ): AvailableSwapAssetListResponse
 
-    @POST("v1/dex-swap/quotes/")
+    @POST("v2/dex-swap/quotes/")
     suspend fun getSwapQuote(@Body requestBody: SwapQuoteRequestBody): SwapQuoteResultResponse
 
     @POST("v1/dex-swap/calculate-pera-fee/")
     suspend fun getPeraFee(@Body requestBody: SwapPeraFeeRequestBody): SwapPeraFeeResponse
 
-    @POST("v1/dex-swap/prepare-transactions/")
+    @POST("v2/dex-swap/prepare-transactions/")
     suspend fun getQuoteTransactions(
         @Body requestBody: CreateSwapQuoteTransactionsRequestBody
     ): CreateSwapQuoteTransactionsResponse

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/service/SwapApiService.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/service/SwapApiService.kt
@@ -19,10 +19,10 @@ import com.algorand.wallet.swap.data.model.SwapHistoriesResponse
 import com.algorand.wallet.swap.data.model.SwapPairHistoriesResponse
 import com.algorand.wallet.swap.data.model.SwapPeraFeeRequestBody
 import com.algorand.wallet.swap.data.model.SwapPeraFeeResponse
-import com.algorand.wallet.swap.data.model.SwapQuoteExceptionRequestBody
 import com.algorand.wallet.swap.data.model.SwapQuoteProvidersResponse
 import com.algorand.wallet.swap.data.model.SwapQuoteRequestBody
 import com.algorand.wallet.swap.data.model.SwapQuoteResultResponse
+import com.algorand.wallet.swap.data.model.SwapUpdateStatusRequestBody
 import com.algorand.wallet.swap.data.model.TopSwapPairsResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -51,10 +51,10 @@ internal interface SwapApiService {
         @Body requestBody: CreateSwapQuoteTransactionsRequestBody
     ): CreateSwapQuoteTransactionsResponse
 
-    @PATCH("v1/dex-swap/quotes/{quote_id}/")
-    suspend fun updateSwapQuoteException(
-        @Path("quote_id") quoteId: Long,
-        @Body swapQuoteExceptionRequestBody: SwapQuoteExceptionRequestBody
+    @PATCH("v2/dex-swap/swaps/{swap_id}/")
+    suspend fun updateSwapStatus(
+        @Path("swap_id") quoteId: Long,
+        @Body swapUpdateStatusRequestBody: SwapUpdateStatusRequestBody
     )
 
     @GET("v2/dex-swap/providers/")

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/di/SwapModule.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/di/SwapModule.kt
@@ -31,6 +31,7 @@ import com.algorand.wallet.swap.data.mapper.DefaultSwapQuoteRequestBodyMapper
 import com.algorand.wallet.swap.data.mapper.DefaultSwapQuoteTransactionMapper
 import com.algorand.wallet.swap.data.mapper.DefaultSwapSelectedAssetDetailMapper
 import com.algorand.wallet.swap.data.mapper.DefaultSwapTransactionPurposeMapper
+import com.algorand.wallet.swap.data.mapper.DefaultSwapUpdateStatusRequestBodyMapper
 import com.algorand.wallet.swap.data.mapper.DefaultTopSwapPairsMapper
 import com.algorand.wallet.swap.data.mapper.SwapAssetAmountMapper
 import com.algorand.wallet.swap.data.mapper.SwapAssetDetailMapper
@@ -43,6 +44,7 @@ import com.algorand.wallet.swap.data.mapper.SwapQuoteRequestBodyMapper
 import com.algorand.wallet.swap.data.mapper.SwapQuoteTransactionMapper
 import com.algorand.wallet.swap.data.mapper.SwapSelectedAssetDetailMapper
 import com.algorand.wallet.swap.data.mapper.SwapTransactionPurposeMapper
+import com.algorand.wallet.swap.data.mapper.SwapUpdateStatusRequestBodyMapper
 import com.algorand.wallet.swap.data.mapper.TopSwapPairsMapper
 import com.algorand.wallet.swap.data.repository.DefaultSwapHistoryPagingSource
 import com.algorand.wallet.swap.data.repository.DefaultSwapHistoryRepository
@@ -72,6 +74,8 @@ import com.algorand.wallet.swap.domain.usecase.GetSwapQuotesUseCase
 import com.algorand.wallet.swap.domain.usecase.GetSwapUseLocalCurrencyPreference
 import com.algorand.wallet.swap.domain.usecase.GetTopSwapPairs
 import com.algorand.wallet.swap.domain.usecase.SetLastUsedSwapAddress
+import com.algorand.wallet.swap.domain.usecase.SetSwapStatusFailed
+import com.algorand.wallet.swap.domain.usecase.SetSwapStatusInProgress
 import com.algorand.wallet.swap.domain.usecase.SetSwapUseLocalCurrencyPreference
 import com.algorand.wallet.utils.date.parser.ISO8601DateTimeParser
 import dagger.Module
@@ -97,7 +101,8 @@ internal object SwapModule {
         availableSwapAssetMapper: AvailableSwapAssetMapper,
         swapQuoteProviderMapper: SwapQuoteProviderMapper,
         inMemoryCacheProvider: InMemoryCacheProvider,
-        topSwapPairsMapper: TopSwapPairsMapper
+        topSwapPairsMapper: TopSwapPairsMapper,
+        swapUpdateStatusRequestBodyMapper: SwapUpdateStatusRequestBodyMapper
     ): SwapRepository {
         return DefaultSwapRepository(
             swapApiService = swapApiService,
@@ -112,6 +117,7 @@ internal object SwapModule {
             availableSwapAssetMapper = availableSwapAssetMapper,
             providersCache = inMemoryCacheProvider.getInMemoryCache(),
             topSwapPairsMapper = topSwapPairsMapper,
+            swapUpdateStatusRequestBodyMapper = swapUpdateStatusRequestBodyMapper,
             useLocalCurrencyCache = persistentCacheProvider.getPersistentCache<Boolean>(
                 type = Boolean::class.java,
                 key = "swap_use_local_currency_preference",
@@ -252,5 +258,20 @@ internal object SwapModule {
     @Provides
     fun provideSetSwapUseLocalCurrencyPreference(repository: SwapRepository): SetSwapUseLocalCurrencyPreference {
         return SetSwapUseLocalCurrencyPreference(repository::setUseLocalCurrencyPreference)
+    }
+
+    @Provides
+    fun provideSwapUpdateStatusRequestBodyMapper(
+        mapper: DefaultSwapUpdateStatusRequestBodyMapper
+    ): SwapUpdateStatusRequestBodyMapper = mapper
+
+    @Provides
+    fun provideSetSwapStatusFailed(repository: SwapRepository): SetSwapStatusFailed {
+        return SetSwapStatusFailed(repository::setSwapStatusFailed)
+    }
+
+    @Provides
+    fun provideSetSwapStatusInProgress(repository: SwapRepository): SetSwapStatusInProgress {
+        return SetSwapStatusInProgress(repository::setSwapStatusInProgress)
     }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/model/SwapStatusFailureReason.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/model/SwapStatusFailureReason.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.wallet.swap.domain.model
+
+enum class SwapStatusFailureReason {
+    OTHER,
+    USER_CANCELLED,
+    INVALID_SUBMISSION,
+    BLOCKCHAIN_ERROR
+}

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/repository/SwapRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/repository/SwapRepository.kt
@@ -33,5 +33,5 @@ internal interface SwapRepository {
     suspend fun getUseLocalCurrencyPreference(): Boolean
     suspend fun setUseLocalCurrencyPreference(useLocalCurrency: Boolean)
     suspend fun setSwapStatusFailed(quoteId: Long, reason: SwapStatusFailureReason)
-    suspend fun setSwapStatusInProgress(quoteId: Long, submittedTxnIds: List<String>)
+    suspend fun setSwapStatusInProgress(quoteId: Long)
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/repository/SwapRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/repository/SwapRepository.kt
@@ -18,6 +18,7 @@ import com.algorand.wallet.swap.domain.model.SwapPeraFee
 import com.algorand.wallet.swap.domain.model.SwapQuoteRequestPayload
 import com.algorand.wallet.swap.domain.model.SwapQuoteTransaction
 import com.algorand.wallet.swap.domain.model.SwapQuoteV2
+import com.algorand.wallet.swap.domain.model.SwapStatusFailureReason
 import com.algorand.wallet.swap.domain.model.TopSwapPairs
 import java.math.BigInteger
 
@@ -27,9 +28,10 @@ internal interface SwapRepository {
     suspend fun getSwapQuotes(payload: SwapQuoteRequestPayload): PeraResult<List<SwapQuoteV2>>
     suspend fun getPeraFee(assetInId: Long, amount: BigInteger): PeraResult<SwapPeraFee>
     suspend fun createQuoteTransactions(quoteId: Long): PeraResult<List<SwapQuoteTransaction>>
-    suspend fun updateSwapQuoteException(quoteId: Long, exceptionText: String)
     suspend fun getAvailableAssetsToSwap(assetInId: Long, query: String?): PeraResult<List<AvailableSwapAsset>>
     suspend fun getTopSwapPairs(): PeraResult<TopSwapPairs>
     suspend fun getUseLocalCurrencyPreference(): Boolean
     suspend fun setUseLocalCurrencyPreference(useLocalCurrency: Boolean)
+    suspend fun setSwapStatusFailed(quoteId: Long, reason: SwapStatusFailureReason)
+    suspend fun setSwapStatusInProgress(quoteId: Long, submittedTxnIds: List<String>)
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/usecase/SwapUseCases.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/usecase/SwapUseCases.kt
@@ -25,6 +25,7 @@ import com.algorand.wallet.swap.domain.model.SwapQuotePayload
 import com.algorand.wallet.swap.domain.model.SwapQuoteV2
 import com.algorand.wallet.swap.domain.model.SwapQuotes
 import com.algorand.wallet.swap.domain.model.SwapSelectedAssetDetail
+import com.algorand.wallet.swap.domain.model.SwapStatusFailureReason
 import com.algorand.wallet.swap.domain.model.TopSwapPairs
 import java.math.BigDecimal
 import kotlinx.coroutines.flow.Flow
@@ -79,4 +80,12 @@ fun interface GetSwapUseLocalCurrencyPreference {
 
 fun interface SetSwapUseLocalCurrencyPreference {
     suspend operator fun invoke(useLocalCurrency: Boolean)
+}
+
+fun interface SetSwapStatusInProgress {
+    suspend operator fun invoke(quoteId: Long, submittedTxnIds: List<String>)
+}
+
+fun interface SetSwapStatusFailed {
+    suspend operator fun invoke(quoteId: Long, reason: SwapStatusFailureReason)
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/usecase/SwapUseCases.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/usecase/SwapUseCases.kt
@@ -83,7 +83,7 @@ fun interface SetSwapUseLocalCurrencyPreference {
 }
 
 fun interface SetSwapStatusInProgress {
-    suspend operator fun invoke(quoteId: Long, submittedTxnIds: List<String>)
+    suspend operator fun invoke(quoteId: Long)
 }
 
 fun interface SetSwapStatusFailed {

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/swap/data/mapper/DefaultSwapQuoteRequestBodyMapperTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/swap/data/mapper/DefaultSwapQuoteRequestBodyMapperTest.kt
@@ -12,10 +12,8 @@
 
 package com.algorand.wallet.swap.data.mapper
 
-import com.algorand.test.peraFixture
 import com.algorand.wallet.swap.data.model.SwapQuoteRequestBody
 import com.algorand.wallet.swap.data.model.SwapTypeResponse
-import com.algorand.wallet.swap.domain.model.SwapQuoteProvider
 import com.algorand.wallet.swap.domain.model.SwapQuoteRequestPayload
 import java.math.BigInteger
 import org.junit.Assert.assertEquals
@@ -27,7 +25,7 @@ class DefaultSwapQuoteRequestBodyMapperTest {
 
     @Test
     fun `EXPECT mapped request body`() {
-        val result = sut(PAYLOAD, PROVIDERS)
+        val result = sut(PAYLOAD)
 
         assertEquals(REQUEST_BODY, result)
     }
@@ -36,7 +34,7 @@ class DefaultSwapQuoteRequestBodyMapperTest {
     fun `EXPECT asset in id to be zero WHEN asset in is ALGO`() {
         val payload = PAYLOAD.copy(assetInId = -7)
 
-        val result = sut(payload, PROVIDERS)
+        val result = sut(payload)
 
         val expected = REQUEST_BODY.copy(assetInId = 0L)
         assertEquals(expected, result)
@@ -46,17 +44,13 @@ class DefaultSwapQuoteRequestBodyMapperTest {
     fun `EXPECT asset out id to be zero WHEN asset out is ALGO`() {
         val payload = PAYLOAD.copy(assetOutId = -7)
 
-        val result = sut(payload, PROVIDERS)
+        val result = sut(payload)
 
         val expected = REQUEST_BODY.copy(assetOutId = 0L)
         assertEquals(expected, result)
     }
 
     private companion object {
-        val PROVIDER_1 = peraFixture<SwapQuoteProvider>().copy(name = "provider1")
-        val PROVIDER_2 = peraFixture<SwapQuoteProvider>().copy(name = "provider2")
-        val PROVIDERS = listOf(PROVIDER_1, PROVIDER_2)
-
         val PAYLOAD = SwapQuoteRequestPayload(
             address = "address",
             deviceId = "deviceId",
@@ -73,7 +67,6 @@ class DefaultSwapQuoteRequestBodyMapperTest {
             assetOutId = 2L,
             amount = BigInteger.valueOf(10_000),
             slippage = 0.01f,
-            providers = listOf("provider1", "provider2"),
             swapType = SwapTypeResponse.FIXED_INPUT
         )
     }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepositoryTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepositoryTest.kt
@@ -21,12 +21,12 @@ import com.algorand.wallet.swap.data.mapper.SwapQuoteMapper
 import com.algorand.wallet.swap.data.mapper.SwapQuoteProviderMapper
 import com.algorand.wallet.swap.data.mapper.SwapQuoteRequestBodyMapper
 import com.algorand.wallet.swap.data.mapper.SwapQuoteTransactionMapper
+import com.algorand.wallet.swap.data.mapper.SwapUpdateStatusRequestBodyMapper
 import com.algorand.wallet.swap.data.mapper.TopSwapPairsMapper
 import com.algorand.wallet.swap.data.model.CreateSwapQuoteTransactionsRequestBody
 import com.algorand.wallet.swap.data.model.CreateSwapQuoteTransactionsResponse
 import com.algorand.wallet.swap.data.model.SwapPeraFeeRequestBody
 import com.algorand.wallet.swap.data.model.SwapPeraFeeResponse
-import com.algorand.wallet.swap.data.model.SwapQuoteExceptionRequestBody
 import com.algorand.wallet.swap.data.model.SwapQuoteProviderResponse
 import com.algorand.wallet.swap.data.model.SwapQuoteProvidersResponse
 import com.algorand.wallet.swap.data.model.SwapQuoteRequestBody
@@ -64,6 +64,7 @@ class DefaultSwapRepositoryTest {
     private val swapQuoteProviderMapper: SwapQuoteProviderMapper = mockk()
     private val topSwapPairsMapper: TopSwapPairsMapper = mockk()
     private val useLocalCurrencyCache: PersistentCache<Boolean> = mockk(relaxed = true)
+    private val swapUpdateStatusRequestBodyMapper: SwapUpdateStatusRequestBodyMapper = mockk(relaxed = true)
 
     private val sut = DefaultSwapRepository(
         swapApiService,
@@ -75,6 +76,7 @@ class DefaultSwapRepositoryTest {
         availableSwapAssetMapper,
         providersCache,
         topSwapPairsMapper,
+        swapUpdateStatusRequestBodyMapper,
         useLocalCurrencyCache
     )
 
@@ -91,7 +93,7 @@ class DefaultSwapRepositoryTest {
     fun `EXPECT error WHEN get swap quotes api call fails`() = runTest {
         every { providersCache.get() } returns CACHED_PROVIDERS
         coEvery { swapApiService.getSwapQuote(SWAP_REQUEST_BODY) } throws Exception()
-        every { quoteRequestMapper(SWAP_REQUEST_PAYLOAD, CACHED_PROVIDERS) } returns SWAP_REQUEST_BODY
+        every { quoteRequestMapper(SWAP_REQUEST_PAYLOAD) } returns SWAP_REQUEST_BODY
 
         val result = sut.getSwapQuotes(SWAP_REQUEST_PAYLOAD)
 
@@ -102,7 +104,7 @@ class DefaultSwapRepositoryTest {
     fun `EXPECT error WHEN swap quotes are empty`() = runTest {
         every { providersCache.get() } returns CACHED_PROVIDERS
         coEvery { swapApiService.getSwapQuote(SWAP_REQUEST_BODY) } returns SWAP_QUOTE_RESULT_RESPONSE
-        every { quoteRequestMapper(SWAP_REQUEST_PAYLOAD, CACHED_PROVIDERS) } returns SWAP_REQUEST_BODY
+        every { quoteRequestMapper(SWAP_REQUEST_PAYLOAD) } returns SWAP_REQUEST_BODY
         every { quoteMapper(SWAP_QUOTE_RESPONSE, CACHED_PROVIDERS) } returns null
 
         val result = sut.getSwapQuotes(SWAP_REQUEST_PAYLOAD)
@@ -114,7 +116,7 @@ class DefaultSwapRepositoryTest {
     fun `EXPECT swap quotes WHEN api call returns valid quotes`() = runTest {
         every { providersCache.get() } returns CACHED_PROVIDERS
         coEvery { swapApiService.getSwapQuote(SWAP_REQUEST_BODY) } returns SWAP_QUOTE_RESULT_RESPONSE
-        every { quoteRequestMapper(SWAP_REQUEST_PAYLOAD, CACHED_PROVIDERS) } returns SWAP_REQUEST_BODY
+        every { quoteRequestMapper(SWAP_REQUEST_PAYLOAD) } returns SWAP_REQUEST_BODY
         every { quoteMapper(SWAP_QUOTE_RESPONSE, CACHED_PROVIDERS) } returns SWAP_QUOTE
 
         val result = sut.getSwapQuotes(SWAP_REQUEST_PAYLOAD)
@@ -128,7 +130,7 @@ class DefaultSwapRepositoryTest {
         coEvery { swapApiService.getSwapQuote(SWAP_REQUEST_BODY) } returns SWAP_QUOTE_RESULT_RESPONSE
         every { providersCache.get() } returnsMany listOf(null, listOf(PROVIDER))
         every { swapQuoteProviderMapper.invoke(PROVIDER_RESPONSE) } returns PROVIDER
-        every { quoteRequestMapper(SWAP_REQUEST_PAYLOAD, listOf(PROVIDER)) } returns SWAP_REQUEST_BODY
+        every { quoteRequestMapper(SWAP_REQUEST_PAYLOAD) } returns SWAP_REQUEST_BODY
         every { quoteMapper(SWAP_QUOTE_RESPONSE, listOf(PROVIDER)) } returns SWAP_QUOTE
 
         val result = sut.getSwapQuotes(SWAP_REQUEST_PAYLOAD)
@@ -203,16 +205,6 @@ class DefaultSwapRepositoryTest {
         val result = sut.createQuoteTransactions(CREATE_QUOTE_ID)
 
         assertEquals(PeraResult.Success(listOf(QUOTE_TRANSACTION)), result)
-    }
-
-    @Test
-    fun `EXPECT no crash WHEN update quote exception api call fails`() = runTest {
-        val body = SwapQuoteExceptionRequestBody("message")
-        coEvery { swapApiService.updateSwapQuoteException(CREATE_QUOTE_ID, body) } throws Exception()
-
-        val result = sut.updateSwapQuoteException(CREATE_QUOTE_ID, "message")
-
-        assertEquals(Unit, result)
     }
 
     @Test


### PR DESCRIPTION
## Description
I had to use old models due to signing flow. Creating new models was going to cause us to refactor signing flow as well. 

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2874
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2873