### PR TITLE
PERA-2925 Format slippage as percentage

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/swap/confirmation/mapper/DefaultSwapConfirmationContentMapper.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/confirmation/mapper/DefaultSwapConfirmationContentMapper.kt
@@ -26,6 +26,7 @@ import com.algorand.android.ui.common.amount.PlainFormattedAmount.SimplePlainFor
 import com.algorand.android.ui.common.amount.SimpleFormattedAmount
 import com.algorand.android.ui.compose.widget.asset.icon.mapper.AssetIconDrawableMapper
 import com.algorand.android.ui.swap.confirmation.viewmodel.SwapConfirmationViewModel.ViewState.Content
+import com.algorand.android.utils.formatAsPercentage
 import com.algorand.wallet.asset.domain.util.AssetConstants.ALGO_ID
 import com.algorand.wallet.swap.domain.model.SwapQuoteV2
 import com.algorand.wallet.swap.domain.model.SwapQuoteV2.AssetDetail
@@ -55,7 +56,8 @@ internal class DefaultSwapConfirmationContentMapper @Inject constructor(
             peraFee = getFeeRenderer(quote.fee.peraFeeAmount),
             minReceivedAssetAmount = getAmountRenderer(quote.assetOutAmount.amountWithSlippage, quote.assetOutDetail),
             assetInToOutPriceRatio = getAssetInToOutPriceRatio(quote),
-            assetOutToInPriceRatio = getAssetOutToInPriceRatio(quote)
+            assetOutToInPriceRatio = getAssetOutToInPriceRatio(quote),
+            slippage = (quote.slippage * SLIPPAGE_MULTIPLIER).formatAsPercentage()
         )
     }
 
@@ -127,5 +129,9 @@ internal class DefaultSwapConfirmationContentMapper @Inject constructor(
         val feeAmount = PeraAmount(fee)
         val formattedAmount = PlainFormattedAmount.AlgoPlainFormattedAmount(feeAmount)
         return AmountRenderer(formattedAmount, Plain, prefix = Currency.ALGO.symbol)
+    }
+
+    private companion object {
+        const val SLIPPAGE_MULTIPLIER = 100f
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/confirmation/view/SwapConfirmationQuoteDetailContainer.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/confirmation/view/SwapConfirmationQuoteDetailContainer.kt
@@ -74,7 +74,7 @@ fun SwapConfirmationQuoteDetailContainer(content: Content, listener: SwapConfirm
         QuoteRowSeparator()
         Provider(content.quote.provider)
         QuoteRowSeparator()
-        SlippageTolerance(content.quote.slippage, listener::onSlippageToleranceInfoClick)
+        SlippageTolerance(content.slippage, listener::onSlippageToleranceInfoClick)
         QuoteRowSeparator()
         PriceImpact(content.priceImpact, listener::onPriceImpactInfoClick)
         QuoteRowSeparator()
@@ -158,14 +158,14 @@ private fun Provider(provider: SwapQuoteProvider) {
 }
 
 @Composable
-private fun SlippageTolerance(slippage: Float, onInfoClick: () -> Unit) {
+private fun SlippageTolerance(slippage: String, onInfoClick: () -> Unit) {
     QuoteDetailRow(
         labelContent = {
             QuoteDetailLabel(textResId = R.string.slippage_tolerance)
             Spacer(modifier = Modifier.width(6.dp))
             InfoIcon(onClick = onInfoClick)
         },
-        valueContent = { QuoteDetailValue(text = "$slippage%") }
+        valueContent = { QuoteDetailValue(text = slippage) }
     )
 }
 

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/confirmation/viewmodel/SwapConfirmationViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/confirmation/viewmodel/SwapConfirmationViewModel.kt
@@ -242,6 +242,7 @@ class SwapConfirmationViewModel @Inject constructor(
             val minReceivedAssetAmount: AmountRenderer,
             val assetInToOutPriceRatio: PriceRatio,
             val assetOutToInPriceRatio: PriceRatio,
+            val slippage: String,
             val contentState: ContentState = ContentState.Idle
         ) : ViewState {
 


### PR DESCRIPTION
Slippage will be displayed as X% instead of 0.0X on swap confirmation screen

<img width="508" height="46" alt="Screenshot 2025-10-10 at 20 56 29" src="https://github.com/user-attachments/assets/9d95e7b0-846d-4207-b3e5-351a187c4dac" />
