### PR TITLE
fix: Mobile browser passkey flow

### DIFF
--- a/common-sdk/src/main/kotlin/com/algorand/wallet/remoteconfig/data/repository/FeatureToggleRepositoryImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/remoteconfig/data/repository/FeatureToggleRepositoryImpl.kt
@@ -25,6 +25,6 @@ internal class FeatureToggleRepositoryImpl @Inject constructor(
     }
 
     override fun isFeatureEnabled(featureName: String): Boolean {
-        return true //return firebaseRemoteConfigService.getBoolean(featureName)
+        return firebaseRemoteConfigService.getBoolean(featureName)
     }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/remoteconfig/data/repository/FeatureToggleRepositoryImpl.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/remoteconfig/data/repository/FeatureToggleRepositoryImpl.kt
@@ -25,6 +25,6 @@ internal class FeatureToggleRepositoryImpl @Inject constructor(
     }
 
     override fun isFeatureEnabled(featureName: String): Boolean {
-        return firebaseRemoteConfigService.getBoolean(featureName)
+        return true //return firebaseRemoteConfigService.getBoolean(featureName)
     }
 }

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/DefaultGetCredentialResponseProcessor.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/DefaultGetCredentialResponseProcessor.kt
@@ -37,7 +37,12 @@ internal class DefaultGetCredentialResponseProcessor @Inject constructor(
 
         val authAssertionResponse = getAuthAssertionResponse(params, callingOrigin).apply {
             // QR code routes seem to have no / but mobile browser embedded routes seem to add the trailing /
-            val origin = if (params.origin.endsWith("/")) params.origin.substring(0, params.origin.length - 1) else params.origin
+            val origin =
+                if (params.origin.endsWith("/")) {
+                    params.origin.substring(0, params.origin.length - 1)
+                } else {
+                    params.origin
+                }
             signature = bip39SignManager
                 .sign(params.bip44Address, origin, params.username, dataToSign())
                 ?: byteArrayOf()

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/DefaultGetCredentialResponseProcessor.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/DefaultGetCredentialResponseProcessor.kt
@@ -15,12 +15,14 @@ package com.algorand.android.credentials.passkeys.ui.viewmodel
 import androidx.credentials.GetCredentialResponse
 import androidx.credentials.PublicKeyCredential
 import com.algorand.android.credentials.passkeys.domain.Bip39SignManager
+import com.algorand.android.credentials.passkeys.domain.WebAuthnUtils
 import com.algorand.android.credentials.passkeys.domain.model.AuthenticatorAssertionResponse
 import com.algorand.android.credentials.passkeys.domain.model.AuthenticatorFlags
 import com.algorand.android.credentials.passkeys.domain.model.FidoPublicKeyCredential
 import com.algorand.android.credentials.passkeys.domain.usecase.SetPasskeyLastUsedTime
 import com.algorand.android.credentials.passkeys.ui.viewmodel.GetPasskeyViewModel.GetCredentialsParams
 import com.algorand.wallet.utils.date.TimeProvider
+import java.util.logging.Logger
 import javax.inject.Inject
 
 internal class DefaultGetCredentialResponseProcessor @Inject constructor(
@@ -36,8 +38,10 @@ internal class DefaultGetCredentialResponseProcessor @Inject constructor(
         }
 
         val authAssertionResponse = getAuthAssertionResponse(params, callingOrigin).apply {
+            // QR code routes seem to have no / but mobile browser embedded routes seem to add the trailing /
+            val origin = if (params.origin.endsWith("/")) params.origin.substring(0, params.origin.length - 1) else params.origin
             signature = bip39SignManager
-                .sign(params.bip44Address, params.origin, params.username, dataToSign())
+                .sign(params.bip44Address, origin, params.username, dataToSign())
                 ?: byteArrayOf()
         }
         setPasskeyLastUsedTime(params.credId, timeProvider.getCurrentTimeMillis())

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/DefaultGetCredentialResponseProcessor.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/DefaultGetCredentialResponseProcessor.kt
@@ -15,14 +15,12 @@ package com.algorand.android.credentials.passkeys.ui.viewmodel
 import androidx.credentials.GetCredentialResponse
 import androidx.credentials.PublicKeyCredential
 import com.algorand.android.credentials.passkeys.domain.Bip39SignManager
-import com.algorand.android.credentials.passkeys.domain.WebAuthnUtils
 import com.algorand.android.credentials.passkeys.domain.model.AuthenticatorAssertionResponse
 import com.algorand.android.credentials.passkeys.domain.model.AuthenticatorFlags
 import com.algorand.android.credentials.passkeys.domain.model.FidoPublicKeyCredential
 import com.algorand.android.credentials.passkeys.domain.usecase.SetPasskeyLastUsedTime
 import com.algorand.android.credentials.passkeys.ui.viewmodel.GetPasskeyViewModel.GetCredentialsParams
 import com.algorand.wallet.utils.date.TimeProvider
-import java.util.logging.Logger
 import javax.inject.Inject
 
 internal class DefaultGetCredentialResponseProcessor @Inject constructor(

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/DefaultGetCredentialResponseProcessor.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/DefaultGetCredentialResponseProcessor.kt
@@ -37,12 +37,7 @@ internal class DefaultGetCredentialResponseProcessor @Inject constructor(
 
         val authAssertionResponse = getAuthAssertionResponse(params, callingOrigin).apply {
             // QR code routes seem to have no / but mobile browser embedded routes seem to add the trailing /
-            val origin =
-                if (params.origin.endsWith("/")) {
-                    params.origin.substring(0, params.origin.length - 1)
-                } else {
-                    params.origin
-                }
+    val origin = params.origin.removeSuffix("/")
             signature = bip39SignManager
                 .sign(params.bip44Address, origin, params.username, dataToSign())
                 ?: byteArrayOf()


### PR DESCRIPTION
# Pull Request Template

## Description
When launching the passkey flow from inside the mobile browser (i.e. without QR code) they seem to add a trailing / to the origin, but when you register the passkey there is no / (and when you use the QR code), so the authentication fails.  This removes the / in authentication.  

Tested with:

- Created passkey with embedded flow and authenticated with embedded and QR code
- Created passkey with QR clow and authenticated with embedded and QR code

## Related Issues
https://algorandfoundation.atlassian.net/browse/PERA-3079

## Checklist
- [X] Have you tested your changes locally?
- [ ] Have you reviewed the code for any potential issues?
- [ ] Have you documented any necessary changes in the project's documentation?
- [ ] Have you added any necessary tests for your changes?
- [ ] Have you updated any relevant dependencies?

## Additional Notes
