### PR TITLE
chore: only require API 34 for passkeys

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -241,7 +241,7 @@
             android:exported="true"
             android:theme="@style/Theme.Transparent"
             android:screenOrientation="portrait"
-            tools:targetApi="35">
+            tools:targetApi="34">
             <intent-filter>
                 <action android:name="com.algorand.android.credentials.CREATE_PASSKEY" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -259,7 +259,7 @@
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
             android:permission="android.permission.BIND_CREDENTIAL_PROVIDER_SERVICE"
-            tools:targetApi="35">
+            tools:targetApi="34">
             <intent-filter>
                 <action android:name="android.service.credentials.CredentialProviderService" />
             </intent-filter>

--- a/app/src/main/kotlin/com/algorand/android/credentials/ProviderService.kt
+++ b/app/src/main/kotlin/com/algorand/android/credentials/ProviderService.kt
@@ -39,7 +39,7 @@ import java.io.IOException
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
-@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @AndroidEntryPoint
 class ProviderService : CredentialProviderService() {
     @Inject
@@ -56,20 +56,24 @@ class ProviderService : CredentialProviderService() {
         option: BeginGetPublicKeyCredentialOption,
         pendingIntent: PendingIntent
     ): PublicKeyCredentialEntry {
-        return PublicKeyCredentialEntry.Builder(
+        var entry = PublicKeyCredentialEntry.Builder(
             applicationContext,
             passkey.username,
             pendingIntent,
             option,
         )
             .setDisplayName(passkey.userHandle)
-            .setBiometricPromptData(
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            entry = entry.setBiometricPromptData(
                 BiometricPromptData(
                     cryptoObject = null,
                     allowedAuthenticators = allowedAuthenticator,
                 ),
             )
-            .build()
+        }
+
+        return entry.build()
     }
 
     /**
@@ -81,7 +85,7 @@ class ProviderService : CredentialProviderService() {
      * @return A newly constructed credential entry of type CreateEntry.
      */
     private fun createEntry(accountName: String, passkeyCount: Int, intent: PendingIntent): CreateEntry {
-        return CreateEntry.Builder(
+        var entry = CreateEntry.Builder(
             accountName, intent
         )
             .setLastUsedTime(
@@ -91,12 +95,17 @@ class ProviderService : CredentialProviderService() {
             .setTotalCredentialCount(passkeyCount).setDescription(
                 CREDENTIAL_DESCRIPTION,
             )
-            .setBiometricPromptData(
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            entry = entry.setBiometricPromptData(
                 BiometricPromptData(
                     cryptoObject = null,
                     allowedAuthenticators = allowedAuthenticator,
                 ),
-            ).build()
+            )
+        }
+
+        return entry.build()
     }
 
     /**
@@ -162,7 +171,7 @@ class ProviderService : CredentialProviderService() {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     private suspend fun populatePasskeyData(
         option: BeginGetPublicKeyCredentialOption,
         responseBuilder: Builder,

--- a/app/src/main/kotlin/com/algorand/android/credentials/ui/CreatePasskeyActivity.kt
+++ b/app/src/main/kotlin/com/algorand/android/credentials/ui/CreatePasskeyActivity.kt
@@ -73,7 +73,7 @@ const val DEFAULT_BYTE_LENGTH = 32
  * - `passkeyRepository`: Provides operations for managing stored passkey and site data.
  * - `passkeyManager`: Handles cryptographic operations such as passkey signing and derivation.
  */
-@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @AndroidEntryPoint
 class CreatePasskeyActivity : FragmentActivity() {
     @Inject

--- a/app/src/main/kotlin/com/algorand/android/credentials/ui/GetPasskeyActivity.kt
+++ b/app/src/main/kotlin/com/algorand/android/credentials/ui/GetPasskeyActivity.kt
@@ -50,7 +50,7 @@ import java.security.Security
  * @property passkeyRepository The repository interface for accessing passkey-related data and operations.
  * @property passkeyManager The manager facilitating passkey operations and handling the assertion process.
  */
-@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @AndroidEntryPoint
 class GetPasskeyActivity : FragmentActivity() {
     @Inject

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/PasskeyActivity.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/PasskeyActivity.kt
@@ -39,7 +39,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @AndroidEntryPoint
 class PasskeyActivity : FragmentActivity(),
     ActivityCredentialRequestResolver by DefaultActivityCredentialRequestResolver() {

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/PasskeyProviderService.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/PasskeyProviderService.kt
@@ -186,7 +186,7 @@ class PasskeyProviderService : CredentialProviderService() {
             entry = entry.setBiometricPromptData(BiometricPromptDataBuilder.getDefaultPromptData())
         }
 
-        return entry .build()
+        return entry.build()
     }
 
     private fun createNewPendingIntent(action: String, extra: Bundle? = null): PendingIntent {

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/PasskeyProviderService.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/PasskeyProviderService.kt
@@ -19,7 +19,6 @@ import android.os.Bundle
 import android.os.CancellationSignal
 import android.os.OutcomeReceiver
 import androidx.annotation.RequiresApi
-import androidx.biometric.BiometricPrompt
 import androidx.credentials.exceptions.ClearCredentialException
 import androidx.credentials.exceptions.ClearCredentialUnsupportedException
 import androidx.credentials.exceptions.CreateCredentialException

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/PasskeyProviderService.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/PasskeyProviderService.kt
@@ -149,26 +149,18 @@ class PasskeyProviderService : CredentialProviderService() {
     private fun createPublicKeyCredentialEntry(entry: GetPasskeyCredentialEntry): PublicKeyCredentialEntry {
         val extras = Bundle().apply { putString(CRED_ID_KEY, entry.credentialId) }
         val intent = createNewPendingIntent(GET_PASSKEY_INTENT, extras)
-        if (Build.VERSION.SDK_INT >= 35) {
-            return PublicKeyCredentialEntry.Builder(
+        var entry = PublicKeyCredentialEntry.Builder(
                 applicationContext,
                 entry.username.orEmpty(),
                 intent,
                 entry.option
-            )
-                .setDisplayName(entry.userDisplayName)
-                .setBiometricPromptData(BiometricPromptDataBuilder.getDefaultPromptData())
-                .build()
-        } else {
-            return PublicKeyCredentialEntry.Builder(
-                applicationContext,
-                entry.username.orEmpty(),
-                intent,
-                entry.option
-            )
-                .setDisplayName(entry.userDisplayName)
-                .build()
+            ).setDisplayName(entry.userDisplayName)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            entry = entry.setBiometricPromptData(BiometricPromptDataBuilder.getDefaultPromptData())
         }
+
+        return entry.build()
     }
 
     override fun onClearCredentialStateRequest(
@@ -184,22 +176,17 @@ class PasskeyProviderService : CredentialProviderService() {
 
     private fun getCreateEntry(accountName: String, passkeyCount: Int, intent: PendingIntent): CreateEntry {
         val description = resources.getString(R.string.your_credential_will_be_saved)
-        if (Build.VERSION.SDK_INT >= 35) {
-            return CreateEntry.Builder(accountName, intent)
-                .setLastUsedTime(Instant.ofEpochMilli(0L))
-                .setPublicKeyCredentialCount(passkeyCount)
-                .setTotalCredentialCount(passkeyCount)
-                .setDescription(description)
-                .setBiometricPromptData(BiometricPromptDataBuilder.getDefaultPromptData())
-                .build()
-        } else {
-            return CreateEntry.Builder(accountName, intent)
-                .setLastUsedTime(Instant.ofEpochMilli(0L))
-                .setPublicKeyCredentialCount(passkeyCount)
-                .setTotalCredentialCount(passkeyCount)
-                .setDescription(description)
-                .build()
+        var entry = CreateEntry.Builder(accountName, intent)
+            .setLastUsedTime(Instant.ofEpochMilli(0L))
+            .setPublicKeyCredentialCount(passkeyCount)
+            .setTotalCredentialCount(passkeyCount)
+            .setDescription(description)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            entry = entry.setBiometricPromptData(BiometricPromptDataBuilder.getDefaultPromptData())
         }
+
+        return entry .build()
     }
 
     private fun createNewPendingIntent(action: String, extra: Bundle? = null): PendingIntent {

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/PasskeyProviderService.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/PasskeyProviderService.kt
@@ -19,6 +19,7 @@ import android.os.Bundle
 import android.os.CancellationSignal
 import android.os.OutcomeReceiver
 import androidx.annotation.RequiresApi
+import androidx.biometric.BiometricPrompt
 import androidx.credentials.exceptions.ClearCredentialException
 import androidx.credentials.exceptions.ClearCredentialUnsupportedException
 import androidx.credentials.exceptions.CreateCredentialException
@@ -54,7 +55,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
-@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @AndroidEntryPoint
 class PasskeyProviderService : CredentialProviderService() {
 
@@ -148,10 +149,26 @@ class PasskeyProviderService : CredentialProviderService() {
     private fun createPublicKeyCredentialEntry(entry: GetPasskeyCredentialEntry): PublicKeyCredentialEntry {
         val extras = Bundle().apply { putString(CRED_ID_KEY, entry.credentialId) }
         val intent = createNewPendingIntent(GET_PASSKEY_INTENT, extras)
-        return PublicKeyCredentialEntry.Builder(applicationContext, entry.username.orEmpty(), intent, entry.option)
-            .setDisplayName(entry.userDisplayName)
-            .setBiometricPromptData(BiometricPromptDataBuilder.getDefaultPromptData())
-            .build()
+        if (Build.VERSION.SDK_INT >= 35) {
+            return PublicKeyCredentialEntry.Builder(
+                applicationContext,
+                entry.username.orEmpty(),
+                intent,
+                entry.option
+            )
+                .setDisplayName(entry.userDisplayName)
+                .setBiometricPromptData(BiometricPromptDataBuilder.getDefaultPromptData())
+                .build()
+        } else {
+            return PublicKeyCredentialEntry.Builder(
+                applicationContext,
+                entry.username.orEmpty(),
+                intent,
+                entry.option
+            )
+                .setDisplayName(entry.userDisplayName)
+                .build()
+        }
     }
 
     override fun onClearCredentialStateRequest(
@@ -167,13 +184,22 @@ class PasskeyProviderService : CredentialProviderService() {
 
     private fun getCreateEntry(accountName: String, passkeyCount: Int, intent: PendingIntent): CreateEntry {
         val description = resources.getString(R.string.your_credential_will_be_saved)
-        return CreateEntry.Builder(accountName, intent)
-            .setLastUsedTime(Instant.ofEpochMilli(0L))
-            .setPublicKeyCredentialCount(passkeyCount)
-            .setTotalCredentialCount(passkeyCount)
-            .setDescription(description)
-            .setBiometricPromptData(BiometricPromptDataBuilder.getDefaultPromptData())
-            .build()
+        if (Build.VERSION.SDK_INT >= 35) {
+            return CreateEntry.Builder(accountName, intent)
+                .setLastUsedTime(Instant.ofEpochMilli(0L))
+                .setPublicKeyCredentialCount(passkeyCount)
+                .setTotalCredentialCount(passkeyCount)
+                .setDescription(description)
+                .setBiometricPromptData(BiometricPromptDataBuilder.getDefaultPromptData())
+                .build()
+        } else {
+            return CreateEntry.Builder(accountName, intent)
+                .setLastUsedTime(Instant.ofEpochMilli(0L))
+                .setPublicKeyCredentialCount(passkeyCount)
+                .setTotalCredentialCount(passkeyCount)
+                .setDescription(description)
+                .build()
+        }
     }
 
     private fun createNewPendingIntent(action: String, extra: Bundle? = null): PendingIntent {

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/mapper/DefaultCreatePasskeyParamsMapper.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/mapper/DefaultCreatePasskeyParamsMapper.kt
@@ -20,7 +20,7 @@ import com.algorand.android.credentials.passkeys.domain.model.PublicKeyCredentia
 import com.algorand.android.credentials.passkeys.ui.viewmodel.CreatePasskeyViewModel.CreatePasskeyParams
 import javax.inject.Inject
 
-@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 internal class DefaultCreatePasskeyParamsMapper @Inject constructor() : CreatePasskeyParamsMapper {
 
     override fun invoke(

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/CreatePasskeyViewModel.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/CreatePasskeyViewModel.kt
@@ -38,7 +38,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 
-@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @HiltViewModel
 internal class CreatePasskeyViewModel @Inject constructor(
     private val eventDelegate: EventDelegate<ViewEvent>,

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/validator/DefaultCreatePasskeyIntentValidator.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/validator/DefaultCreatePasskeyIntentValidator.kt
@@ -29,7 +29,7 @@ import com.algorand.android.credentials.passkeys.validator.AppInfoValidationResu
 import com.algorand.android.credentials.passkeys.validator.AppInfoValidationResult.Success
 import javax.inject.Inject
 
-@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 internal class DefaultCreatePasskeyIntentValidator @Inject constructor(
     private val appInfoValidator: CallingAppInfoValidator,
     private val createPasskeyParamsMapper: CreatePasskeyParamsMapper,

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/validator/DefaultGetPasskeyIntentValidator.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/validator/DefaultGetPasskeyIntentValidator.kt
@@ -26,7 +26,7 @@ import com.algorand.android.credentials.passkeys.ui.model.GetPasskeyIntentValida
 import com.algorand.android.credentials.passkeys.ui.viewmodel.GetPasskeyViewModel
 import javax.inject.Inject
 
-@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 internal class DefaultGetPasskeyIntentValidator @Inject constructor(
     private val appInfoValidator: CallingAppInfoValidator,
     private val getPasskeyByCredentialId: GetPasskeyByCredentialId


### PR DESCRIPTION
# Pull Request Template

## Description
Downgrades the passkey support to API 34 which is where Android added support for 3rd party credential providers.  The in-flow biometrics is only supported on 35 though.

## Related Issues
Part of https://algorandfoundation.atlassian.net/browse/PERA-3067

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [ ] Have you documented any necessary changes in the project's documentation?
- [ ] Have you added any necessary tests for your changes?
- [ ] Have you updated any relevant dependencies?

## Additional Notes
I only have an Android 15 device so can't actually test the API 34 flow
