### PR TITLE
PERA-2800 Remove snapshot testing

### DIFF
--- a/.github/workflows/android-app-tests.yml
+++ b/.github/workflows/android-app-tests.yml
@@ -45,6 +45,10 @@ jobs:
           distribution: "zulu"
           java-version: "21"
           cache: "gradle"
+      - name: "Run KLint"
+        run: ./gradlew ktlint
+      - name: "Run Detekt"
+        run: ./gradlew detekt
       - name: "Run Lint Checks"
         run: ./gradlew lint
       - name: "Archive App Lint Test Results"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,6 @@ plugins {
 
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.compose)
-    alias(libs.plugins.screenshot)
 }
 
 apply from: "$projectDir/quality.gradle"
@@ -235,7 +234,6 @@ android {
     }
 
     namespace libs.versions.android.namespace.get().toString()
-    experimentalProperties["android.experimental.enableScreenshotTest"] = true
 }
 
 dependencies {
@@ -354,5 +352,4 @@ dependencies {
     androidTestImplementation libs.room.testing
     androidTestImplementation libs.runner
     androidTestImplementation libs.espresso.core
-    screenshotTestImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/app/quality.gradle
+++ b/app/quality.gradle
@@ -24,7 +24,7 @@ detekt {
     def configFile = new File(rootDir, 'detekt-config.yml')
     if (!configFile.exists()) {
         new File("$projectDir/detekt-config.yml")
-                .withInputStream{ i -> configFile.withOutputStream{ it << i }}
+                .withInputStream { i -> configFile.withOutputStream { it << i } }
     }
     input = files("$projectDir")
     config = files("$configFile")
@@ -78,7 +78,7 @@ tasks.register('pmd', Pmd) {
     }
 }
 
-preBuild.dependsOn('checkstyle')
-preBuild.dependsOn ktlint
-preBuild.dependsOn('detekt')
+//preBuild.dependsOn('checkstyle')
+//preBuild.dependsOn ktlint
+//preBuild.dependsOn('detekt')
 //preBuild.dependsOn('pmd')

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,3 @@ kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
 kotlin.apple.xcodeCompatibility.nowarn=true
 kotlin.apple.deprecated.allowUsingEmbedAndSignWithCocoaPodsDependencies=true
 ksp.incremental=false
-android.experimental.enableScreenshotTest=true

--- a/scripts/hook-linter
+++ b/scripts/hook-linter
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+export JAVA_HOME=`/usr/libexec/java_home -v 21`
+
+printf "\nRunning Ktlint\n"
+./gradlew ktlint
+
+printf "\nRunning Detekt\n"
+./gradlew detekt

--- a/scripts/initgithook.sh
+++ b/scripts/initgithook.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+GIT_DIR=$(git rev-parse --git-dir)
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+echo "Installing git hooks..."
+echo "GIT_DIR: $GIT_DIR"
+echo "GIT_ROOT: $GIT_ROOT"
+
+mkdir -p "${GIT_DIR}/hooks/"
+
+cp "${GIT_ROOT}/scripts/hook-linter" "${GIT_DIR}/hooks/pre-push" && chmod +x "${GIT_DIR}/hooks/pre-push"
+
+echo "Git hooks installed!"


### PR DESCRIPTION
- Removed screenshot testing to enable "cancel build if unit test fails" step. 
- Removed prebuilt lint checks and created git hooks

## To enable git hooks
We need to run `./scripts/initgithook.sh` which will create hooks folder in project's git and copy `hook-linter` as `pre-push` hook. 

**don't forget to give execution permission (`chmod +x`) to `initgithooks.sh`**

After that, `hook-linter` script will be executed right before pushing a commit. 