### PR TITLE
PERA-3067 Remove trailing slash from origin

### DIFF
--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/DefaultGetCredentialResponseProcessor.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/ui/viewmodel/DefaultGetCredentialResponseProcessor.kt
@@ -36,10 +36,8 @@ internal class DefaultGetCredentialResponseProcessor @Inject constructor(
         }
 
         val authAssertionResponse = getAuthAssertionResponse(params, callingOrigin).apply {
-            // QR code routes seem to have no / but mobile browser embedded routes seem to add the trailing /
-    val origin = params.origin.removeSuffix("/")
             signature = bip39SignManager
-                .sign(params.bip44Address, origin, params.username, dataToSign())
+                .sign(params.bip44Address, params.origin, params.username, dataToSign())
                 ?: byteArrayOf()
         }
         setPasskeyLastUsedTime(params.credId, timeProvider.getCurrentTimeMillis())

--- a/credentials/src/main/java/com/algorand/android/credentials/passkeys/validator/domain/usecase/GetCallingAppOriginCheckingGpmAllowlistUseCase.kt
+++ b/credentials/src/main/java/com/algorand/android/credentials/passkeys/validator/domain/usecase/GetCallingAppOriginCheckingGpmAllowlistUseCase.kt
@@ -33,7 +33,7 @@ internal class GetCallingAppOriginCheckingGpmAllowlistUseCase @Inject constructo
 
     private fun getOrigin(callingAppInfo: CallingAppInfo, allowlist: JsonElement): PeraResult<String> {
         return try {
-            PeraResult.Success(callingAppInfo.getOrigin(allowlist.toString()).orEmpty())
+            PeraResult.Success(callingAppInfo.getOrigin(allowlist.toString()).orEmpty().removeSuffix("/"))
         } catch (e: Exception) {
             PeraResult.Error(e)
         }


### PR DESCRIPTION
## Description

Tested scenarios;

- Register passkey - mobile browser
    - Auth - mobile Chrome browser
    - Auth - mobile Brave browser
    - Auth - mobile Firefox browser
    - Auth - desktop browser - in-app qr scanner
    - Auth - desktop browser - android camera app

- Register passkey - desktop browser - android camera app & in-app qr scanner
    - Auth - desktop browser - android camera app
    - Auth - desktop browser - in-app qr scanner
    - Auth - mobile Chrome browser
    - Auth - mobile Brave browser
    - Auth - mobile Firefox browser

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3067

