### PR TITLE
PERA-3417 Use vertical scroll instead of scrollable in MenuScreen

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/menu/view/MenuListCardItem.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/menu/view/MenuListCardItem.kt
@@ -14,10 +14,11 @@ package com.algorand.android.ui.menu.view
 
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandIn
-import androidx.compose.animation.shrinkOut
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -29,7 +30,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.res.painterResource
@@ -40,8 +40,6 @@ import com.algorand.android.R
 import com.algorand.android.ui.compose.theme.PeraTheme
 import com.algorand.android.ui.compose.widget.button.PeraButtonIcon
 import com.algorand.android.ui.compose.widget.button.PeraPrimaryButton
-import com.algorand.android.ui.compose.widget.button.PeraSecondaryButton
-import com.algorand.android.ui.compose.widget.progress.PeraCircularProgressIndicator
 import com.algorand.android.ui.menu.viewmodel.MenuCardsViewModel
 import com.algorand.android.ui.menu.viewmodel.MenuCardsViewModel.ViewState.CardCreated
 
@@ -51,60 +49,14 @@ internal fun MenuListCardItem(viewModel: MenuCardsViewModel, listener: MenuListC
     AnimatedVisibility(
         modifier = Modifier.fillMaxWidth(),
         visible = currentState is CardCreated,
-        enter = expandIn(),
-        exit = shrinkOut()
+        enter = fadeIn() + expandVertically(),
+        exit = fadeOut() + shrinkVertically()
     ) {
         GoToCardsState(listener::onGoToCardsClick)
     }
     LaunchedEffect(Unit) {
         viewModel.initCardState()
     }
-}
-
-@Composable
-private fun LoadingState() {
-    CardItemContainer(
-        description = {
-            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                PeraCircularProgressIndicator()
-            }
-        }
-    )
-}
-
-@Composable
-private fun ErrorState(onRetryClick: () -> Unit) {
-    CardItemContainer(
-        description = {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                CardDescriptionText(R.string.an_error_occurred)
-                PeraSecondaryButton(
-                    onClick = onRetryClick,
-                    text = stringResource(R.string.retry)
-                )
-            }
-        }
-    )
-}
-
-@Composable
-private fun CreateCardState(onClick: () -> Unit) {
-    CardItemContainer(
-        description = {
-            CardDescriptionText(R.string.get_the_worlds_first)
-        },
-        button = {
-            PeraPrimaryButton(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = onClick,
-                text = stringResource(R.string.create_pera_card),
-                leftIcon = { PeraButtonIcon(R.drawable.ic_add) }
-            )
-        }
-    )
 }
 
 @Composable
@@ -125,33 +77,11 @@ private fun GoToCardsState(onClick: () -> Unit) {
 }
 
 @Composable
-private fun WaitlistedState() {
-    CardItemContainer(
-        description = {
-            Column {
-                CardDescriptionTitleText(R.string.you_are_all_set)
-                Spacer(modifier = Modifier.height(8.dp))
-                CardDescriptionText(R.string.we_will_inform_this)
-            }
-        }
-    )
-}
-
-@Composable
 private fun CardDescriptionText(@StringRes resId: Int) {
     Text(
         text = stringResource(resId),
         style = PeraTheme.typography.body.regular.sans,
         color = PeraTheme.colors.text.gray
-    )
-}
-
-@Composable
-private fun CardDescriptionTitleText(@StringRes resId: Int) {
-    Text(
-        text = stringResource(resId),
-        style = PeraTheme.typography.body.regular.sansMedium,
-        color = PeraTheme.colors.text.main
     )
 }
 

--- a/app/src/main/kotlin/com/algorand/android/ui/menu/view/MenuScreen.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/menu/view/MenuScreen.kt
@@ -14,15 +14,14 @@ package com.algorand.android.ui.menu.view
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -45,8 +44,8 @@ fun MenuScreen(
     Column(
         modifier = Modifier
             .background(color = PeraTheme.colors.background.primary)
-            .fillMaxSize()
-            .scrollable(rememberScrollState(), orientation = Orientation.Vertical)
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
             .padding(start = 16.dp, end = 16.dp, bottom = 32.dp)
     ) {
         MenuToolbar(listener::onSettingsClick, listener::onScanQrClick)


### PR DESCRIPTION
## Description
- Duplicated menu items can be ignored. They were added to make list longer so the animation can be tested.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3417

https://github.com/user-attachments/assets/c9c8dc9d-cd4c-4fd6-824f-731e4ce98572

