### PR TITLE
PERA-3184 :: Define global nav action to prevent nav failure

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/send/transferpreview/AssetTransferPreviewFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/send/transferpreview/AssetTransferPreviewFragment.kt
@@ -22,6 +22,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.viewModels
 import com.algorand.android.HomeNavigationDirections
 import com.algorand.android.R
+import com.algorand.android.SendAlgoNavigationDirections
 import com.algorand.android.core.transaction.TransactionSignBaseFragment
 import com.algorand.android.databinding.FragmentTransferAssetPreviewBinding
 import com.algorand.android.models.AnnotatedString
@@ -391,11 +392,10 @@ class AssetTransferPreviewFragment : TransactionSignBaseFragment(R.layout.fragme
 
     private fun navToTransactionConfirmationNavigation(transactionId: String) {
         nav(
-            AssetTransferPreviewFragmentDirections
-                .actionAssetTransferPreviewFragmentToTransactionConfirmationNavigation(
-                    transactionId = transactionId,
-                    titleResId = R.string.asset_transfer_completed
-                )
+            SendAlgoNavigationDirections.actionGlobalTransactionConfirmationNavigation(
+                transactionId = transactionId,
+                titleResId = R.string.asset_transfer_completed
+            )
         )
     }
 

--- a/app/src/main/kotlin/com/algorand/android/ui/send/transferpreview/AssetTransferPreviewViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/send/transferpreview/AssetTransferPreviewViewModel.kt
@@ -138,6 +138,7 @@ class AssetTransferPreviewViewModel @Inject constructor(
     }
 
     fun onNoteUpdate(newNote: String) {
+        if (sendAlgoJob?.isActive == true) return
         viewModelScope.launch {
             if (_assetTransferPreviewFlow.value?.isNoteEditable == true) {
                 val newPreview = _assetTransferPreviewFlow.value?.copy(note = newNote)

--- a/app/src/main/res/navigation/send_algo_navigation.xml
+++ b/app/src/main/res/navigation/send_algo_navigation.xml
@@ -291,16 +291,6 @@
                 android:defaultValue="true"
                 app:argType="boolean" />
         </action>
-        <action
-            android:id="@+id/action_assetTransferPreviewFragment_to_transactionConfirmationNavigation"
-            app:destination="@id/transactionConfirmationNavigation">
-            <argument
-                android:name="transactionId"
-                app:argType="string" />
-            <argument
-                android:name="titleResId"
-                app:argType="integer" />
-        </action>
     </fragment>
 
     <dialog

--- a/app/src/main/res/navigation/send_algo_navigation.xml
+++ b/app/src/main/res/navigation/send_algo_navigation.xml
@@ -32,6 +32,17 @@
         app:popUpToInclusive="true" />
 
     <action
+        android:id="@+id/action_global_transactionConfirmationNavigation"
+        app:destination="@id/transactionConfirmationNavigation">
+        <argument
+            android:name="transactionId"
+            app:argType="string" />
+        <argument
+            android:name="titleResId"
+            app:argType="integer" />
+    </action>
+
+    <action
         android:id="@+id/action_global_singleButtonBottomSheet"
         app:destination="@id/singleButtonBottomSheetNavigation">
         <argument


### PR DESCRIPTION
## Description
- Tapping on add note button and confirm button at the same time was causing navigation failure, which is solved by creating global action. 

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3184
