### PR TITLE
PERA-2994 :: Fix swap history crash

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/AssetIcon.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/AssetIcon.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.BoxWithConstraintsScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
@@ -61,6 +60,8 @@ sealed interface AssetIconDrawable {
     data object AlgoDrawable : AssetIconDrawable
     data class AssetDrawable(private val url: String, val unitName: String?) : AssetIconDrawable {
 
+        fun isUrlValid() = url.isNotBlank()
+
         fun getImageUrl(containerWidthPx: Int): String {
             return PrismUrlBuilder.create(url)
                 .addWidth(containerWidthPx)
@@ -77,24 +78,6 @@ fun AssetIcon(modifier: Modifier, drawable: AssetIconDrawable, shape: Shape = Ro
             AssetIconDrawable.AlgoDrawable -> AlgoIcon()
             is AssetIconDrawable.AssetDrawable -> AssetDrawableIcon(drawable, shape)
         }
-    }
-}
-
-@Composable
-fun AssetIcons(modifier: Modifier = Modifier, firstDrawable: AssetIconDrawable, secondDrawable: AssetIconDrawable) {
-    Box(modifier = modifier.padding(2.dp)) {
-        val iconModifier = Modifier
-            .size(25.dp)
-            .border(width = 2.dp, color = PeraTheme.colors.background.primary, shape = CircleShape)
-            .padding(1.dp)
-        AssetIcon(iconModifier, firstDrawable, shape = CircleShape)
-        AssetIcon(
-            modifier = Modifier
-                .padding(start = 14.dp, top = 14.dp)
-                .then(iconModifier),
-            drawable = secondDrawable,
-            shape = CircleShape
-        )
     }
 }
 

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/AssetPairIcons.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/AssetPairIcons.kt
@@ -38,7 +38,7 @@ import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.bumptech.glide.integration.compose.placeholder
 
-private val ICON_SIZE = 24.dp
+private val iconSize = 24.dp
 
 @Composable
 fun AssetPairIcons(modifier: Modifier = Modifier, firstDrawable: AssetIconDrawable, secondDrawable: AssetIconDrawable) {
@@ -71,7 +71,7 @@ private fun AssetPairIcon(modifier: Modifier, drawable: AssetIconDrawable) {
 @Composable
 private fun AssetDrawableIcon(drawable: AssetIconDrawable.AssetDrawable) {
     if (drawable.isUrlValid()) {
-        val widthAsPx = with(LocalDensity.current) { ICON_SIZE.toPx().toInt() }
+        val widthAsPx = with(LocalDensity.current) { iconSize.toPx().toInt() }
         GlideImage(
             modifier = Modifier.clip(CircleShape),
             model = drawable.getImageUrl(widthAsPx),
@@ -107,7 +107,7 @@ private fun AssetNameIcon(unitName: String?) {
 @Composable
 private fun AlgoIcon() {
     Image(
-        modifier = Modifier.size(ICON_SIZE),
+        modifier = Modifier.size(iconSize),
         contentDescription = null,
         imageVector = ImageVector.vectorResource(id = R.drawable.ic_algo_circle)
     )

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/AssetPairIcons.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/asset/icon/AssetPairIcons.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.ui.compose.widget.asset.icon
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.algorand.android.R
+import com.algorand.android.ui.compose.theme.PeraTheme
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
+import com.bumptech.glide.integration.compose.placeholder
+
+private val ICON_SIZE = 24.dp
+
+@Composable
+fun AssetPairIcons(modifier: Modifier = Modifier, firstDrawable: AssetIconDrawable, secondDrawable: AssetIconDrawable) {
+    Box(modifier = modifier.padding(2.dp)) {
+        val iconModifier = Modifier
+            .size(25.dp)
+            .border(width = 2.dp, color = PeraTheme.colors.background.primary, shape = CircleShape)
+            .padding(1.dp)
+        AssetPairIcon(iconModifier, firstDrawable)
+        AssetPairIcon(
+            modifier = Modifier
+                .padding(start = 14.dp, top = 14.dp)
+                .then(iconModifier),
+            drawable = secondDrawable
+        )
+    }
+}
+
+@Composable
+private fun AssetPairIcon(modifier: Modifier, drawable: AssetIconDrawable) {
+    Box(modifier, contentAlignment = Alignment.Center) {
+        when (drawable) {
+            AssetIconDrawable.AlgoDrawable -> AlgoIcon()
+            is AssetIconDrawable.AssetDrawable -> AssetDrawableIcon(drawable)
+        }
+    }
+}
+
+@OptIn(ExperimentalGlideComposeApi::class)
+@Composable
+private fun AssetDrawableIcon(drawable: AssetIconDrawable.AssetDrawable) {
+    if (drawable.isUrlValid()) {
+        val widthAsPx = with(LocalDensity.current) { ICON_SIZE.toPx().toInt() }
+        GlideImage(
+            modifier = Modifier.clip(CircleShape),
+            model = drawable.getImageUrl(widthAsPx),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            failure = placeholder { AssetNameIcon(drawable.unitName) }
+        )
+    } else {
+        AssetNameIcon(drawable.unitName)
+    }
+}
+
+@Composable
+private fun AssetNameIcon(unitName: String?) {
+    val safeAssetName = if (unitName.isNullOrBlank()) stringResource(R.string.unnamed) else unitName
+    val displayName = safeAssetName.take(1).uppercase()
+    Box(
+        Modifier
+            .background(color = PeraTheme.colors.background.primary, shape = CircleShape)
+            .fillMaxSize()
+            .border(1.dp, PeraTheme.colors.layer.grayLighter, shape = CircleShape),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = displayName,
+            color = PeraTheme.colors.text.gray,
+            style = PeraTheme.typography.body.regular.sans,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun AlgoIcon() {
+    Image(
+        modifier = Modifier.size(ICON_SIZE),
+        contentDescription = null,
+        imageVector = ImageVector.vectorResource(id = R.drawable.ic_algo_circle)
+    )
+}

--- a/app/src/main/kotlin/com/algorand/android/ui/compose/widget/button/slidetoconfirm/SlideToConfirmButtonThumb.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/compose/widget/button/slidetoconfirm/SlideToConfirmButtonThumb.kt
@@ -97,7 +97,7 @@ fun BoxWithConstraintsScope.SlideToConfirmButtonThumb(
                         }
                     )
                 }
-                .padding(start = with(density) { dragOffsetAnimator.value.toDp() })
+                .padding(start = with(density) { dragOffsetAnimator.value.coerceAtLeast(0f).toDp() })
                 .background(color = PeraTheme.colors.button.primary.background, shape = CircleShape)
                 .then(modifier),
             contentAlignment = Alignment.Center

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/history/view/PagingSwapHistoryList.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/history/view/PagingSwapHistoryList.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -39,7 +40,7 @@ import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.algorand.android.R
 import com.algorand.android.ui.compose.theme.PeraTheme
-import com.algorand.android.ui.compose.widget.asset.icon.AssetIcons
+import com.algorand.android.ui.compose.widget.asset.icon.AssetPairIcons
 import com.algorand.android.ui.compose.widget.modifier.clickableNoRipple
 import com.algorand.android.ui.swap.history.model.SwapHistoryItem
 import kotlinx.coroutines.flow.Flow
@@ -57,7 +58,10 @@ fun PagingSwapHistoryList(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         contentPadding = contentPadding,
     ) {
-        items(swapHistory.itemCount) { index ->
+        items(
+            count = swapHistory.itemCount,
+            key = { index -> swapHistory[index]?.id ?: index }
+        ) { index ->
             swapHistory[index]?.let { swapHistoryItem ->
                 SwapHistoryListItem(swapHistoryItem, onSwapItemClick)
                 if (index in 0 until swapHistory.itemCount - 1) {
@@ -76,7 +80,7 @@ fun PagingSwapHistoryList(
 @Composable
 private fun SwapHistoryListItem(item: SwapHistoryItem, onClick: (SwapHistoryItem) -> Unit) {
     Row(modifier = Modifier.clickableNoRipple { onClick(item) }, verticalAlignment = Alignment.CenterVertically) {
-        AssetIcons(firstDrawable = item.assetInDrawable, secondDrawable = item.assetOutDrawable)
+        AssetPairIcons(firstDrawable = item.assetInDrawable, secondDrawable = item.assetOutDrawable)
         Spacer(modifier = Modifier.width(8.dp))
         Text(
             modifier = Modifier.weight(1f),
@@ -98,48 +102,37 @@ private fun SwapHistoryListItem(item: SwapHistoryItem, onClick: (SwapHistoryItem
 
 @Composable
 private fun getItemDescription(item: SwapHistoryItem): AnnotatedString {
-    return buildAnnotatedString {
-        val assetInAmount = "${item.amountIn} ${item.assetInShortName}"
-        val assetOutAmount = "${item.amountOut} ${item.assetOutShortName}"
-        val descriptionText = stringResource(R.string.swapped_asset_for_asset_formatted, assetInAmount, assetOutAmount)
-        val startIndex = descriptionText.indexOf(assetOutAmount)
-        val endIndex = startIndex + assetOutAmount.length
+    val boldWeight = PeraTheme.typography.body.regular.sansBold.fontWeight
+    val dateColor = PeraTheme.colors.text.gray
+    val mainSpan = SpanStyle(
+        color = PeraTheme.colors.text.main,
+        fontStyle = PeraTheme.typography.body.regular.sans.fontStyle
+    )
+    val descriptionTextTemplate = stringResource(R.string.swapped_asset_for_asset_formatted)
+    return remember(item) {
+        buildAnnotatedString {
+            val assetInAmount = "${item.amountIn} ${item.assetInShortName}"
+            val assetOutAmount = "${item.amountOut} ${item.assetOutShortName}"
+            val descriptionText = String.format(descriptionTextTemplate, assetInAmount, assetOutAmount)
+            val startIndex = descriptionText.indexOf(assetOutAmount)
+            val endIndex = startIndex + assetOutAmount.length
 
-        val font = PeraTheme.typography.body.regular.sans
-        val color = PeraTheme.colors.text.main
-        withStyle(style = SpanStyle(color = color, fontStyle = font.fontStyle)) {
-            append(descriptionText.substring(0, startIndex))
-        }
-
-        withStyle(
-            style = SpanStyle(
-                color = color,
-                fontStyle = font.fontStyle,
-                fontWeight = PeraTheme.typography.body.regular.sansBold.fontWeight
-            )
-        ) {
-            append(assetOutAmount)
-        }
-        withStyle(style = SpanStyle(color = color, fontStyle = font.fontStyle)) {
-            append(descriptionText.substring(endIndex, descriptionText.length))
-        }
-
-        if (item.datetime != null) {
-            withStyle(
-                style = SpanStyle(
-                    color = PeraTheme.colors.text.grayLighter,
-                    fontStyle = PeraTheme.typography.body.regular.sans.fontStyle
-                )
-            ) {
-                append(" • ")
+            withStyle(style = mainSpan) {
+                append(descriptionText.substring(0, startIndex))
             }
-            withStyle(
-                style = SpanStyle(
-                    color = PeraTheme.colors.text.gray,
-                    fontStyle = PeraTheme.typography.body.regular.sans.fontStyle
-                )
-            ) {
-                append(item.datetime)
+
+            withStyle(style = mainSpan.copy(fontWeight = boldWeight)) {
+                append(assetOutAmount)
+            }
+            withStyle(style = mainSpan) {
+                append(descriptionText.substring(endIndex, descriptionText.length))
+            }
+
+            if (item.datetime != null) {
+                withStyle(style = mainSpan.copy(color = dateColor)) {
+                    append(" • ")
+                    append(item.datetime)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/history/view/SwapPairHistoryWidget.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/history/view/SwapPairHistoryWidget.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.algorand.android.R
 import com.algorand.android.ui.compose.theme.PeraTheme
-import com.algorand.android.ui.compose.widget.asset.icon.AssetIcons
+import com.algorand.android.ui.compose.widget.asset.icon.AssetPairIcons
 import com.algorand.android.ui.compose.widget.modifier.clickableNoRipple
 import com.algorand.android.ui.compose.widget.modifier.shimmer
 import com.algorand.android.ui.swap.history.model.SwapPairHistoryItem
@@ -119,7 +119,7 @@ private fun ContentState(pairs: List<SwapPairHistoryItem>, onSwapPairClick: (Swa
                     .padding(horizontal = 12.dp, vertical = 4.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                AssetIcons(firstDrawable = pair.assetInIconDrawable, secondDrawable = pair.assetOutIconDrawable)
+                AssetPairIcons(firstDrawable = pair.assetInIconDrawable, secondDrawable = pair.assetOutIconDrawable)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = assetPairText,

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/history/viewmodel/SwapHistoryViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/history/viewmodel/SwapHistoryViewModel.kt
@@ -34,7 +34,9 @@ import com.algorand.wallet.viewmodel.StateDelegate
 import com.algorand.wallet.viewmodel.StateViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -65,6 +67,7 @@ class SwapHistoryViewModel @Inject constructor(
                     getSwapHistory(pagingData)
                         .map { pagingData -> pagingData.map { swapHistoryItemMapper(it) } }
                         .cachedIn(viewModelScope)
+                        .flowOn(Dispatchers.IO)
                 )
             }
         }

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/topfive/view/TopSwapPairsContainer.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/topfive/view/TopSwapPairsContainer.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.algorand.android.R
 import com.algorand.android.ui.compose.theme.PeraTheme
-import com.algorand.android.ui.compose.widget.asset.icon.AssetIcons
+import com.algorand.android.ui.compose.widget.asset.icon.AssetPairIcons
 import com.algorand.android.ui.compose.widget.modifier.clickableNoRipple
 import com.algorand.android.ui.compose.widget.modifier.shimmer
 import com.algorand.android.ui.swap.topfive.model.TopSwapPairItem
@@ -144,7 +144,7 @@ private fun SwapPairItem(modifier: Modifier, index: Int, detail: TopSwapPairItem
             style = PeraTheme.typography.body.large.sans,
             color = PeraTheme.colors.text.gray
         )
-        AssetIcons(firstDrawable = detail.assetInIconDrawable, secondDrawable = detail.assetOutIconDrawable)
+        AssetPairIcons(firstDrawable = detail.assetInIconDrawable, secondDrawable = detail.assetOutIconDrawable)
         Spacer(modifier = Modifier.width(8.dp))
         Row(modifier = Modifier.weight(1f)) {
             Text(

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/widget/viewmodel/DefaultSwapWidgetViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/widget/viewmodel/DefaultSwapWidgetViewModel.kt
@@ -145,17 +145,19 @@ class DefaultSwapWidgetViewModel @Inject constructor(
     override fun selectQuote(providerItem: SwapQuoteProviderSelectionItem) {
         stateDelegate.onState<ViewState.Content> { content ->
             val quoteState = getContentQuoteState() ?: return
-            stateDelegate.updateState {
-                val quoteSelection = when (providerItem) {
-                    Auto -> QuoteSelection(quoteId = quoteState.bestOfferQuoteId, selectionType = Type.Auto)
-                    is Provider -> QuoteSelection(quoteId = providerItem.quoteId, selectionType = Type.Manual)
-                }
-                val selectedQuote = quoteState.quotes.first { it.quote.quoteId == quoteSelection.quoteId }.quote
-                content.copy(
-                    contentState = quoteState.copy(quoteSelection = quoteSelection),
-                    amountRenderers = amountRendererMapper.getQuoteRenderers(selectedQuote, content.useLocalCurrency),
-                )
+            val quoteSelection = when (providerItem) {
+                Auto -> QuoteSelection(quoteId = quoteState.bestOfferQuoteId, selectionType = Type.Auto)
+                is Provider -> QuoteSelection(quoteId = providerItem.quoteId, selectionType = Type.Manual)
             }
+            val selectedQuote = quoteState.quotes
+                .firstOrNull { it.quote.quoteId == quoteSelection.quoteId }
+                ?.quote
+                ?: return
+            val newState = content.copy(
+                contentState = quoteState.copy(quoteSelection = quoteSelection),
+                amountRenderers = amountRendererMapper.getQuoteRenderers(selectedQuote, content.useLocalCurrency),
+            )
+            stateDelegate.updateState { newState }
         }
     }
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapHistoryPagingSource.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapHistoryPagingSource.kt
@@ -39,18 +39,35 @@ internal class DefaultSwapHistoryPagingSource @Inject constructor(
     ): LoadResult<SwapHistoryPagingData, SwapHistory> {
         return try {
             val keys = params.key
-            val swapHistoryResponseResult = getSwapHistory(params.key)
-            if (params is LoadParams.Refresh) {
-                getPageResult(keys, swapHistoryResponseResult)
-            } else {
-                if (swapHistoryResponseResult.getDataOrNull()?.next == keys?.nextUrl) {
-                    return LoadResult.Error(Exception())
+            when (params) {
+                is LoadParams.Refresh -> {
+                    val swapHistoryResponseResult = getSwapHistory(params.key)
+                    getPageResult(keys, swapHistoryResponseResult)
                 }
-                getPageResult(keys, swapHistoryResponseResult)
+                is LoadParams.Append -> append(params)
+                is LoadParams.Prepend -> prepend(params)
             }
         } catch (exception: Exception) {
             LoadResult.Error(exception)
         }
+    }
+
+    private suspend fun append(
+        params: LoadParams.Append<SwapHistoryPagingData>
+    ): LoadResult<SwapHistoryPagingData, SwapHistory> {
+        val nextUrl = params.key.nextUrl ?: return emptyPage()
+        val response = getSwapHistoryMore(nextUrl)
+        if (response.getDataOrNull()?.next == nextUrl) return emptyPage()
+        return getPageResult(params.key, response)
+    }
+
+    private suspend fun prepend(
+        params: LoadParams.Prepend<SwapHistoryPagingData>
+    ): LoadResult<SwapHistoryPagingData, SwapHistory> {
+        val previousUrl = params.key.previousUrl ?: return emptyPage()
+        val response = getSwapHistoryMore(previousUrl)
+        if (response.getDataOrNull()?.previous == previousUrl) return emptyPage()
+        return getPageResult(params.key, response)
     }
 
     private suspend fun getPageResult(
@@ -61,8 +78,8 @@ internal class DefaultSwapHistoryPagingSource @Inject constructor(
             onSuccess = {
                 LoadResult.Page(
                     data = it.results.mapNotNull { swapHistoryMapper(it) },
-                    prevKey = params?.copy(previousUrl = it.previous),
-                    nextKey = params?.copy(nextUrl = it.next)
+                    prevKey = if (it.previous != null) params?.copy(previousUrl = it.previous) else null,
+                    nextKey = if (it.next != null) params?.copy(nextUrl = it.next) else null
                 )
             },
             onFailed = { exception, _ ->
@@ -85,11 +102,22 @@ internal class DefaultSwapHistoryPagingSource @Inject constructor(
         }
     }
 
+    private suspend fun getSwapHistoryMore(url: String): PeraResult<SwapHistoriesResponse> {
+        return try {
+            val result = swapApiService.getSwapHistoryMore(url)
+            PeraResult.Success(result)
+        } catch (exception: Exception) {
+            PeraResult.Error(exception)
+        }
+    }
+
     private fun getSwapStatusString(statuses: List<SwapHistoryStatus>): String {
         return statuses.joinToString(",") { status ->
             swapHistoryStatusMapper(status).value
         }
     }
+
+    private fun emptyPage(): LoadResult<SwapHistoryPagingData, SwapHistory> = LoadResult.Page(emptyList(), null, null)
 
     companion object {
         const val ITEM_PER_PAGE = 20

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/service/SwapApiService.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/service/SwapApiService.kt
@@ -30,6 +30,7 @@ import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
+import retrofit2.http.Url
 
 internal interface SwapApiService {
 
@@ -70,6 +71,9 @@ internal interface SwapApiService {
         @Query("limit") limit: Int,
         @Query("statuses") statuses: String?
     ): SwapHistoriesResponse
+
+    @GET
+    suspend fun getSwapHistoryMore(@Url url: String): SwapHistoriesResponse
 
     @GET("v2/dex-swap/distinct-pairs-history/")
     suspend fun getSwapPairsHistory(


### PR DESCRIPTION
## Description
- PagingSource was calling prepend right after refresh,  since the keys were the same, it was throwing an exception. 
- After fixing paging issue, I've realized that there is a performance issue on asset pair icons. It is fixed as well.
- [Selecting invalid provider crash](https://console.firebase.google.com/u/1/project/algorand-e3fe3/crashlytics/app/android:com.algorand.android/issues/54b7bc8ec8d847df400bdd1e68527dac?time=7d&types=crash&sessionEventKey=68DFC78D029A0001486552070357E822_2135427660479186351) is fixed
- [Slide to confirm negative padding crash](https://console.firebase.google.com/u/1/project/algorand-e3fe3/crashlytics/app/android:com.algorand.android/issues/e148eb4fa02d4fe1b7c444df3a8c160e?time=24h&types=crash&versions=6.202518.1%20(5091)&sessionEventKey=68E28820027F00012BA4A1D18D0EE38A_2136202068600882932) is fixed

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2994
