### PR TITLE
PERA-3172 Exclude algosdk classes from obfuscation

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -27,6 +27,7 @@
 -keep interface com.algorand.wallet.** { *; }
 -keep class androidx.** { *; }
 -keep class com.algorand.android.**.model.** { *; }
+-keep class com.algorand.algosdk.** { *; }
 
 -keep class com.algorand.android.ui.wctransactionrequest.WalletConnectTransactionListItem
 # ---------------- END PERA ---------------------


### PR DESCRIPTION
## Description
App was unable to deserialize AlgodClient classes due to obfuscation.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3172
