### PR TITLE
PERA-2879 :: Swap v2 UI fixes

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/AssetIcon.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/AssetIcon.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
@@ -70,11 +71,11 @@ sealed interface AssetIconDrawable {
 }
 
 @Composable
-fun AssetIcon(modifier: Modifier, drawable: AssetIconDrawable) {
+fun AssetIcon(modifier: Modifier, drawable: AssetIconDrawable, shape: Shape = RoundedCornerShape(8.dp)) {
     BoxWithConstraints(modifier = modifier) {
         when (drawable) {
             AssetIconDrawable.AlgoDrawable -> AlgoIcon()
-            is AssetIconDrawable.AssetDrawable -> AssetDrawableIcon(drawable)
+            is AssetIconDrawable.AssetDrawable -> AssetDrawableIcon(drawable, shape)
         }
     }
 }
@@ -86,12 +87,13 @@ fun AssetIcons(modifier: Modifier = Modifier, firstDrawable: AssetIconDrawable, 
             .size(25.dp)
             .border(width = 2.dp, color = PeraTheme.colors.background.primary, shape = CircleShape)
             .padding(1.dp)
-        AssetIcon(iconModifier, firstDrawable)
+        AssetIcon(iconModifier, firstDrawable, shape = CircleShape)
         AssetIcon(
             modifier = Modifier
                 .padding(start = 14.dp, top = 14.dp)
                 .then(iconModifier),
-            drawable = secondDrawable
+            drawable = secondDrawable,
+            shape = CircleShape
         )
     }
 }
@@ -110,11 +112,11 @@ private fun BoxWithConstraintsScope.AlgoIcon() {
 }
 
 @Composable
-private fun BoxWithConstraintsScope.AssetDrawableIcon(drawable: AssetIconDrawable.AssetDrawable) {
+private fun BoxWithConstraintsScope.AssetDrawableIcon(drawable: AssetIconDrawable.AssetDrawable, shape: Shape) {
     val placeholder = placeholder { AssetNameIcon(maxWidth, drawable.unitName) }
     val widthAsPx = with(LocalDensity.current) { maxWidth.toPx().toInt() }
     GlideImage(
-        modifier = Modifier.clip(RoundedCornerShape(8.dp)),
+        modifier = Modifier.clip(shape),
         model = drawable.getImageUrl(widthAsPx),
         contentDescription = null,
         contentScale = ContentScale.Crop,

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/history/view/SwapPairHistoryWidget.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/history/view/SwapPairHistoryWidget.kt
@@ -14,6 +14,7 @@ package com.algorand.android.ui.swap.history.view
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -92,7 +93,7 @@ fun SwapPairHistoryWidget(
 
 @Composable
 private fun ContentState(pairs: List<SwapPairHistoryItem>, onSwapPairClick: (Long, Long) -> Unit) {
-    LazyRow(contentPadding = PaddingValues(horizontal = 24.dp)) {
+    LazyRow(contentPadding = PaddingValues(horizontal = 24.dp), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         items(pairs) { pair ->
             val assetPairText = stringResource(
                 R.string.asset_to_asset_formatted,

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/history/viewmodel/SwapHistoryViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/history/viewmodel/SwapHistoryViewModel.kt
@@ -23,9 +23,7 @@ import com.algorand.android.ui.swap.history.viewmodel.SwapHistoryViewModel.ViewS
 import com.algorand.android.usecase.NetworkSlugUseCase
 import com.algorand.wallet.swap.domain.model.SwapHistoryPagingData
 import com.algorand.wallet.swap.domain.model.SwapHistoryStatus.Completed
-import com.algorand.wallet.swap.domain.model.SwapHistoryStatus.Failed
 import com.algorand.wallet.swap.domain.model.SwapHistoryStatus.InProgress
-import com.algorand.wallet.swap.domain.model.SwapHistoryStatus.Pending
 import com.algorand.wallet.swap.domain.usecase.GetSwapHistory
 import com.algorand.wallet.viewmodel.StateDelegate
 import com.algorand.wallet.viewmodel.StateViewModel
@@ -50,7 +48,7 @@ class SwapHistoryViewModel @Inject constructor(
         stateDelegate.onState<ViewState.Idle> {
             val pagingData = SwapHistoryPagingData(
                 address = address,
-                statuses = listOf(Pending, Failed, InProgress, Completed),
+                statuses = listOf(Completed, InProgress),
                 nextUrl = null,
                 previousUrl = null
             )

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/history/viewmodel/SwapPairHistoryViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/history/viewmodel/SwapPairHistoryViewModel.kt
@@ -19,8 +19,7 @@ import com.algorand.android.ui.swap.history.model.SwapPairHistoryItem
 import com.algorand.android.ui.swap.history.viewmodel.SwapPairHistoryViewModel.ViewState
 import com.algorand.android.ui.swap.widget.viewmodel.SwapWidgetViewModel
 import com.algorand.wallet.swap.domain.model.SwapHistoryStatus.Completed
-import com.algorand.wallet.swap.domain.model.SwapHistoryStatus.Failed
-import com.algorand.wallet.swap.domain.model.SwapHistoryStatus.Pending
+import com.algorand.wallet.swap.domain.model.SwapHistoryStatus.InProgress
 import com.algorand.wallet.swap.domain.usecase.GetSwapPairHistory
 import com.algorand.wallet.viewmodel.StateDelegate
 import com.algorand.wallet.viewmodel.StateViewModel
@@ -63,7 +62,7 @@ class SwapPairHistoryViewModel @Inject constructor(
         addressFlow.onEach { address ->
             viewStateFlow.value = ViewState.Loading
             if (address.isNullOrBlank()) return@onEach
-            viewStateFlow.value = getSwapPairHistory(address, listOf(Completed, Failed, Pending)).use(
+            viewStateFlow.value = getSwapPairHistory(address, listOf(Completed, InProgress)).use(
                 onSuccess = { pairs ->
                     if (pairs.isEmpty()) {
                         ViewState.Empty

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/widget/model/SwapAmountInput.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/widget/model/SwapAmountInput.kt
@@ -13,6 +13,7 @@
 package com.algorand.android.ui.swap.widget.model
 
 import java.math.BigDecimal
+import java.text.DecimalFormatSymbols
 import java.text.NumberFormat
 import java.util.Locale
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,10 +21,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 class SwapAmountInput {
 
     val amountInputFlow = MutableStateFlow<Input>(Input("", null))
+    private val symbols = DecimalFormatSymbols.getInstance(Locale.getDefault())
 
     fun setInput(input: String) {
         val amountAsBigDecimal = getInputAsBigDecimal(input)
-        amountInputFlow.value = Input(input, amountAsBigDecimal)
+        val normalizedInput = input.replace(symbols.groupingSeparator, symbols.decimalSeparator)
+        amountInputFlow.value = Input(normalizedInput, amountAsBigDecimal)
     }
 
     fun setInput(amount: BigDecimal) {


### PR DESCRIPTION
## Related Issues
- Closes [Swap history widget doesn't display latest swaps](https://algorandfoundation.atlassian.net/browse/PERA-2881)
    - Updated swap history status queries to display `completed` and `in progress` swaps. 
       > In progress means transactions have been accepted by the chain, but not confirmed by backend
- Closes [Swap history widget padding issue](https://algorandfoundation.atlassian.net/browse/PERA-2879)
- Closes [Decimal input not supported](https://algorandfoundation.atlassian.net/browse/PERA-2884)
    - Replaced grouping symbol inputs with decimal symbol. As an example; if user taps on "." when their default locale is Turkish, it will be replaced with ",", and vice versa for English locale. Since raw input never contains grouping symbol, we shouldn't have any problem. 
