### PR TITLE
PERA-2868 Add add asset title to asset addition  button

### DIFF
--- a/app/src/main/res/layout/item_account_detail_asset_title.xml
+++ b/app/src/main/res/layout/item_account_detail_asset_title.xml
@@ -29,6 +29,7 @@
         app:primaryButtonIcon="@drawable/ic_customize"
         app:primaryButtonText="@string/manage"
         app:secondaryButtonIcon="@drawable/ic_plus"
+        app:secondaryButtonText="@string/add_asset"
         app:title="@string/assets" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -676,6 +676,7 @@
     <string name="search_assets_id">Search Assets ID or Name</string>
     <string name="no_asset_found">No Asset Found</string>
     <string name="adding_asset">Adding Asset</string>
+    <string name="add_asset">Add Asset</string>
     <string name="removing_asset">Removing Asset</string>
     <string name="to_opt_out_from_an_asset">To opt-out from an asset, you must first transfer any remaining balance to another account.</string>
     <string name="show_asset_url">Show Asset URL</string>


### PR DESCRIPTION
## Description
Plus icon seems a little larger than the current design, because I used existing component not to create a new one. If necessary, I recreate the component to match the design.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2868

<img width="437" height="441" alt="Screenshot 2025-11-30 at 18 30 14" src="https://github.com/user-attachments/assets/a84916fb-e4ee-4ac7-ab45-921a03a519fd" />
