### PR TITLE
PERA-3019 :: Fix duplicate words issue on passphrase validation screen

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/customviews/PassphraseValidationGroupView.kt
+++ b/app/src/main/kotlin/com/algorand/android/customviews/PassphraseValidationGroupView.kt
@@ -6,8 +6,8 @@ import android.widget.LinearLayout
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updateMargins
 import com.algorand.android.R
-import kotlin.random.Random
-import kotlin.random.nextInt
+import com.algorand.android.utils.PassphraseKeywordUtils.generatePassphraseValidationItems
+import com.algorand.android.utils.PassphraseValidationItem
 
 class PassphraseValidationGroupView @JvmOverloads constructor(
     context: Context,
@@ -36,24 +36,23 @@ class PassphraseValidationGroupView @JvmOverloads constructor(
             passphraseValidationViews.clear()
             removeAllViews()
         }
-        val uniqueWords = words
-            .distinct()
-            .takeIf { it.size >= PER_ITEM_COUNT * SIZE }
-            ?: words
-
-        uniqueWords.withIndex()
-            .shuffled()
-            .windowed(PER_ITEM_COUNT, PER_ITEM_COUNT, partialWindows = false)
-            .take(SIZE)
-            .forEachIndexed { index, wordsWithIndexedValue ->
-                addPassphraseValidationView(
-                    passphraseValidatorView = createPassphraseValidatorView(wordsWithIndexedValue),
-                    addMarginToBottom = index + 1 != SIZE
-                )
-            }
-
+        addPassphraseValidationViews(words)
         if (isFirstSetup.not()) {
             listener?.onInputUpdate(allWordsSelected = false)
+        }
+    }
+
+    private fun addPassphraseValidationViews(words: List<String>) {
+        val validationItems = generatePassphraseValidationItems(
+            words = words,
+            itemCount = VALIDATION_VIEW_COUNT,
+            perItemCount = PER_ITEM_COUNT
+        )
+        validationItems.forEachIndexed { index, item ->
+            addPassphraseValidationView(
+                passphraseValidatorView = createPassphraseValidatorView(item),
+                addMarginToBottom = index + 1 != validationItems.size
+            )
         }
     }
 
@@ -71,16 +70,14 @@ class PassphraseValidationGroupView @JvmOverloads constructor(
     }
 
     private fun createPassphraseValidatorView(
-        wordsWithIndexedValue: List<IndexedValue<String>>
+        item: PassphraseValidationItem
     ): PassphraseValidatorView {
         return PassphraseValidatorView(context).apply {
-            val correctWordPositionInList = Random.nextInt(0 until PER_ITEM_COUNT)
-            val (correctWordPosition, correctWord) = wordsWithIndexedValue[correctWordPositionInList]
             setup(
-                words = wordsWithIndexedValue.map { it.value },
-                correctWord = correctWord,
-                correctWordPosition = correctWordPosition,
-                passphraseValidatorViewListener
+                words = item.options,
+                correctWord = item.correctWord,
+                correctWordPosition = item.correctWordIndex,
+                listener = passphraseValidatorViewListener
             )
         }
     }
@@ -94,7 +91,7 @@ class PassphraseValidationGroupView @JvmOverloads constructor(
     }
 
     companion object {
-        private const val SIZE = 4
+        private const val VALIDATION_VIEW_COUNT = 4
         private const val PER_ITEM_COUNT = 3
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/customviews/PassphraseValidationGroupView.kt
+++ b/app/src/main/kotlin/com/algorand/android/customviews/PassphraseValidationGroupView.kt
@@ -36,8 +36,12 @@ class PassphraseValidationGroupView @JvmOverloads constructor(
             passphraseValidationViews.clear()
             removeAllViews()
         }
+        val uniqueWords = words
+            .distinct()
+            .takeIf { it.size >= PER_ITEM_COUNT * SIZE }
+            ?: words
 
-        words.withIndex()
+        uniqueWords.withIndex()
             .shuffled()
             .windowed(PER_ITEM_COUNT, PER_ITEM_COUNT, partialWindows = false)
             .take(SIZE)

--- a/app/src/main/kotlin/com/algorand/android/utils/PassphraseKeywordUtils.kt
+++ b/app/src/main/kotlin/com/algorand/android/utils/PassphraseKeywordUtils.kt
@@ -27,6 +27,41 @@ object PassphraseKeywordUtils {
         return predefinedWords.binarySearch(word) >= 0
     }
 
+    fun generatePassphraseValidationItems(
+        words: List<String>,
+        itemCount: Int,
+        perItemCount: Int,
+    ): List<PassphraseValidationItem> {
+        val diffWords = (predefinedWords - words).toMutableList()
+        val validationItems = mutableListOf<PassphraseValidationItem>()
+
+        words.withIndex()
+            .shuffled()
+            .take(itemCount)
+            .forEach { correctWord ->
+                val incorrectOptions = diffWords
+                    .shuffled()
+                    .take(perItemCount - 1)
+
+                diffWords.removeAll(incorrectOptions)
+
+                val options = buildList {
+                    add(correctWord.value)
+                    addAll(incorrectOptions)
+                }.shuffled()
+
+                validationItems.add(
+                    PassphraseValidationItem(
+                        correctWordIndex = correctWord.index,
+                        correctWord = correctWord.value,
+                        options = options
+                    )
+                )
+            }
+
+        return validationItems
+    }
+
     private val predefinedWords = listOf(
         "abandon",
         "ability",

--- a/app/src/main/kotlin/com/algorand/android/utils/PassphraseKeywordUtils.kt
+++ b/app/src/main/kotlin/com/algorand/android/utils/PassphraseKeywordUtils.kt
@@ -32,16 +32,14 @@ object PassphraseKeywordUtils {
         itemCount: Int,
         perItemCount: Int,
     ): List<PassphraseValidationItem> {
-        val diffWords = (predefinedWords - words).toMutableList()
+        val diffWords = (predefinedWords - words).shuffled().toMutableList()
         val validationItems = mutableListOf<PassphraseValidationItem>()
 
         words.withIndex()
             .shuffled()
             .take(itemCount)
             .forEach { correctWord ->
-                val incorrectOptions = diffWords
-                    .shuffled()
-                    .take(perItemCount - 1)
+                val incorrectOptions = diffWords.take(perItemCount - 1)
 
                 diffWords.removeAll(incorrectOptions)
 

--- a/app/src/main/kotlin/com/algorand/android/utils/PassphraseValidationItem.kt
+++ b/app/src/main/kotlin/com/algorand/android/utils/PassphraseValidationItem.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.utils
+
+data class PassphraseValidationItem(
+    val correctWordIndex: Int,
+    val correctWord: String,
+    val options: List<String>
+)


### PR DESCRIPTION
# Pull Request Template

## Description
- Filtering the duplicate words from the passphrase before shuffling them for the validation list

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3019

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
