### PR TITLE
PERA-3148 Optimize github workflow

### DIFF
--- a/.github/workflows/android-app-tests.yml
+++ b/.github/workflows/android-app-tests.yml
@@ -1,18 +1,16 @@
-name: "Android App Tests"
+name: "Android App Checks"
 
 on:
-
-  push:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:
 
-  android-unit-tests:
-    name: "Android App Unit Tests"
+  android-build:
+    name: "Android App Build"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
@@ -23,6 +21,17 @@ jobs:
           distribution: "zulu"
           java-version: "21"
           cache: "gradle"
+      - name: "Run KtLint"
+        run: ./gradlew ktlint
+      - name: "Run Detekt"
+        run: ./gradlew detekt
+      - name: "Archive App Lint Test Results"
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: "app-lint-results"
+          path: ./**/build/reports/**
+          overwrite: true
       - name: "Run Unit Tests"
         run: ./gradlew testDebugUnitTest
       - name: "Archive App Unit Tests Report"
@@ -32,45 +41,6 @@ jobs:
           name: "app-unit-tests-results"
           path: ./**/build/reports/**
           overwrite: true
-
-  android-lint:
-    name: "Android App Lint Checks"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-      - name: "Install JDK 21"
-        uses: actions/setup-java@v4
-        with:
-          distribution: "zulu"
-          java-version: "21"
-          cache: "gradle"
-      - name: "Run KLint"
-        run: ./gradlew ktlint
-      - name: "Run Detekt"
-        run: ./gradlew detekt
-      - name: "Run Lint Checks"
-        run: ./gradlew lint
-      - name: "Archive App Lint Test Results"
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: "app-lint-results"
-          path: ./**/build/reports/**
-          overwrite: true
-
-  android-test-coverage:
-    name: "Android common-sdk Test Coverage"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-      - name: "Install JDK 21"
-        uses: actions/setup-java@v4
-        with:
-          distribution: "zulu"
-          java-version: "21"
-          cache: "gradle"
       - name: "Update packages"
         run: sudo apt-get update
       - name: "Install xmlstarlet"
@@ -84,18 +54,5 @@ jobs:
           name: "test-coverage-result"
           path: ./common-sdk/build/reports/kover/**
           overwrite: true
-
-  android-bundle-publish-test:
-    name: "Android App Bundle Publish Test"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-      - name: "Install JDK 21"
-        uses: actions/setup-java@v4
-        with:
-          distribution: "zulu"
-          java-version: "21"
-          cache: "gradle"
-      - name: "Run App Bundle Publish Test"
-        run: ./gradlew packageProdReleaseBundle
+      - name: "Build Prod Debug Bundle"
+        run: ./gradlew packageProdDebugBundle


### PR DESCRIPTION
## Description
- Removed `push` trigger
    - This change will remove duplicate jobs, however it won't run after merging which we don't check because of Bitrise. 
- Removed `lint` step
    - Last step (build) is already checking critical lint issues. `lint` step runs for every build type which takes ~10 mins. Since we don't check warning from GitHub action, no need to keep this step. 
- Replaced `prod build` with `debug build`
    - Biggest difference is obfuscation. Since we don't get obfuscation related issues on compile time and we have bitrise workflow, no need to build prod which takes ~18 min, while debug is taking ~10 mins. 

Previous build times:  ~21 minutes
<img width="299" height="215" alt="Screenshot 2025-11-12 at 20 00 21" src="https://github.com/user-attachments/assets/83e6a6bd-931b-4487-aeb0-dc949ef86869" />

Latest build time: ~12 minutes
<img width="280" height="87" alt="Screenshot 2025-11-12 at 20 00 56" src="https://github.com/user-attachments/assets/ef323d64-3c3f-4db4-9e60-a4a5c2a98a04" />

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3148
