### PR TITLE
PERA-3230 Display exact amount on history item

### DIFF
--- a/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/mapper/DefaultTransactionHistoryAssetTransferTypeMapper.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/mapper/DefaultTransactionHistoryAssetTransferTypeMapper.kt
@@ -41,14 +41,14 @@ internal class DefaultTransactionHistoryAssetTransferTypeMapper @Inject construc
         val assetTransferType = mapAssetTransferType(address, response) ?: return null
         return Type.AssetTransfer(
             assetId = response.assetTransferTransaction?.assetId ?: return null,
-            assetUnitName = "", // TODO
+            assetUnitName = response.assetTransferTransaction.asset?.unitName.orEmpty(),
             type = assetTransferType
         )
     }
 
     private fun mapAssetTransferType(address: String, response: TransactionHistoryDetailResponse): AssetTransferType? {
         return response.assetTransferTransaction?.run {
-            mapAssetTransferType(address, receiver, closeTo, response.sender, amount, null) // TODO
+            mapAssetTransferType(address, receiver, closeTo, response.sender, amount, asset)
         }
     }
 

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/mapper/DefaultTransactionHistoryMapper.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/mapper/DefaultTransactionHistoryMapper.kt
@@ -105,8 +105,8 @@ internal class DefaultTransactionHistoryMapper @Inject constructor(
                 assetInUnitName = assetIn.unitName.orEmpty(),
                 assetOutId = assetOut?.id ?: return null,
                 assetOutUnitName = assetOut.unitName.orEmpty(),
-                amountIn = amountInWithSlippage.formatToBigDecimal(assetIn.decimals) ?: return null,
-                amountOut = amountOutWithSlippage.formatToBigDecimal(assetOut.decimals) ?: return null
+                amountIn = amountIn.formatToBigDecimal(assetIn.decimals) ?: return null,
+                amountOut = amountOut.formatToBigDecimal(assetOut.decimals) ?: return null
             )
         }
     }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/model/TransactionHistoryDetailResponse.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/model/TransactionHistoryDetailResponse.kt
@@ -80,7 +80,9 @@ internal data class TransactionHistoryDetailResponse(
         @SerializedName("close_to")
         val closeTo: String?,
         @SerializedName("clawback_address")
-        val clawbackAddress: String?
+        val clawbackAddress: String?,
+        @SerializedName("asset")
+        val asset: TransactionHistoryAssetSummaryResponse?
     )
 
     internal data class ApplicationTransactionResponse(

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/model/TransactionHistorySwapGroupDetailResponse.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/model/TransactionHistorySwapGroupDetailResponse.kt
@@ -25,6 +25,10 @@ internal data class TransactionHistorySwapGroupDetailResponse(
     val assetIn: TransactionHistoryAssetSummaryResponse?,
     @SerializedName("asset_out")
     val assetOut: TransactionHistoryAssetSummaryResponse?,
+    @SerializedName("amount_in")
+    val amountIn: String?,
+    @SerializedName("amount_out")
+    val amountOut: String?,
     @SerializedName("amount_in_with_slippage")
     val amountInWithSlippage: String?,
     @SerializedName("amount_out_with_slippage")

--- a/common-sdk/src/test/kotlin/com/algorand/wallet/transaction/history/data/repository/DefaultTransactionHistoryRepositoryTest.kt
+++ b/common-sdk/src/test/kotlin/com/algorand/wallet/transaction/history/data/repository/DefaultTransactionHistoryRepositoryTest.kt
@@ -25,13 +25,13 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.math.BigDecimal.ZERO
+import java.time.ZonedDateTime
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.math.BigDecimal.ZERO
-import java.time.ZonedDateTime
 
 class DefaultTransactionHistoryRepositoryTest {
 
@@ -76,7 +76,7 @@ class DefaultTransactionHistoryRepositoryTest {
         const val ADDRESS = "address"
         const val GROUP_ID = "groupId"
         val SWAP_GROUP_DETAIL_RESPONSE = TransactionHistorySwapGroupDetailResponse(
-            "", "", "", null, null, "", "", 0, null, "", null, null
+            "", "", "", null, null, "", "", "", "", 0, null, "", null, null
         )
         val SWAP_GROUP_DETAIL = TransactionHistorySwapGroupDetail(
             "", "", "", "", 1L, "", ZERO, 2L, "", ZERO, emptyList(), null, ZonedDateTime.now()


### PR DESCRIPTION
## Description
- Swap history item will be populated by using new field called `amount_out` and `amount_in`, instead of amounts with slippage

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3230

Mobile app:
<img width="586" height="231" alt="Screenshot 2026-01-15 at 15 24 48" src="https://github.com/user-attachments/assets/94b70524-6f3e-4bb6-8ea7-052f94ccca30" />

Pera Explorer:
<img width="664" height="76" alt="Screenshot 2026-01-15 at 15 24 58" src="https://github.com/user-attachments/assets/b7fbc53e-128f-46f5-9eac-54d0bdb2ab99" />
