### PR TITLE
PERA-2917 :: Remove bottom padding from the swap screen

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/CoreMainActivity.kt
+++ b/app/src/main/kotlin/com/algorand/android/CoreMainActivity.kt
@@ -12,6 +12,7 @@
 
 package com.algorand.android
 
+import android.graphics.Rect
 import android.os.Bundle
 import android.os.PersistableBundle
 import android.view.MenuItem
@@ -279,22 +280,36 @@ abstract class CoreMainActivity : BaseActivity() {
     }
 
     private fun setWindowInsetsForSystemBars() {
-        ViewCompat.setOnApplyWindowInsetsListener(binding.rootConstraintLayout) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars()
-                        or WindowInsetsCompat.Type.displayCutout()
+        val root = binding.rootConstraintLayout
+
+        val initialPadding = Rect(
+            root.paddingLeft,
+            root.paddingTop,
+            root.paddingRight,
+            root.paddingBottom
+        )
+
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
+            val sys = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
             )
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+
             v.updatePadding(
-                left = bars.left,
-                top = 0,
-                right = bars.right,
-                bottom = bars.bottom,
+                left = initialPadding.left + sys.left,
+                top = initialPadding.top,
+                right = initialPadding.right + sys.right,
+                bottom = initialPadding.bottom + maxOf(sys.bottom, ime.bottom)
             )
+
             binding.statusBarBackgroundView.updateLayoutParams {
-                height = bars.top
+                height = sys.top
             }
-            WindowInsetsCompat.CONSUMED
+
+            insets
         }
+
+        ViewCompat.requestApplyInsets(root)
     }
 
     private fun handleStatusBarIconColorChanges(

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/widget/view/SwapButtonWidget.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/widget/view/SwapButtonWidget.kt
@@ -16,22 +16,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.algorand.android.R
@@ -43,11 +34,9 @@ import com.algorand.wallet.swap.domain.model.SwapQuoteV2
 
 @Composable
 fun BoxScope.SwapButtonWidget(viewModel: SwapButtonViewModel, onClick: (SwapQuoteV2) -> Unit) {
-    val bottomPadding by rememberBottomPadding()
     Box(
         modifier = Modifier
             .background(color = PeraTheme.colors.background.primary)
-            .padding(bottom = bottomPadding)
             .fillMaxWidth()
             .align(Alignment.BottomCenter)
     ) {
@@ -73,16 +62,5 @@ fun BoxScope.SwapButtonWidget(viewModel: SwapButtonViewModel, onClick: (SwapQuot
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun rememberBottomPadding(): State<Dp> {
-    val density = LocalDensity.current
-    val keyboardHeight = WindowInsets.ime.getBottom(density)
-    val navigationBarHeight = WindowInsets.navigationBars.getBottom(density)
-
-    return remember(keyboardHeight, navigationBarHeight) {
-        mutableStateOf(with(density) { keyboardHeight.toDp() - navigationBarHeight.toDp() }.coerceAtLeast(0.dp))
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
- We do set insets on core main activity. Setting additional padding on swap screen was causing problem. That space is removed.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2917

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [X] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
