### PR TITLE
PERA-2888 Filter out invalid asset amount inputs

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/swap/topfive/view/TopSwapPairsContainer.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/topfive/view/TopSwapPairsContainer.kt
@@ -55,6 +55,7 @@ fun TopSwapPairsContainer(viewModel: TopSwapPairsViewModel) {
             ViewState.Idle -> Unit
             ViewState.Error -> ErrorState()
             ViewState.Loading -> LoadingState()
+            ViewState.Empty -> EmptyState()
             is ViewState.Content -> ContentState(viewState.topSwapPairItems)
         }
     }
@@ -75,6 +76,15 @@ private fun ErrorState() {
             style = PeraTheme.typography.footnote.sansMedium
         )
     }
+}
+
+@Composable
+private fun EmptyState() {
+    Text(
+        text = stringResource(R.string.no_swap_activity_in_the),
+        color = PeraTheme.colors.text.gray,
+        style = PeraTheme.typography.footnote.sansMedium
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/topfive/viewmodel/DefaultTopSwapPairsViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/topfive/viewmodel/DefaultTopSwapPairsViewModel.kt
@@ -80,7 +80,7 @@ class DefaultTopSwapPairsViewModel @Inject constructor(
             getTopSwapPairs().use(
                 onSuccess = { result ->
                     val items = result.details.map { mapToTopSwapPairItem(it) }
-                    viewStateFlow.value = if (items.isEmpty()) ViewState.Error else ViewState.Content(items)
+                    viewStateFlow.value = if (items.isEmpty()) ViewState.Empty else ViewState.Content(items)
                 },
                 onFailed = { _, _ ->
                     viewStateFlow.value = ViewState.Error

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/topfive/viewmodel/TopSwapPairsViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/topfive/viewmodel/TopSwapPairsViewModel.kt
@@ -28,6 +28,7 @@ interface TopSwapPairsViewModel : StateViewModel<ViewState> {
         data object Idle : ViewState
         data object Loading : ViewState
         data object Error : ViewState
+        data object Empty : ViewState
         data class Content(val topSwapPairItems: List<TopSwapPairItem>) : ViewState
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/widget/model/SwapAmountInput.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/widget/model/SwapAmountInput.kt
@@ -18,14 +18,15 @@ import java.text.NumberFormat
 import java.util.Locale
 import kotlinx.coroutines.flow.MutableStateFlow
 
-class SwapAmountInput {
+class SwapAmountInput(val locale: Locale) {
 
     val amountInputFlow = MutableStateFlow<Input>(Input("", null))
-    private val symbols = DecimalFormatSymbols.getInstance(Locale.getDefault())
+    private val symbols = DecimalFormatSymbols.getInstance(locale)
+    private val inputRegex = Regex("^\\d*([.,]?\\d*)$")
 
     fun setInput(input: String) {
         val amountAsBigDecimal = getInputAsBigDecimal(input)
-        val normalizedInput = input.replace(symbols.groupingSeparator, symbols.decimalSeparator)
+        val normalizedInput = getNormalizedInput(input) ?: return
         amountInputFlow.value = Input(normalizedInput, amountAsBigDecimal)
     }
 
@@ -45,6 +46,11 @@ class SwapAmountInput {
     }
 
     private fun getFormatter(): NumberFormat = NumberFormat.getInstance(Locale.getDefault())
+
+    fun getNormalizedInput(input: String): String? {
+        val normalizedInput = input.replace(symbols.groupingSeparator, symbols.decimalSeparator)
+        return if (inputRegex.matches(normalizedInput)) normalizedInput else null
+    }
 
     data class Input(
         val rawInput: String,

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/widget/viewmodel/DefaultSwapWidgetViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/widget/viewmodel/DefaultSwapWidgetViewModel.kt
@@ -38,6 +38,7 @@ import com.algorand.wallet.swap.domain.usecase.GetSwapUseLocalCurrencyPreference
 import com.algorand.wallet.viewmodel.StateDelegate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
+import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -73,7 +74,7 @@ class DefaultSwapWidgetViewModel @Inject constructor(
     override val state: StateFlow<ViewState>
         get() = stateDelegate.state
 
-    private val swapAmountInput = SwapAmountInput()
+    private val swapAmountInput = SwapAmountInput(Locale.getDefault())
 
     override fun setAmountInput(amountInput: String) {
         swapAmountInput.setInput(amountInput)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1567,4 +1567,5 @@
     <string name="swap_history">Swap History</string>
     <string name="see_all">See all</string>
     <string name="your_swap_history_will_appear">Your swap history will appear here once you\'ve completed a swap.</string>
+    <string name="no_swap_activity_in_the">No swap activity in the last 24 hours</string>
 </resources>

--- a/app/src/test/kotlin/com/algorand/android/ui/swap/widget/model/SwapAmountInputTest.kt
+++ b/app/src/test/kotlin/com/algorand/android/ui/swap/widget/model/SwapAmountInputTest.kt
@@ -84,14 +84,14 @@ class SwapAmountInputTest {
             Input("1", BigDecimal.valueOf(1)),
             Input("", null),
             Input(".", null),
-            Input(".1", BigDecimal("0.1")),
+            Input(".1", BigDecimal.valueOf(0.1)),
             Input(".", null),
             Input("", null),
             Input("0", BigDecimal.valueOf(0)),
             Input("0.", BigDecimal.valueOf(0)),
-            Input("0.1", BigDecimal("0.1")),
-            Input("0.12", BigDecimal("0.12")),
-            Input("0.123", BigDecimal("0.123"))
+            Input("0.1", BigDecimal.valueOf(0.1)),
+            Input("0.12", BigDecimal.valueOf(0.12)),
+            Input("0.123", BigDecimal.valueOf(0.123))
         )
     }
 
@@ -111,12 +111,12 @@ class SwapAmountInputTest {
         amountObserver.assertValueHistory(
             Input("", null),
             Input(",", null),
-            Input(",1", BigDecimal("0.1")),
+            Input(",1", BigDecimal.valueOf(0.1)),
             Input(",", null),
             Input("", null),
             Input("0", BigDecimal.valueOf(0)),
             Input("0,", BigDecimal.valueOf(0)),
-            Input("0,1", BigDecimal("0.1"))
+            Input("0,1", BigDecimal.valueOf(0.1))
         )
     }
 }

--- a/app/src/test/kotlin/com/algorand/android/ui/swap/widget/model/SwapAmountInputTest.kt
+++ b/app/src/test/kotlin/com/algorand/android/ui/swap/widget/model/SwapAmountInputTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.swap.widget.model
+
+import com.algorand.android.ui.swap.widget.model.SwapAmountInput.Input
+import com.algorand.test.test
+import java.math.BigDecimal
+import java.util.Locale
+import org.junit.Test
+
+class SwapAmountInputTest {
+
+    val sut = SwapAmountInput(Locale.ENGLISH)
+    val amountObserver = sut.amountInputFlow.test()
+
+    @Test
+    fun `EXPECT no update when inputs are invalid`() {
+        val asciiStart = 32
+        val asciiEnd = 127
+        var index = asciiStart
+        while (index <= asciiEnd) {
+            sut.setInput(index.toChar().toString())
+            index += 1
+        }
+
+        // Comma is being replaced with dot.
+        // Second valid input is comma (ASCII-44) and third valid one is dot (ASCII-46).
+        // Since previous value is also dot (comma being replaced), flow is not being updated,
+        // That's why there is only one dot in the history.
+        amountObserver.assertValueHistory(
+            Input("", null),
+            Input(".", null),
+            Input("0", BigDecimal.valueOf(0)),
+            Input("1", BigDecimal.valueOf(1)),
+            Input("2", BigDecimal.valueOf(2)),
+            Input("3", BigDecimal.valueOf(3)),
+            Input("4", BigDecimal.valueOf(4)),
+            Input("5", BigDecimal.valueOf(5)),
+            Input("6", BigDecimal.valueOf(6)),
+            Input("7", BigDecimal.valueOf(7)),
+            Input("8", BigDecimal.valueOf(8)),
+            Input("9", BigDecimal.valueOf(9))
+        )
+    }
+
+    @Test
+    fun `EXPECT decimal numbers WHEN input starts with separator`() {
+        sut.setInput("1")
+        sut.setInput("12")
+        sut.setInput("123")
+        sut.setInput("1234")
+        sut.setInput("123")
+        sut.setInput("12")
+        sut.setInput("1")
+        sut.setInput("")
+        sut.setInput(".")
+        sut.setInput(".1")
+        sut.setInput(".")
+        sut.setInput("")
+        sut.setInput("0")
+        sut.setInput("0.")
+        sut.setInput("0.1")
+        sut.setInput("0.12")
+        sut.setInput("0.123")
+
+        amountObserver.assertValueHistory(
+            Input("", null),
+            Input("1", BigDecimal.valueOf(1)),
+            Input("12", BigDecimal.valueOf(12)),
+            Input("123", BigDecimal.valueOf(123)),
+            Input("1234", BigDecimal.valueOf(1234)),
+            Input("123", BigDecimal.valueOf(123)),
+            Input("12", BigDecimal.valueOf(12)),
+            Input("1", BigDecimal.valueOf(1)),
+            Input("", null),
+            Input(".", null),
+            Input(".1", BigDecimal("0.1")),
+            Input(".", null),
+            Input("", null),
+            Input("0", BigDecimal.valueOf(0)),
+            Input("0.", BigDecimal.valueOf(0)),
+            Input("0.1", BigDecimal("0.1")),
+            Input("0.12", BigDecimal("0.12")),
+            Input("0.123", BigDecimal("0.123"))
+        )
+    }
+
+    @Test
+    fun `EXPECT different locales to be supported`() {
+        val sut = SwapAmountInput(Locale.GERMAN)
+        val amountObserver = sut.amountInputFlow.test()
+
+        sut.setInput(".")
+        sut.setInput(".1")
+        sut.setInput(".")
+        sut.setInput("")
+        sut.setInput("0")
+        sut.setInput("0.")
+        sut.setInput("0.1")
+
+        amountObserver.assertValueHistory(
+            Input("", null),
+            Input(",", null),
+            Input(",1", BigDecimal("0.1")),
+            Input(",", null),
+            Input("", null),
+            Input("0", BigDecimal.valueOf(0)),
+            Input("0,", BigDecimal.valueOf(0)),
+            Input("0,1", BigDecimal("0.1"))
+        )
+    }
+}


### PR DESCRIPTION
## Description
Even if we set keyboard type as `decimal`, some keyboards have space or other chars. If user enters space as first char, app crashes. To solve the issue I added regex which allows decimal separators and digits only.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2888