### PR TITLE
PERA-3219 :: WalletConnect fixes

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/dependencyinjection/NetworkModule.kt
+++ b/app/src/main/kotlin/com/algorand/android/dependencyinjection/NetworkModule.kt
@@ -28,14 +28,14 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import java.util.concurrent.TimeUnit
+import javax.inject.Named
+import javax.inject.Singleton
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import java.util.concurrent.TimeUnit
-import javax.inject.Named
-import javax.inject.Singleton
 
 /**
  * Module which provides all required dependencies about network
@@ -139,20 +139,6 @@ object NetworkModule {
     @Singleton
     @Named("algodExplorerPriceHttpClient")
     fun provideAlgodExplorerPriceHttpClient(
-        loggingInterceptor: HttpLoggingInterceptor
-    ): OkHttpClient {
-        return OkHttpClient.Builder()
-            .addInterceptor(loggingInterceptor)
-            .connectTimeout(TIMEOUT_CONSTANT, TimeUnit.SECONDS)
-            .readTimeout(TIMEOUT_CONSTANT, TimeUnit.SECONDS)
-            .writeTimeout(TIMEOUT_CONSTANT, TimeUnit.SECONDS)
-            .build()
-    }
-
-    @Provides
-    @Singleton
-    @Named("walletConnectHttpClient")
-    fun provideWalletConnectHttpClient(
         loggingInterceptor: HttpLoggingInterceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/client/v1/WalletConnectClientV1Impl.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/client/v1/WalletConnectClientV1Impl.kt
@@ -52,10 +52,10 @@ import com.algorand.android.utils.getCurrentTimeAsSec
 import com.algorand.android.utils.launchIO
 import com.algorand.android.utils.recordException
 import com.algorand.android.utils.walletconnect.WalletConnectSessionRetryCounter
+import javax.inject.Named
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import javax.inject.Named
 
 @Suppress("LongParameterList")
 class WalletConnectClientV1Impl(
@@ -352,7 +352,7 @@ class WalletConnectClientV1Impl(
     private fun connectToSession(sessionCacheData: WalletConnectV1SessionCachedData) {
         with(sessionCacheData) {
             addCallback(sessionCacheDataCallback)
-            session.offer()
+            session.init()
         }
         sessionCachedDataHandler.addNewCachedData(sessionCacheData)
     }

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/client/v1/session/WalletConnectSessionBuilder.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/client/v1/session/WalletConnectSessionBuilder.kt
@@ -28,8 +28,8 @@ import com.algorand.android.utils.walletconnect.peermeta.WalletConnectPeraPeerMe
 import com.algorand.android.utils.walletconnect.peermeta.WalletConnectSessionPeerMetaBuilder
 import com.google.gson.Gson
 import com.squareup.moshi.Moshi
-import okhttp3.OkHttpClient
 import javax.inject.Inject
+import okhttp3.OkHttpClient
 
 class WalletConnectSessionBuilder @Inject constructor(
     private val gson: Gson,
@@ -76,9 +76,7 @@ class WalletConnectSessionBuilder @Inject constructor(
             sessionStore = storage,
             transportBuilder = OkHttpTransport.Builder(okHttpClient, moshi),
             clientMeta = WalletConnectSessionPeerMetaBuilder.build(WalletConnectPeraPeerMeta)
-        ).apply {
-            init()
-        }
+        )
 
         return WalletConnectV1SessionCachedData.create(
             session = session,

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/client/v1/session/WalletConnectV1SessionCachedDataHandler.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/client/v1/session/WalletConnectV1SessionCachedDataHandler.kt
@@ -20,7 +20,8 @@ import javax.inject.Singleton
 @Singleton
 class WalletConnectV1SessionCachedDataHandler @Inject constructor() {
 
-    private val connectedSessions: ConcurrentHashMap<Long, WalletConnectV1SessionCachedData> = ConcurrentHashMap(50)
+    private val connectedSessions: ConcurrentHashMap<Long, WalletConnectV1SessionCachedData> =
+        ConcurrentHashMap(INITIAL_CAPACITY)
 
     fun getSessionById(id: Long): WCSession? = connectedSessions[id]?.session
 
@@ -33,5 +34,9 @@ class WalletConnectV1SessionCachedDataHandler @Inject constructor() {
 
     fun deleteCachedData(sessionId: Long, onCacheDeleted: (WalletConnectV1SessionCachedData) -> Unit) {
         connectedSessions.remove(sessionId)?.also { onCacheDeleted(it) }
+    }
+
+    private companion object {
+        const val INITIAL_CAPACITY = 50
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/client/v1/session/WalletConnectV1SessionCachedDataHandler.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/client/v1/session/WalletConnectV1SessionCachedDataHandler.kt
@@ -13,47 +13,25 @@
 package com.algorand.android.modules.walletconnect.client.v1.session
 
 import app.perawallet.walletconnectv1.impls.WCSession
-import com.algorand.android.modules.walletconnect.client.v1.session.WalletConnectV1SessionCachedData.Companion.INITIAL_RETRY_COUNT
-import com.algorand.android.utils.popIfOrNull
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class WalletConnectV1SessionCachedDataHandler @Inject constructor() {
 
-    private val connectedSessions: MutableList<WalletConnectV1SessionCachedData> = mutableListOf()
+    private val connectedSessions: ConcurrentHashMap<Long, WalletConnectV1SessionCachedData> = ConcurrentHashMap(50)
 
-    fun getSessionById(id: Long): WCSession? = getCachedDataById(id)?.session
+    fun getSessionById(id: Long): WCSession? = connectedSessions[id]?.session
 
-    fun getCachedDataById(id: Long): WalletConnectV1SessionCachedData? =
-        getConnectedSessions { sessions -> sessions.firstOrNull { it.sessionId == id } }
+    fun getCachedDataById(id: Long): WalletConnectV1SessionCachedData? = connectedSessions[id]
 
     fun addNewCachedData(sessionCachedData: WalletConnectV1SessionCachedData) {
-        getConnectedSessions { sessions ->
-            val cachedSession = sessions.popIfOrNull { it.sessionId == sessionCachedData.sessionId }
-            val safeRetryCount = cachedSession?.retryCount ?: INITIAL_RETRY_COUNT
-            sessionCachedData.retryCount = safeRetryCount
-            sessions.add(sessionCachedData)
-        }
+        if (connectedSessions.contains(sessionCachedData.sessionId)) return
+        connectedSessions[sessionCachedData.sessionId] = sessionCachedData
     }
 
     fun deleteCachedData(sessionId: Long, onCacheDeleted: (WalletConnectV1SessionCachedData) -> Unit) {
-        getConnectedSessions { sessions ->
-            val sessionIndex = sessions.indexOfFirst { it.sessionId == sessionId }
-            if (sessionIndex != ITEM_NOT_FOUND_INDEX) {
-                sessions.removeAt(sessionIndex).also { onCacheDeleted(it) }
-            }
-        }
-    }
-
-    // TODO Use Mutex
-    private fun <T> getConnectedSessions(action: (MutableList<WalletConnectV1SessionCachedData>) -> T): T {
-        return synchronized(this) {
-            action(connectedSessions)
-        }
-    }
-
-    companion object {
-        private const val ITEM_NOT_FOUND_INDEX = -1
+        connectedSessions.remove(sessionId)?.also { onCacheDeleted(it) }
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/di/WalletConnectDiModule.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/di/WalletConnectDiModule.kt
@@ -20,6 +20,11 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import java.util.concurrent.TimeUnit
+import javax.inject.Named
+import javax.inject.Singleton
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -34,4 +39,20 @@ internal object WalletConnectDiModule {
     fun provideCreateWalletConnectAccount(
         useCase: CreateWalletConnectAccountUseCase
     ): CreateWalletConnectAccount = useCase
+
+    @Provides
+    @Singleton
+    @Suppress("MagicNumber")
+    @Named("walletConnectHttpClient")
+    fun provideWalletConnectHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .connectTimeout(60, TimeUnit.SECONDS)
+            .readTimeout(0, TimeUnit.SECONDS)
+            .pingInterval(30, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
+            .build()
+    }
 }


### PR DESCRIPTION
## Description
- Added 30 seconds ping interval for socket connections. 
- Removed http client readTimeout
- Updated session cache 
- Removed `session.offer()` which results in sending session request unnecessarily

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3219
