### PR TITLE
PERA-3221 :: Use auth address to sign arb data txns

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/mapper/WalletConnectArbitraryDataMapper.kt
+++ b/app/src/main/kotlin/com/algorand/android/mapper/WalletConnectArbitraryDataMapper.kt
@@ -16,14 +16,12 @@ import com.algorand.android.models.BaseAccountAssetData
 import com.algorand.android.models.WCArbitraryData
 import com.algorand.android.models.WalletConnectAccount
 import com.algorand.android.models.WalletConnectArbitraryData
-import com.algorand.android.models.WalletConnectArbitraryDataSigner
 import com.algorand.android.models.WalletConnectAssetInformation
 import com.algorand.android.models.WalletConnectPeerMeta
 import com.algorand.android.modules.accountcore.domain.usecase.GetAccountOwnedAssetData
 import com.algorand.android.modules.accountcore.ui.usecase.GetAccountIconDrawablePreview
-import com.algorand.android.modules.walletconnect.domain.WalletConnectErrorProvider
+import com.algorand.android.modules.walletconnect.domain.usecase.CreateWalletConnectArbitraryDataSigner
 import com.algorand.wallet.account.custom.domain.usecase.GetAccountCustomName
-import com.algorand.wallet.account.detail.domain.usecase.GetAccountType
 import com.algorand.wallet.account.info.domain.usecase.GetAccountAlgoBalance
 import com.algorand.wallet.asset.domain.util.AssetConstants
 import com.algorand.wallet.utils.multiplyOrZero
@@ -32,13 +30,12 @@ import javax.inject.Inject
 
 @SuppressWarnings("ReturnCount")
 class WalletConnectArbitraryDataMapper @Inject constructor(
-    private val errorProvider: WalletConnectErrorProvider,
     private val getAccountIconDrawablePreview: GetAccountIconDrawablePreview,
     private val walletConnectAssetInformationMapper: WalletConnectAssetInformationMapper,
     private val getAccountCustomName: GetAccountCustomName,
     private val getAccountAlgoBalance: GetAccountAlgoBalance,
     private val getAccountOwnedAssetData: GetAccountOwnedAssetData,
-    private val getAccountType: GetAccountType
+    private val createArbitraryDataSigner: CreateWalletConnectArbitraryDataSigner
 ) {
 
     suspend fun createWalletConnectArbitraryData(
@@ -56,13 +53,7 @@ class WalletConnectArbitraryDataMapper @Inject constructor(
             val ownedAsset = getAccountOwnedAssetData(signerAddress, AssetConstants.ALGO_ID)
 
             val walletConnectAssetInformation = createWalletConnectAssetInformation(ownedAsset, amount)
-            val wcSigner = signer?.let {
-                WalletConnectArbitraryDataSigner.create(
-                    signerAccountType = getAccountType(signerAddress),
-                    signer,
-                    errorProvider
-                )
-            }
+            val wcSigner = createArbitraryDataSigner(signerAddress)
 
             WalletConnectArbitraryData(
                 chainId = arbitraryData.chainId,

--- a/app/src/main/kotlin/com/algorand/android/models/WalletConnectArbitraryDataSigner.kt
+++ b/app/src/main/kotlin/com/algorand/android/models/WalletConnectArbitraryDataSigner.kt
@@ -13,10 +13,7 @@
 package com.algorand.android.models
 
 import android.os.Parcelable
-import com.algorand.android.modules.walletconnect.domain.WalletConnectErrorProvider
 import com.algorand.android.modules.walletconnect.domain.model.WalletConnectError
-import com.algorand.android.utils.isValidAddress
-import com.algorand.wallet.account.detail.domain.model.AccountType
 import kotlinx.parcelize.Parcelize
 
 sealed class WalletConnectArbitraryDataSigner : Parcelable {
@@ -24,38 +21,6 @@ sealed class WalletConnectArbitraryDataSigner : Parcelable {
     open val address: String? = null
 
     open val isValidSigner: Boolean = false
-
-    companion object {
-
-        fun create(
-            signerAccountType: AccountType?,
-            signerAddress: String,
-            errorProvider: WalletConnectErrorProvider
-        ): WalletConnectArbitraryDataSigner {
-            return when {
-                signerAddress.isBlank() -> DisplayOnly
-                else -> returnInvalidInputIfSignerIsInvalid(
-                    signerAccountType,
-                    Signer(signerAddress, signerAccountType is AccountType.LedgerBle),
-                    errorProvider.getInvalidPublicKeyError()
-                )
-            }
-        }
-
-        private fun returnInvalidInputIfSignerIsInvalid(
-            signerAccountType: AccountType?,
-            signer: WalletConnectArbitraryDataSigner,
-            error: WalletConnectError
-        ): WalletConnectArbitraryDataSigner {
-            return signer.takeIf {
-                it.address?.isValidAddress() == true &&
-                        (signerAccountType == AccountType.Algo25 ||
-                                signerAccountType == AccountType.HdKey ||
-                                signerAccountType == AccountType.Rekeyed ||
-                                signerAccountType == AccountType.RekeyedAuth)
-            } ?: Unsignable(error)
-        }
-    }
 
     @Parcelize
     data class Signer(override val address: String, val isLedger: Boolean) : WalletConnectArbitraryDataSigner() {

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/di/WalletConnectDiModule.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/di/WalletConnectDiModule.kt
@@ -14,6 +14,8 @@ package com.algorand.android.modules.walletconnect.di
 
 import com.algorand.android.modules.walletconnect.domain.usecase.CreateWalletConnectAccount
 import com.algorand.android.modules.walletconnect.domain.usecase.CreateWalletConnectAccountUseCase
+import com.algorand.android.modules.walletconnect.domain.usecase.CreateWalletConnectArbitraryDataSigner
+import com.algorand.android.modules.walletconnect.domain.usecase.CreateWalletConnectArbitraryDataSignerUseCase
 import com.algorand.android.modules.walletconnect.domain.usecase.GetWalletConnectTransactionSigner
 import com.algorand.android.modules.walletconnect.domain.usecase.GetWalletConnectTransactionSignerUseCase
 import dagger.Module
@@ -55,4 +57,9 @@ internal object WalletConnectDiModule {
             .writeTimeout(60, TimeUnit.SECONDS)
             .build()
     }
+
+    @Provides
+    fun provideCreateWalletConnectArbitraryDataSigner(
+        useCase: CreateWalletConnectArbitraryDataSignerUseCase
+    ): CreateWalletConnectArbitraryDataSigner = useCase
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/domain/usecase/CreateWalletConnectArbitraryDataSigner.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/domain/usecase/CreateWalletConnectArbitraryDataSigner.kt
@@ -15,5 +15,5 @@ package com.algorand.android.modules.walletconnect.domain.usecase
 import com.algorand.android.models.WalletConnectArbitraryDataSigner
 
 fun interface CreateWalletConnectArbitraryDataSigner {
-    suspend operator fun invoke(signerAddress: String) : WalletConnectArbitraryDataSigner
+    suspend operator fun invoke(signerAddress: String): WalletConnectArbitraryDataSigner
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/domain/usecase/CreateWalletConnectArbitraryDataSigner.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/domain/usecase/CreateWalletConnectArbitraryDataSigner.kt
@@ -10,23 +10,10 @@
  * limitations under the License
  */
 
-package com.algorand.android.models
+package com.algorand.android.modules.walletconnect.domain.usecase
 
-import android.os.Parcelable
-import com.algorand.android.utils.decodeBase64
-import kotlinx.parcelize.Parcelize
+import com.algorand.android.models.WalletConnectArbitraryDataSigner
 
-@Parcelize
-data class WalletConnectArbitraryData(
-    val chainId: Float?,
-    val data: String?,
-    val message: String?,
-    val signer: WalletConnectArbitraryDataSigner,
-    val signerAccount: WalletConnectAccount?,
-    val peerMeta: WalletConnectPeerMeta?,
-    val signerAlgoBalance: WalletConnectAssetInformation?
-) : Parcelable {
-
-    val decodedTransaction: ByteArray?
-        get() = data?.decodeBase64()
+fun interface CreateWalletConnectArbitraryDataSigner {
+    suspend operator fun invoke(signerAddress: String) : WalletConnectArbitraryDataSigner
 }

--- a/app/src/main/kotlin/com/algorand/android/modules/walletconnect/domain/usecase/CreateWalletConnectArbitraryDataSignerUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/walletconnect/domain/usecase/CreateWalletConnectArbitraryDataSignerUseCase.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.modules.walletconnect.domain.usecase
+
+import com.algorand.android.models.WalletConnectArbitraryDataSigner
+import com.algorand.android.models.WalletConnectArbitraryDataSigner.DisplayOnly
+import com.algorand.android.models.WalletConnectArbitraryDataSigner.Signer
+import com.algorand.android.models.WalletConnectArbitraryDataSigner.Unsignable
+import com.algorand.android.modules.walletconnect.domain.WalletConnectErrorProvider
+import com.algorand.wallet.account.core.domain.model.TransactionSigner.Algo25
+import com.algorand.wallet.account.core.domain.model.TransactionSigner.HdKey
+import com.algorand.wallet.account.core.domain.model.TransactionSigner.LedgerBle
+import com.algorand.wallet.account.core.domain.model.TransactionSigner.SignerNotFound
+import com.algorand.wallet.account.core.domain.usecase.GetTransactionSigner
+import javax.inject.Inject
+
+internal class CreateWalletConnectArbitraryDataSignerUseCase @Inject constructor(
+    private val getTransactionSigner: GetTransactionSigner,
+    private val errorProvider: WalletConnectErrorProvider,
+) : CreateWalletConnectArbitraryDataSigner {
+
+    override suspend fun invoke(signerAddress: String): WalletConnectArbitraryDataSigner {
+        if (signerAddress.isBlank()) return DisplayOnly
+
+        return when (val transactionSigner = getTransactionSigner(signerAddress)) {
+            is Algo25, is HdKey -> Signer(address = transactionSigner.address, isLedger = false)
+            is LedgerBle -> Unsignable(errorProvider.getUnableToSignError())
+            is SignerNotFound -> Unsignable(errorProvider.getMissingSignerError())
+        }
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/utils/walletconnect/WalletConnectArbitraryDataSignHelper.kt
+++ b/app/src/main/kotlin/com/algorand/android/utils/walletconnect/WalletConnectArbitraryDataSignHelper.kt
@@ -28,7 +28,7 @@ class WalletConnectArbitraryDataSignHelper @Inject constructor() :
     private var arbitraryDataToSignCount = enqueuedItemCount
 
     override fun initItemsToBeEnqueued(enqueuedItems: List<WalletConnectArbitraryData>) {
-        arbitraryDataToSignCount = enqueuedItems.filter { it.signerAccount?.address != null }.size
+        arbitraryDataToSignCount = enqueuedItems.filter { it.signer.address != null }.size
         super.initItemsToBeEnqueued(enqueuedItems)
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/utils/walletconnect/WalletConnectArbitraryDataSignManager.kt
+++ b/app/src/main/kotlin/com/algorand/android/utils/walletconnect/WalletConnectArbitraryDataSignManager.kt
@@ -28,9 +28,9 @@ import com.algorand.wallet.account.local.domain.usecase.GetAlgo25SecretKey
 import com.algorand.wallet.account.local.domain.usecase.GetHdSeed
 import com.algorand.wallet.account.local.domain.usecase.GetLocalAccount
 import com.algorand.wallet.algosdk.transaction.sdk.SignHdKeyTransaction
+import javax.inject.Inject
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 class WalletConnectArbitraryDataSignManager @Inject constructor(
     private val walletConnectSignValidator: WalletConnectSignValidator,
@@ -66,7 +66,7 @@ class WalletConnectArbitraryDataSignManager @Inject constructor(
             totalItemCount: Int
         ) {
             currentScope.launch {
-                val signerAddress = item.signerAccount?.address
+                val signerAddress = item.signer.address
 
                 if (signerAddress.isNullOrBlank()) {
                     cacheNullDequeuedItem()

--- a/app/src/test/kotlin/com/algorand/android/modules/walletconnect/domain/usecase/CreateWalletConnectArbitraryDataSignerUseCaseTest.kt
+++ b/app/src/test/kotlin/com/algorand/android/modules/walletconnect/domain/usecase/CreateWalletConnectArbitraryDataSignerUseCaseTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.modules.walletconnect.domain.usecase
+
+import com.algorand.android.models.WalletConnectArbitraryDataSigner
+import com.algorand.android.models.WalletConnectArbitraryDataSigner.DisplayOnly
+import com.algorand.android.modules.walletconnect.domain.WalletConnectErrorProvider
+import com.algorand.android.modules.walletconnect.domain.model.WalletConnectError
+import com.algorand.test.peraFixture
+import com.algorand.wallet.account.core.domain.model.TransactionSigner
+import com.algorand.wallet.account.core.domain.model.TransactionSigner.SignerNotFound
+import com.algorand.wallet.account.core.domain.usecase.GetTransactionSigner
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class CreateWalletConnectArbitraryDataSignerUseCaseTest {
+
+    private val getTransactionSigner: GetTransactionSigner = mockk()
+    private val errorProvider: WalletConnectErrorProvider = mockk {
+        every { getUnableToSignError() } returns UNABLE_TO_SIGN_ERROR
+        every { getMissingSignerError() } returns MISSING_SIGNER_ERROR
+    }
+
+    private val sut = CreateWalletConnectArbitraryDataSignerUseCase(getTransactionSigner, errorProvider)
+
+    @Test
+    fun `EXPECT DisplayOnly WHEN signer address is blank`() = runTest {
+        val signerAddress = ""
+
+        val result = sut(signerAddress)
+
+        assertTrue(result is DisplayOnly)
+    }
+
+    @Test
+    fun `EXPECT Unsignable WHEN transaction signer is NoAuth`() = runTest {
+        coEvery { getTransactionSigner(SIGNER_ADDRESS) } returns SignerNotFound.NoAuth(SIGNER_ADDRESS)
+
+        val result = sut(SIGNER_ADDRESS)
+
+        assertTrue(result is WalletConnectArbitraryDataSigner.Unsignable)
+        assertEquals(MISSING_SIGNER_ERROR, result.error)
+    }
+
+    @Test
+    fun `EXPECT Unsignable WHEN transaction signer is Rekeyed`() = runTest {
+        coEvery { getTransactionSigner(SIGNER_ADDRESS) } returns SignerNotFound.Rekeyed(SIGNER_ADDRESS)
+
+        val result = sut(SIGNER_ADDRESS)
+
+        assertTrue(result is WalletConnectArbitraryDataSigner.Unsignable)
+        assertEquals(MISSING_SIGNER_ERROR, result.error)
+    }
+
+    @Test
+    fun `EXPECT Unsignable WHEN transaction signer is AccountNotFound`() = runTest {
+        coEvery { getTransactionSigner(SIGNER_ADDRESS) } returns SignerNotFound.AccountNotFound(SIGNER_ADDRESS)
+
+        val result = sut(SIGNER_ADDRESS)
+
+        assertTrue(result is WalletConnectArbitraryDataSigner.Unsignable)
+        assertEquals(MISSING_SIGNER_ERROR, result.error)
+    }
+
+    @Test
+    fun `EXPECT Unsignable WHEN transaction signer is AuthAccountIsNoAuth`() = runTest {
+        coEvery { getTransactionSigner(SIGNER_ADDRESS) } returns SignerNotFound.AuthAccountIsNoAuth(SIGNER_ADDRESS)
+
+        val result = sut(SIGNER_ADDRESS)
+
+        assertTrue(result is WalletConnectArbitraryDataSigner.Unsignable)
+        assertEquals(MISSING_SIGNER_ERROR, result.error)
+    }
+
+    @Test
+    fun `EXPECT Unsignable WHEN transaction signer is AuthAccountSigningDetailsNotFound`() = runTest {
+        coEvery { getTransactionSigner(SIGNER_ADDRESS) } returns SignerNotFound.AuthAccountSigningDetailsNotFound(
+            address = SIGNER_ADDRESS,
+            authAddress = "authAddress"
+        )
+
+        val result = sut(SIGNER_ADDRESS)
+
+        assertTrue(result is WalletConnectArbitraryDataSigner.Unsignable)
+        assertEquals(MISSING_SIGNER_ERROR, result.error)
+    }
+
+    @Test
+    fun `EXPECT Unsignable WHEN transaction signer is AuthAddressNotFound`() = runTest {
+        coEvery { getTransactionSigner(SIGNER_ADDRESS) } returns SignerNotFound.AuthAddressNotFound(SIGNER_ADDRESS)
+
+        val result = sut(SIGNER_ADDRESS)
+
+        assertTrue(result is WalletConnectArbitraryDataSigner.Unsignable)
+        assertEquals(MISSING_SIGNER_ERROR, result.error)
+    }
+
+    @Test
+    fun `EXPECT Unsignable WHEN transaction signer is LedgerBLE`() = runTest {
+        coEvery { getTransactionSigner(SIGNER_ADDRESS) } returns TransactionSigner.LedgerBle(
+            address = SIGNER_ADDRESS,
+            bluetoothAddress = "btAddress"
+        )
+
+        val result = sut(SIGNER_ADDRESS)
+
+        assertTrue(result is WalletConnectArbitraryDataSigner.Unsignable)
+        assertEquals(UNABLE_TO_SIGN_ERROR, result.error)
+    }
+
+    @Test
+    fun `EXPECT Signer WHEN transaction signer is Algo25`() = runTest {
+        coEvery { getTransactionSigner(SIGNER_ADDRESS) } returns TransactionSigner.Algo25(AUTH_ADDRESS)
+
+        val result = sut(SIGNER_ADDRESS)
+
+        assertEquals(AUTH_ADDRESS, result.address)
+    }
+
+    @Test
+    fun `EXPECT Signer WHEN transaction signer is HdKey`() = runTest {
+        coEvery { getTransactionSigner(SIGNER_ADDRESS) } returns TransactionSigner.HdKey(AUTH_ADDRESS)
+
+        val result = sut(SIGNER_ADDRESS)
+
+        assertEquals(AUTH_ADDRESS, result.address)
+    }
+
+    private companion object {
+        private const val SIGNER_ADDRESS = "ADDRESS"
+        private const val AUTH_ADDRESS = "AUTH_ADDRESS"
+        private val MISSING_SIGNER_ERROR = peraFixture<WalletConnectError>()
+        private val UNABLE_TO_SIGN_ERROR = peraFixture<WalletConnectError>()
+    }
+}


### PR DESCRIPTION
## Description
App is going to check the auth address of the signer before signing the arbitrary data transactions.

## Related Issues
Closes https://algorandfoundation.atlassian.net/browse/PERA-3221

