### PR TITLE
PERA-3127 :: Use double instead of float for slippage tolerance

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/swap/configuration/model/SwapConfigurationResult.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/configuration/model/SwapConfigurationResult.kt
@@ -13,7 +13,7 @@
 package com.algorand.android.ui.swap.configuration.model
 
 data class SwapConfigurationResult(
-    val balancePercentage: Float?,
-    val slippageTolerance: Float?,
+    val balancePercentage: Int?,
+    val slippageTolerance: Double?,
     val useLocalCurrency: Boolean
 )

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/configuration/view/SwapConfigurationBottomSheet.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/configuration/view/SwapConfigurationBottomSheet.kt
@@ -65,14 +65,14 @@ import com.algorand.android.ui.swap.configuration.view.ChipOption.Companion.CUST
 import com.algorand.android.ui.swap.viewmodel.SwapViewModel
 import com.algorand.android.utils.emptyString
 import com.algorand.android.utils.extensions.capitalizeWords
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.Locale
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 private const val MAX_BALANCE = 100
-private const val MIN_BALANCE = 0
+private const val MIN_BALANCE = 1
 private const val MAX_SLIPPAGE = 10f
 private const val MIN_SLIPPAGE = 0.01f
 
@@ -110,8 +110,8 @@ fun SwapConfigurationBottomSheet(
                 endContainer = {
                     PeraToolbarTextButton(text = stringResource(R.string.apply), enabled = isApplyButtonEnabled) {
                         val result = SwapConfigurationResult(
-                            balancePercentage = balanceTextState.value.text.toFloatOrNull(),
-                            slippageTolerance = slippageTextState.value.text.toFloatOrNull(),
+                            balancePercentage = balanceTextState.value.text.toIntOrNull(),
+                            slippageTolerance = slippageTextState.value.text.toDoubleOrNull(),
                             useLocalCurrency = localCurrencyState.value
                         )
                         scope.launch { swapViewModel.logSettingsApplyClick() }

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/view/SwapScreenContentState.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/view/SwapScreenContentState.kt
@@ -127,7 +127,7 @@ fun SwapScreenContentState(
                 onApplyClick = {
                     swapViewModel.applySwapConfigs(it)
                     if (it.balancePercentage != null) {
-                        val percentage = it.balancePercentage.toInt()
+                        val percentage = it.balancePercentage
                         widgetViewModel.setAmountByPercentage(swapViewModel.getSwapDetails(), percentage)
                     }
                     swapConfigurationBottomSheetState.hide()

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/viewmodel/SwapViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/viewmodel/SwapViewModel.kt
@@ -249,7 +249,7 @@ class SwapViewModel @Inject constructor(
         val address: String? = null,
         val assetInId: Long = ALGO_ID,
         val assetOutId: Long = USDC_MAINNET_ID,
-        val slippage: Float? = null,
+        val slippage: Double? = null,
         val useLocalCurrency: Boolean = false,
         val primaryCurrencySymbol: String = ""
     )

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/widget/mapper/DefaultSwapQuoteFetchStateMapper.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/widget/mapper/DefaultSwapQuoteFetchStateMapper.kt
@@ -69,6 +69,6 @@ internal class DefaultSwapQuoteFetchStateMapper @Inject constructor(
     }
 
     private companion object {
-        const val SLIPPAGE_TOLERANCE_DIVIDER = 100f
+        const val SLIPPAGE_TOLERANCE_DIVIDER = 100.0
     }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapQuoteRequestBody.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/model/SwapQuoteRequestBody.kt
@@ -29,5 +29,5 @@ internal data class SwapQuoteRequestBody(
     @SerializedName("amount")
     val amount: BigInteger,
     @SerializedName("slippage")
-    val slippage: Float?
+    val slippage: Double?
 )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepository.kt
@@ -51,7 +51,7 @@ internal class DefaultSwapRepository @Inject constructor(
     private val topSwapPairsMapper: TopSwapPairsMapper,
     private val swapUpdateStatusRequestBodyMapper: SwapUpdateStatusRequestBodyMapper,
     private val useLocalCurrencyCache: PersistentCache<Boolean>,
-    private val slippageTolerancePersistentCache: PersistentCache<Float>
+    private val slippageTolerancePersistentCache: PersistentCache<Double>
 ) : SwapRepository {
 
     override suspend fun getSwapQuotes(payload: SwapQuoteRequestPayload): PeraResult<List<SwapQuoteV2>> {
@@ -156,11 +156,11 @@ internal class DefaultSwapRepository @Inject constructor(
         useLocalCurrencyCache.put(useLocalCurrency)
     }
 
-    override suspend fun getSlippageTolerancePercentage(): Float? {
+    override suspend fun getSlippageTolerancePercentage(): Double? {
         return slippageTolerancePersistentCache.get()
     }
 
-    override suspend fun setSlippageTolerancePercentage(percentage: Float?) {
+    override suspend fun setSlippageTolerancePercentage(percentage: Double?) {
         if (percentage == null) {
             slippageTolerancePersistentCache.clear()
         } else {

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/di/SwapModule.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/di/SwapModule.kt
@@ -127,8 +127,8 @@ internal object SwapModule {
                 type = Boolean::class.java,
                 key = "swap_use_local_currency_preference",
             ),
-            slippageTolerancePersistentCache = persistentCacheProvider.getPersistentCache<Float>(
-                type = Float::class.java,
+            slippageTolerancePersistentCache = persistentCacheProvider.getPersistentCache<Double>(
+                type = Double::class.java,
                 key = "swap_slippage_tolerance_preference",
             )
         )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/model/SwapQuotePayload.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/model/SwapQuotePayload.kt
@@ -19,5 +19,5 @@ data class SwapQuotePayload(
     val assetInId: Long,
     val assetOutId: Long,
     val amount: BigInteger,
-    val slippage: Float?
+    val slippage: Double?
 )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/model/SwapQuoteRequestPayload.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/model/SwapQuoteRequestPayload.kt
@@ -20,5 +20,5 @@ data class SwapQuoteRequestPayload(
     val assetOutId: Long,
     val amount: BigInteger,
     val deviceId: String,
-    val slippage: Float? = null
+    val slippage: Double? = null
 )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/repository/SwapRepository.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/repository/SwapRepository.kt
@@ -35,6 +35,6 @@ internal interface SwapRepository {
     suspend fun setUseLocalCurrencyPreference(useLocalCurrency: Boolean)
     suspend fun setSwapStatusFailed(quoteId: Long, reason: SwapStatusFailureReason)
     suspend fun setSwapStatusInProgress(swapId: Long, txnIds: List<TransactionId>)
-    suspend fun setSlippageTolerancePercentage(percentage: Float?)
-    suspend fun getSlippageTolerancePercentage(): Float?
+    suspend fun setSlippageTolerancePercentage(percentage: Double?)
+    suspend fun getSlippageTolerancePercentage(): Double?
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/usecase/SwapUseCases.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/swap/domain/usecase/SwapUseCases.kt
@@ -101,9 +101,9 @@ fun interface SendSwapTransactions {
 }
 
 fun interface SetSwapSlippageTolerancePercentage {
-    suspend operator fun invoke(percentage: Float?)
+    suspend operator fun invoke(percentage: Double?)
 }
 
 fun interface GetSwapSlippageTolerancePercentage {
-    suspend operator fun invoke(): Float?
+    suspend operator fun invoke(): Double?
 }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/swap/data/mapper/DefaultSwapQuoteRequestBodyMapperTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/swap/data/mapper/DefaultSwapQuoteRequestBodyMapperTest.kt
@@ -57,7 +57,7 @@ class DefaultSwapQuoteRequestBodyMapperTest {
             assetInId = 1L,
             assetOutId = 2L,
             amount = BigInteger.valueOf(10_000),
-            slippage = 0.01f
+            slippage = 0.01
         )
 
         val REQUEST_BODY = SwapQuoteRequestBody(
@@ -66,7 +66,7 @@ class DefaultSwapQuoteRequestBodyMapperTest {
             assetInId = 1L,
             assetOutId = 2L,
             amount = BigInteger.valueOf(10_000),
-            slippage = 0.01f,
+            slippage = 0.01,
             swapType = SwapTypeResponse.FIXED_INPUT
         )
     }

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepositoryTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/swap/data/repository/DefaultSwapRepositoryTest.kt
@@ -64,7 +64,7 @@ class DefaultSwapRepositoryTest {
     private val swapQuoteProviderMapper: SwapQuoteProviderMapper = mockk()
     private val topSwapPairsMapper: TopSwapPairsMapper = mockk()
     private val useLocalCurrencyCache: PersistentCache<Boolean> = mockk(relaxed = true)
-    private val slippageToleranceCache: PersistentCache<Float> = mockk(relaxed = true)
+    private val slippageToleranceCache: PersistentCache<Double> = mockk(relaxed = true)
     private val swapUpdateStatusRequestBodyMapper: SwapUpdateStatusRequestBodyMapper = mockk(relaxed = true)
 
     private val sut = DefaultSwapRepository(

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/swap/domain/usecase/GetSwapQuotesUseCaseTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/swap/domain/usecase/GetSwapQuotesUseCaseTest.kt
@@ -162,7 +162,7 @@ class GetSwapQuotesUseCaseTest {
         val ASSET_IN = peraFixture<Long>()
         val ASSET_OUT = peraFixture<Long>()
         val AMOUNT = peraFixture<BigInteger>()
-        val SLIPPAGE = peraFixture<Float?>()
+        val SLIPPAGE = peraFixture<Double?>()
 
         val PAYLOAD = SwapQuotePayload(ADDRESS, ASSET_IN, ASSET_OUT, AMOUNT, SLIPPAGE)
         val REQUEST = SwapQuoteRequestPayload(ADDRESS, ASSET_IN, ASSET_OUT, AMOUNT, DEVICE_ID, SLIPPAGE)


### PR DESCRIPTION
## Description
0.03f / 100f was causing floating point inaccuracy; 2.9999999E-4. Replaced float usages with double for slippage tolerance

## Related Issues
Closes https://algorandfoundation.atlassian.net/browse/PERA-3127