### PR TITLE
PERA-3459 :: Update Account History and Inner Transaction Count Display

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/history/ui/AccountTransactionHistoryFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/history/ui/AccountTransactionHistoryFragment.kt
@@ -17,7 +17,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
+import com.algorand.android.R
 import com.algorand.android.core.BaseFragment
 import com.algorand.android.models.DateFilter
 import com.algorand.android.models.FragmentConfiguration
@@ -25,6 +27,9 @@ import com.algorand.android.ui.compose.extensions.createComposeView
 import com.algorand.android.ui.transaction.csv.model.CreateCsvArgs
 import com.algorand.android.ui.transaction.csv.viewmodel.CsvViewModel
 import com.algorand.android.ui.transaction.history.viewmodel.TransactionHistoryViewModel
+import com.algorand.android.utils.CSV_FILE_MIME_TYPE
+import com.algorand.android.utils.extensions.collectLatestOnLifecycle
+import com.algorand.android.utils.shareFile
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -36,10 +41,21 @@ class AccountTransactionHistoryFragment : BaseFragment(0), AccountHistoryScreenL
     private val transactionHistoryViewModel: TransactionHistoryViewModel by viewModels()
     private val csvViewModel: CsvViewModel by viewModels()
 
+    private val shareResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        // Nothing to do
+    }
+
     private var listener: AccountTransactionHistoryListener? = null
 
     private val address: String
         get() = arguments?.getString(ADDRESS_KEY).orEmpty()
+
+    private val csvViewEventCollector: suspend (CsvViewModel.ViewEvent) -> Unit = {
+        when (it) {
+            is CsvViewModel.ViewEvent.ShareFile -> shareFile(it.file, CSV_FILE_MIME_TYPE, shareResultLauncher)
+            CsvViewModel.ViewEvent.ShowErrorMessage -> showGlobalError(getString(R.string.an_error_occurred))
+        }
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return createComposeView {
@@ -60,6 +76,7 @@ class AccountTransactionHistoryFragment : BaseFragment(0), AccountHistoryScreenL
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         transactionHistoryViewModel.initViewState(address, assetId = null)
+        viewLifecycleOwner.collectLatestOnLifecycle(csvViewModel.viewEvent, csvViewEventCollector)
     }
 
     override fun onFilterClick() {

--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/history/ui/AccountTransactionHistoryFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/history/ui/AccountTransactionHistoryFragment.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.modules.accountdetail.history.ui
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import com.algorand.android.core.BaseFragment
+import com.algorand.android.models.DateFilter
+import com.algorand.android.models.FragmentConfiguration
+import com.algorand.android.ui.compose.extensions.createComposeView
+import com.algorand.android.ui.transaction.csv.model.CreateCsvArgs
+import com.algorand.android.ui.transaction.csv.viewmodel.CsvViewModel
+import com.algorand.android.ui.transaction.history.viewmodel.TransactionHistoryViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AccountTransactionHistoryFragment : BaseFragment(0), AccountHistoryScreenListener {
+
+    override val fragmentConfiguration: FragmentConfiguration = FragmentConfiguration(isBottomBarNeeded = true)
+
+    private val accountTransactionHistoryViewModel: AccountTransactionHistoryViewModel by viewModels()
+    private val transactionHistoryViewModel: TransactionHistoryViewModel by viewModels()
+    private val csvViewModel: CsvViewModel by viewModels()
+
+    private var listener: AccountTransactionHistoryListener? = null
+
+    private val address: String
+        get() = arguments?.getString(ADDRESS_KEY).orEmpty()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return createComposeView {
+            AccountTransactionHistoryScreen(csvViewModel, transactionHistoryViewModel, this)
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        listener = parentFragment as? AccountTransactionHistoryListener
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        listener = null
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        transactionHistoryViewModel.initViewState(address, assetId = null)
+    }
+
+    override fun onFilterClick() {
+        accountTransactionHistoryViewModel.logAccountHistoryFilterEventTracker()
+        val currentFilter = transactionHistoryViewModel.getDateFilter()
+        listener?.onFilterTransactionClick(currentFilter)
+    }
+
+    override fun onCsvClick() {
+        accountTransactionHistoryViewModel.logAccountHistoryExportCsvEventTracker()
+        context?.cacheDir?.let { cacheDir ->
+            val args = CreateCsvArgs(
+                cacheDirectory = cacheDir,
+                address = address,
+                assetId = null,
+                dateRange = transactionHistoryViewModel.getSelectedDateRange()
+            )
+            csvViewModel.createCsv(args)
+        }
+    }
+
+    override fun onTransactionClick(id: String) {
+        listener?.onStandardTransactionClick(id)
+    }
+
+    override fun onApplicationCallClick(id: String) {
+        listener?.onApplicationCallTransactionClick(id)
+    }
+
+    override fun onSwapClick(groupId: String) {
+        listener?.onSwapTransactionClick(groupId)
+    }
+
+    interface AccountTransactionHistoryListener {
+        fun onStandardTransactionClick(id: String)
+        fun onApplicationCallTransactionClick(id: String)
+        fun onSwapTransactionClick(groupId: String)
+        fun onFilterTransactionClick(dateFilter: DateFilter)
+    }
+
+    companion object Companion {
+
+        private const val ADDRESS_KEY = "address"
+
+        fun newInstance(address: String): AccountTransactionHistoryFragment {
+            return AccountTransactionHistoryFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ADDRESS_KEY, address)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/history/ui/AccountTransactionHistoryScreen.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/history/ui/AccountTransactionHistoryScreen.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.modules.accountdetail.history.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.algorand.android.ui.transaction.csv.viewmodel.CsvViewModel
+import com.algorand.android.ui.transaction.history.view.TransactionHistoryListItemHeader
+import com.algorand.android.ui.transaction.history.view.TransactionHistoryListListener
+import com.algorand.android.ui.transaction.history.view.pagingTransactionHistoryListItems
+import com.algorand.android.ui.transaction.history.viewmodel.TransactionHistoryViewModel
+import com.algorand.android.ui.transaction.history.viewmodel.TransactionHistoryViewModel.ViewState
+
+@Composable
+fun AccountTransactionHistoryScreen(
+    csvViewModel: CsvViewModel,
+    transactionHistoryViewModel: TransactionHistoryViewModel,
+    listener: AccountHistoryScreenListener
+) {
+    val txnHistoryState = transactionHistoryViewModel.state.collectAsStateWithLifecycle()
+    val historyItems = (txnHistoryState.value as? ViewState.Content)?.pagingData?.collectAsLazyPagingItems()
+    Column(modifier = Modifier.fillMaxSize()) {
+        TransactionHistoryListItemHeader(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            csvViewModel = csvViewModel,
+            isFilterSelected = transactionHistoryViewModel.isFilterSelected(),
+            onFilterClick = listener::onFilterClick,
+            onCsvClick = listener::onCsvClick
+        )
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            pagingTransactionHistoryListItems(historyItems, listener)
+        }
+    }
+}
+
+interface AccountHistoryScreenListener : TransactionHistoryListListener {
+    fun onFilterClick()
+    fun onCsvClick()
+}

--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/history/ui/AccountTransactionHistoryViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/history/ui/AccountTransactionHistoryViewModel.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022-2025 Pera Wallet, LDA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.algorand.android.modules.accountdetail.history.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.algorand.android.modules.tracking.accountdetail.accounthistory.AccountHistoryFragmentEventTracker
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class AccountTransactionHistoryViewModel @Inject constructor(
+    private val accountHistoryFragmentEventTracker: AccountHistoryFragmentEventTracker
+) : ViewModel() {
+
+    fun logAccountHistoryFilterEventTracker() {
+        viewModelScope.launch {
+            accountHistoryFragmentEventTracker.logAccountHistoryFilterEvent()
+        }
+    }
+
+    fun logAccountHistoryExportCsvEventTracker() {
+        viewModelScope.launch {
+            accountHistoryFragmentEventTracker.logAccountHistoryExportCsvEvent()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/ui/AccountDetailFragment.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/ui/AccountDetailFragment.kt
@@ -46,6 +46,7 @@ import com.algorand.android.modules.accountcore.ui.model.AccountDetailSummary
 import com.algorand.android.modules.accountdetail.assets.ui.AccountAssetsFragment
 import com.algorand.android.modules.accountdetail.haveyoubackedupconfirmation.ui.HaveYouBackedUpAccountConfirmationBottomSheet.Companion.HAVE_YOU_BACKED_UP_ACCOUNT_CONFIRMATION_KEY
 import com.algorand.android.modules.accountdetail.history.ui.AccountHistoryFragment
+import com.algorand.android.modules.accountdetail.history.ui.AccountTransactionHistoryFragment.AccountTransactionHistoryListener
 import com.algorand.android.modules.accountdetail.removeaccount.ui.RemoveAccountConfirmationBottomSheet.Companion.ACCOUNT_REMOVE_CONFIRMATION_KEY
 import com.algorand.android.modules.accountdetail.ui.AccountDetailFragmentDirections.Companion.actionAccountDetailFragmentToAssetRemovalActionNavigation
 import com.algorand.android.modules.accountdetail.ui.AccountDetailFragmentDirections.Companion.actionAccountDetailFragmentToAssetTransferBalanceActionNavigation
@@ -81,7 +82,8 @@ class AccountDetailFragment :
     BaseFragment(R.layout.fragment_account_detail),
     AccountHistoryFragment.Listener,
     AccountAssetsFragment.Listener,
-    AccountCollectiblesFragment.Listener {
+    AccountCollectiblesFragment.Listener,
+    AccountTransactionHistoryListener {
 
     private val toolbarConfiguration = ToolbarConfiguration(
         startIconResId = R.drawable.ic_left_arrow,
@@ -128,23 +130,38 @@ class AccountDetailFragment :
     private lateinit var accountDetailPagerAdapter: AccountDetailPagerAdapter
 
     override fun onStandardTransactionClick(transaction: BaseTransactionItem.TransactionItem) {
-        nav(
-            AccountDetailFragmentDirections.actionAccountDetailFragmentToTransactionDetailNavigation(
-                transactionId = transaction.id ?: return,
-                accountAddress = accountDetailViewModel.accountAddress,
-                entryPoint = TransactionDetailEntryPoint.STANDARD_TRANSACTION
-            )
-        )
+        navToTransactionDetail(transaction.id ?: return, TransactionDetailEntryPoint.STANDARD_TRANSACTION)
     }
 
     override fun onApplicationCallTransactionClick(
         transaction: BaseTransactionItem.TransactionItem.ApplicationCallItem
     ) {
+        navToTransactionDetail(transaction.id ?: return, TransactionDetailEntryPoint.APPLICATION_CALL_TRANSACTION)
+    }
+
+    override fun onStandardTransactionClick(id: String) {
+        navToTransactionDetail(id, TransactionDetailEntryPoint.STANDARD_TRANSACTION)
+    }
+
+    override fun onApplicationCallTransactionClick(id: String) {
+        navToTransactionDetail(id, TransactionDetailEntryPoint.APPLICATION_CALL_TRANSACTION)
+    }
+
+    override fun onSwapTransactionClick(groupId: String) {
+        nav(
+            AccountDetailFragmentDirections.actionAccountDetailFragmentToSwapGroupDetailFragment(
+                accountAddress = accountDetailViewModel.accountAddress,
+                groupId = groupId
+            )
+        )
+    }
+
+    private fun navToTransactionDetail(txnId: String, entryPoint: TransactionDetailEntryPoint) {
         nav(
             AccountDetailFragmentDirections.actionAccountDetailFragmentToTransactionDetailNavigation(
-                transactionId = transaction.id ?: return,
+                transactionId = txnId,
                 accountAddress = accountDetailViewModel.accountAddress,
-                entryPoint = TransactionDetailEntryPoint.APPLICATION_CALL_TRANSACTION
+                entryPoint = entryPoint
             )
         )
     }
@@ -415,7 +432,11 @@ class AccountDetailFragment :
     }
 
     private fun initAccountDetailPager() {
-        accountDetailPagerAdapter = AccountDetailPagerAdapter(this, accountDetailViewModel.accountAddress)
+        accountDetailPagerAdapter = AccountDetailPagerAdapter(
+            fragment = this,
+            address = accountDetailViewModel.accountAddress,
+            isAccountHistoryV2Enabled = accountDetailViewModel.isAccountHistoryV2Enabled()
+        )
         binding.accountDetailViewPager.adapter = accountDetailPagerAdapter
     }
 

--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/ui/AccountDetailPagerAdapter.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/ui/AccountDetailPagerAdapter.kt
@@ -18,12 +18,14 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.algorand.android.R
 import com.algorand.android.modules.accountdetail.assets.ui.AccountAssetsFragment
 import com.algorand.android.modules.accountdetail.history.ui.AccountHistoryFragment
+import com.algorand.android.modules.accountdetail.history.ui.AccountTransactionHistoryFragment
 import com.algorand.android.modules.accountdetail.ui.model.AccountDetailPagerAdapterItem
 import com.algorand.android.ui.asset.collectible.listing.account.view.AccountCollectiblesFragment
 
 class AccountDetailPagerAdapter(
     fragment: Fragment,
-    address: String
+    address: String,
+    isAccountHistoryV2Enabled: Boolean
 ) : FragmentStateAdapter(fragment) {
 
     // TODO: 9.08.2022 Since all fragment instance references are kept inside the list, they may cause memory leak
@@ -37,10 +39,17 @@ class AccountDetailPagerAdapter(
             fragmentInstance = AccountCollectiblesFragment.newInstance(address),
             titleResId = R.string.nfts
         ),
-        AccountDetailPagerAdapterItem(
-            fragmentInstance = AccountHistoryFragment.newInstance(address),
-            titleResId = R.string.history
-        )
+        if (isAccountHistoryV2Enabled) {
+            AccountDetailPagerAdapterItem(
+                fragmentInstance = AccountTransactionHistoryFragment.newInstance(address),
+                titleResId = R.string.history
+            )
+        } else {
+            AccountDetailPagerAdapterItem(
+                fragmentInstance = AccountHistoryFragment.newInstance(address),
+                titleResId = R.string.history
+            )
+        }
     )
 
     override fun getItemCount(): Int = pagerItemList.size

--- a/app/src/main/kotlin/com/algorand/android/modules/accountdetail/ui/AccountDetailViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/modules/accountdetail/ui/AccountDetailViewModel.kt
@@ -95,6 +95,8 @@ class AccountDetailViewModel @Inject constructor(
 
     fun isAssetDetailV2Enabled(): Boolean = isFeatureToggleEnabled(FeatureToggle.ASSET_DETAIL_V2.key)
 
+    fun isAccountHistoryV2Enabled(): Boolean = isFeatureToggleEnabled(FeatureToggle.ACCOUNT_HISTORY_V2.key)
+
     fun removeAccount(publicKey: String) {
         viewModelScope.launch(Dispatchers.IO) {
             accountDeletionUseCase.removeAccount(publicKey)

--- a/app/src/main/kotlin/com/algorand/android/ui/transaction/history/mapper/DefaultTransactionHistoryItemMapper.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/transaction/history/mapper/DefaultTransactionHistoryItemMapper.kt
@@ -33,7 +33,7 @@ internal class DefaultTransactionHistoryItemMapper @Inject constructor() : Trans
     override fun map(transactionHistory: TransactionHistory): TransactionHistoryItem {
         return with(transactionHistory) {
             when (this.type) {
-                is ApplicationCall -> TransactionHistoryItem.ApplicationCall(id, fee.formatAsFee())
+                is ApplicationCall -> mapApplicationCallTransaction(transactionHistory)
                 is AssetConfiguration -> TransactionHistoryItem.AssetConfiguration(id, fee.formatAsFee())
                 Heartbeat -> TransactionHistoryItem.Heartbeat(id, fee.formatAsFee())
                 KeyRegistration -> TransactionHistoryItem.KeyRegistration(id, fee.formatAsFee())
@@ -123,6 +123,16 @@ internal class DefaultTransactionHistoryItemMapper @Inject constructor() : Trans
                 formattedAmountOut = formatAmount(assetOutId, amountOut, assetOutUnitName)
             )
         }
+    }
+
+    private fun mapApplicationCallTransaction(transactionHistory: TransactionHistory): TransactionHistoryItem {
+        val applicationCall = transactionHistory.type as ApplicationCall
+        return TransactionHistoryItem.ApplicationCall(
+            id = transactionHistory.id,
+            appId = applicationCall.applicationId.toString(),
+            txnCount = applicationCall.txnCount,
+            formattedFee = transactionHistory.fee.formatAsFee()
+        )
     }
 
     private fun BigDecimal.formatAsFee(): String {

--- a/app/src/main/kotlin/com/algorand/android/ui/transaction/history/model/TransactionHistoryItem.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/transaction/history/model/TransactionHistoryItem.kt
@@ -49,7 +49,12 @@ sealed interface TransactionHistoryItem {
 
     data class Self(val id: String, val formattedAmount: String) : TransactionHistoryItem
 
-    data class ApplicationCall(val id: String, val formattedFee: String) : TransactionHistoryItem
+    data class ApplicationCall(
+        val id: String,
+        val appId: String,
+        val txnCount: Int,
+        val formattedFee: String
+    ) : TransactionHistoryItem
 
     data class AssetConfiguration(val id: String, val formattedFee: String) : TransactionHistoryItem
 

--- a/app/src/main/kotlin/com/algorand/android/ui/transaction/history/view/PagingTransactionHistoryListItems.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/transaction/history/view/PagingTransactionHistoryListItems.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -154,7 +155,7 @@ private fun LazyListScope.emptyState() {
 private fun TransactionHistoryListItem(item: TransactionHistoryItem, listener: TransactionHistoryListListener) {
     with(listener) {
         when (item) {
-            is ApplicationCall -> GenericItemContainer(R.string.application_call, item.formattedFee) {
+            is ApplicationCall -> ApplicationCallItem(item) {
                 onApplicationCallClick(item.id)
             }
 
@@ -218,6 +219,35 @@ private fun SendItem(item: Send, onClick: () -> Unit) {
         amountTextColor = if (item.amount > ZERO) PeraTheme.colors.helper.negative else PeraTheme.colors.text.main,
         onClick = onClick
     )
+}
+
+@Composable
+private fun ApplicationCallItem(item: ApplicationCall, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .clickableNoRipple(onClick = onClick)
+            .fillMaxWidth()
+            .padding(vertical = 16.dp, horizontal = 24.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TxnIcon(R.drawable.ic_buy_sell_small)
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.Center
+        ) {
+            PrimaryText(stringResource(R.string.app_call))
+            SecondaryText(stringResource(R.string.formatted_application_id, item.appId))
+            if (item.txnCount > 0) {
+                Text(
+                    text = pluralStringResource(R.plurals.count_inner_transactions, item.txnCount, item.txnCount),
+                    style = PeraTheme.typography.footnote.sans,
+                    color = PeraTheme.colors.link.primary
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/algorand/android/ui/transaction/history/view/PagingTransactionHistoryListItems.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/transaction/history/view/PagingTransactionHistoryListItems.kt
@@ -100,13 +100,28 @@ private fun LazyListScope.contentState(
     historyItems: LazyPagingItems<TransactionHistoryItem>,
     listener: TransactionHistoryListListener
 ) {
-    items(
-        count = historyItems.itemCount,
-        key = { index -> index }
-    ) { index ->
+    for (index in 0 until historyItems.itemCount) {
         val historyItem = historyItems[index]
         if (historyItem != null) {
-            TransactionHistoryListItem(historyItem, listener)
+            if (historyItem is Date) {
+                stickyDateHeader(index, historyItem)
+            } else {
+                item(key = index) {
+                    TransactionHistoryListItem(historyItem, listener)
+                }
+            }
+        }
+    }
+}
+
+private fun LazyListScope.stickyDateHeader(index: Int, dateItem: Date) {
+    stickyHeader(key = "${index}${dateItem.date}") {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(PeraTheme.colors.background.primary)
+        ) {
+            DateItem(dateItem.date)
         }
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/transaction/history/viewmodel/TransactionHistoryViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/transaction/history/viewmodel/TransactionHistoryViewModel.kt
@@ -32,6 +32,7 @@ import com.algorand.wallet.transaction.history.domain.usecase.GetTransactionHist
 import com.algorand.wallet.viewmodel.StateDelegate
 import com.algorand.wallet.viewmodel.StateViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -39,7 +40,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 @HiltViewModel
 class TransactionHistoryViewModel @Inject constructor(
@@ -54,7 +54,7 @@ class TransactionHistoryViewModel @Inject constructor(
         stateDelegate.setDefaultState(ViewState.Idle)
     }
 
-    fun initViewState(address: String, assetId: Long) {
+    fun initViewState(address: String, assetId: Long?) {
         stateDelegate.onState<ViewState.Idle> {
             stateDelegate.updateState {
                 ViewState.Content(address, assetId, getTransactionPagingDataFlow(address, assetId))
@@ -73,7 +73,10 @@ class TransactionHistoryViewModel @Inject constructor(
     fun getDateFilter(): DateFilter = dateFilter.value
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun getTransactionPagingDataFlow(address: String, assetId: Long): Flow<PagingData<TransactionHistoryItem>> {
+    private fun getTransactionPagingDataFlow(
+        address: String,
+        assetId: Long?
+    ): Flow<PagingData<TransactionHistoryItem>> {
         return dateFilter
             .flatMapLatest { filter ->
                 val pagingData = getPagingData(address, assetId, filter)
@@ -111,7 +114,7 @@ class TransactionHistoryViewModel @Inject constructor(
         }
     }
 
-    private fun getPagingData(address: String, assetId: Long, filter: DateFilter?): TransactionHistoryPagingData {
+    private fun getPagingData(address: String, assetId: Long?, filter: DateFilter?): TransactionHistoryPagingData {
         return TransactionHistoryPagingData(
             address = address,
             assetId = assetId,
@@ -125,7 +128,7 @@ class TransactionHistoryViewModel @Inject constructor(
         data object Idle : ViewState
         data class Content(
             val address: String,
-            val assetId: Long,
+            val assetId: Long?,
             val pagingData: Flow<PagingData<TransactionHistoryItem>>
         ) : ViewState
     }

--- a/app/src/main/res/navigation/home_navigation.xml
+++ b/app/src/main/res/navigation/home_navigation.xml
@@ -1100,6 +1100,9 @@
                 android:name="assetAction"
                 app:argType="com.algorand.android.models.AssetAction" />
         </action>
+        <action
+            android:id="@+id/action_accountDetailFragment_to_swapGroupDetailFragment"
+            app:destination="@id/swapGroupDetailFragment" />
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="disconnect">Disconnect</string>
     <string name="the_requested_operation_and">The requested operation and/or account has not been authorized by the user.</string>
     <string name="application_id">Application ID</string>
+    <string name="formatted_application_id">Application ID: %1$s</string>
     <string name="connected_with_formatted">Connected with %1$s</string>
     <string name="off">Off</string>
     <string name="on">On</string>

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/remoteconfig/domain/model/FeatureToggle.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/remoteconfig/domain/model/FeatureToggle.kt
@@ -21,5 +21,6 @@ enum class FeatureToggle(val key: String, val description: String) {
     ASSET_DETAIL_V2_ENDPOINTS("enable_asset_detail_v2_endpoint", "Asset Detail V2 Endpoints"),
     SWAP_TXN_VALIDATION("enable_swap_txn_validation", "Swap Transaction Validation"),
     XO_SWAP("enable_xo_swap", "XO Swap Feature"),
-    XO_SWAP_TEST_PAGE("enable_xo_swap_test_page", "XO Swap Test Page")
+    XO_SWAP_TEST_PAGE("enable_xo_swap_test_page", "XO Swap Test Page"),
+    ACCOUNT_HISTORY_V2("enable_account_history_v2", "Account Transaction History V2"),
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/mapper/DefaultTransactionHistoryMapper.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/mapper/DefaultTransactionHistoryMapper.kt
@@ -62,7 +62,7 @@ internal class DefaultTransactionHistoryMapper @Inject constructor(
         return when (response.txType) {
             PAY_TRANSACTION -> paymentTypeMapper(address, response)
             ASSET_TRANSACTION -> assetTransferTypeMapper(address, response)
-            APP_TRANSACTION -> Type.ApplicationCall(response.applicationTransaction?.applicationId ?: return null)
+            APP_TRANSACTION -> mapAppCallTxn(response.applicationTransaction?.applicationId, response.innerTxns?.size)
             ASSET_CONFIGURATION -> Type.AssetConfiguration(response.assetConfigTransaction?.assetId ?: return null)
             KEYREG_TRANSACTION -> Type.KeyRegistration
             HEARTBEAT_TRANSACTION -> Type.Heartbeat
@@ -89,12 +89,19 @@ internal class DefaultTransactionHistoryMapper @Inject constructor(
         return when (response.txType) {
             PAY_TRANSACTION -> paymentTypeMapper(address, response)
             ASSET_TRANSACTION -> assetTransferTypeMapper(address, response)
-            APP_TRANSACTION -> Type.ApplicationCall(response.applicationId ?: return null)
+            APP_TRANSACTION -> mapAppCallTxn(response.applicationId, response.innerTransactionCount)
             ASSET_CONFIGURATION -> Type.AssetConfiguration(response.asset?.id ?: return null)
             KEYREG_TRANSACTION -> Type.KeyRegistration
             HEARTBEAT_TRANSACTION -> Type.Heartbeat
             UNDEFINED, null -> null
         }
+    }
+
+    private fun mapAppCallTxn(appId: Long?, innerTxnCount: Int?): Type? {
+        return Type.ApplicationCall(
+            applicationId = appId ?: return null,
+            txnCount = innerTxnCount ?: DEFAULT_INNER_TXN_COUNT
+        )
     }
 
     private fun mapSwapTransaction(response: TransactionHistoryItemResponse): Type.Swap? {
@@ -109,5 +116,9 @@ internal class DefaultTransactionHistoryMapper @Inject constructor(
                 amountOut = amountOut.formatToBigDecimal(assetOut.decimals) ?: return null
             )
         }
+    }
+
+    private companion object {
+        const val DEFAULT_INNER_TXN_COUNT = 0
     }
 }

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/model/TransactionHistoryItemResponse.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/data/model/TransactionHistoryItemResponse.kt
@@ -42,5 +42,7 @@ internal data class TransactionHistoryItemResponse(
     @SerializedName("asset")
     val asset: TransactionHistoryAssetSummaryResponse?,
     @SerializedName("application_id")
-    val applicationId: Long?
+    val applicationId: Long?,
+    @SerializedName("inner_transaction_count")
+    val innerTransactionCount: Int?
 )

--- a/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/domain/model/TransactionHistory.kt
+++ b/common-sdk/src/main/kotlin/com/algorand/wallet/transaction/history/domain/model/TransactionHistory.kt
@@ -66,7 +66,7 @@ data class TransactionHistory(
 
         data class AssetConfiguration(val assetId: Long) : Type
 
-        data class ApplicationCall(val applicationId: Long) : Type
+        data class ApplicationCall(val applicationId: Long, val txnCount: Int) : Type
 
         data object KeyRegistration : Type
 


### PR DESCRIPTION
## Description
- Added inner transaction count for app call transaction items
- Implemented new transaction history endpoint for account overall transaction history
- Added sticky header for date items on transaction list
- Created feature toggle for new screen not to block current release in case there is an issue

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3459

https://github.com/user-attachments/assets/24216e45-d075-47dd-b93e-c820a8127e5c

