### PR TITLE
PERA-3660 Show progress on swap screen until cache initialization

### DIFF
--- a/app/src/main/kotlin/com/algorand/android/ui/swap/usecase/GetPreselectedSwapAddressUseCase.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/usecase/GetPreselectedSwapAddressUseCase.kt
@@ -12,15 +12,17 @@
 
 package com.algorand.android.ui.swap.usecase
 
-import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheData
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLiteCacheStatus
+import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheFlow
 import com.algorand.wallet.account.detail.domain.model.AccountType
 import com.algorand.wallet.swap.domain.usecase.GetLastUsedSwapAddress
 import com.algorand.wallet.swap.domain.usecase.SetLastUsedSwapAddress
 import javax.inject.Inject
+import kotlinx.coroutines.flow.first
 
 internal class GetPreselectedSwapAddressUseCase @Inject constructor(
     private val getLastUsedSwapAddress: GetLastUsedSwapAddress,
-    private val getAccountLiteCacheData: GetAccountLiteCacheData,
+    private val getAccountLiteCacheFlow: GetAccountLiteCacheFlow,
     private val setLastUsedSwapAddress: SetLastUsedSwapAddress
 ) : GetPreselectedSwapAddress {
 
@@ -37,12 +39,16 @@ internal class GetPreselectedSwapAddressUseCase @Inject constructor(
         }
     }
 
-    private fun getSortedAuthAddresses(): List<String> {
-        return getAccountLiteCacheData()?.accountLites?.mapNotNull { (address, accountLite) ->
+    private suspend fun getSortedAuthAddresses(): List<String> {
+        val cacheStatus = getAccountLiteCacheFlow().first {
+            it !is AccountLiteCacheStatus.Idle && it !is AccountLiteCacheStatus.Loading
+        }
+        val data = cacheStatus as? AccountLiteCacheStatus.Data ?: return emptyList()
+        return data.accountLites.mapNotNull { (address, accountLite) ->
             address.takeIf {
                 val accountType = accountLite.cachedInfo?.type ?: return@takeIf false
                 accountType.canSignTransaction() && accountType !is AccountType.Joint
             }
-        }.orEmpty()
+        }
     }
 }

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/view/SwapScreen.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/view/SwapScreen.kt
@@ -22,10 +22,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.algorand.android.ui.compose.theme.PeraTheme
+import com.algorand.android.ui.compose.widget.progress.PeraCircularProgressIndicator
 import com.algorand.android.ui.swap.history.viewmodel.SwapPairHistoryViewModel
 import com.algorand.android.ui.swap.providers.viewmodel.SwapQuoteProvidersViewModel
 import com.algorand.android.ui.swap.topfive.viewmodel.DefaultTopSwapPairsViewModel
@@ -68,7 +70,8 @@ fun SwapScreen(
             val viewState = swapViewModel.state.collectAsStateWithLifecycle()
             val scope = rememberCoroutineScope()
             when (viewState.value) {
-                SwapViewModel.ViewState.Idle -> Unit
+                SwapViewModel.ViewState.Idle,
+                SwapViewModel.ViewState.Loading -> FullScreenProgress()
                 is SwapViewModel.ViewState.Content -> {
                     SwapToolbar(scope, swapViewModel, listener)
                     SwapScreenContentState(
@@ -100,6 +103,13 @@ fun SwapScreen(
                 Introduction -> SwapScreenIntroductionState(listener = listener)
             }
         }
+    }
+}
+
+@Composable
+private fun FullScreenProgress() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        PeraCircularProgressIndicator()
     }
 }
 

--- a/app/src/main/kotlin/com/algorand/android/ui/swap/viewmodel/SwapViewModel.kt
+++ b/app/src/main/kotlin/com/algorand/android/ui/swap/viewmodel/SwapViewModel.kt
@@ -44,6 +44,8 @@ import com.algorand.wallet.swap.domain.usecase.SetSwapUseLocalCurrencyPreference
 import com.algorand.wallet.viewmodel.StateDelegate
 import com.algorand.wallet.viewmodel.StateViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.math.BigInteger
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -52,8 +54,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.math.BigInteger
-import javax.inject.Inject
 
 @HiltViewModel
 class SwapViewModel @Inject constructor(
@@ -182,6 +182,7 @@ class SwapViewModel @Inject constructor(
     }
 
     private suspend fun initSwapViewState(arg: SwapFragmentArgs) {
+        stateDelegate.updateState { ViewState.Loading }
         val address = getSwapAddress(arg)
         if (address == null) {
             stateDelegate.updateState { ViewState.NoAccountState }
@@ -235,6 +236,7 @@ class SwapViewModel @Inject constructor(
 
     sealed interface ViewState {
         data object Idle : ViewState
+        data object Loading : ViewState
         data object NoAccountState : ViewState
         data object Introduction : ViewState
         data class Content(

--- a/app/src/test/kotlin/com/algorand/android/ui/swap/usecase/GetPreselectedSwapAddressUseCaseTest.kt
+++ b/app/src/test/kotlin/com/algorand/android/ui/swap/usecase/GetPreselectedSwapAddressUseCaseTest.kt
@@ -13,36 +13,44 @@
 package com.algorand.android.ui.swap.usecase
 
 import com.algorand.android.modules.accounts.lite.domain.model.AccountLite
+import com.algorand.android.modules.accounts.lite.domain.model.AccountLiteCacheStatus
 import com.algorand.android.modules.accounts.lite.domain.model.AccountLiteCacheStatus.Data
-import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheData
+import com.algorand.android.modules.accounts.lite.domain.usecase.GetAccountLiteCacheFlow
 import com.algorand.test.peraFixture
 import com.algorand.wallet.account.detail.domain.model.AccountType
 import com.algorand.wallet.swap.domain.usecase.GetLastUsedSwapAddress
 import com.algorand.wallet.swap.domain.usecase.SetLastUsedSwapAddress
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class GetPreselectedSwapAddressUseCaseTest {
 
     private val getLastUsedSwapAddress: GetLastUsedSwapAddress = mockk()
     private val setLastUsedSwapAddress: SetLastUsedSwapAddress = mockk(relaxed = true)
-    private val getAccountLiteCacheData: GetAccountLiteCacheData = mockk()
+    private val cacheFlow = MutableStateFlow<AccountLiteCacheStatus>(AccountLiteCacheStatus.Idle)
+    private val getAccountLiteCacheFlow: GetAccountLiteCacheFlow = mockk {
+        every { this@mockk() } returns cacheFlow
+    }
 
     private val sut = GetPreselectedSwapAddressUseCase(
         getLastUsedSwapAddress,
-        getAccountLiteCacheData,
+        getAccountLiteCacheFlow,
         setLastUsedSwapAddress
     )
 
     @Test
     fun `EXPECT last used address WHEN exists in cache and can sign transaction`(): TestResult = runTest {
         coEvery { getLastUsedSwapAddress() } returns ALGO_25_ADDRESS
-        coEvery { getAccountLiteCacheData() } returns Data(emptyList(), ACCOUNT_LITES)
+        cacheFlow.value = Data(emptyList(), ACCOUNT_LITES)
 
         val result = sut()
 
@@ -55,7 +63,7 @@ class GetPreselectedSwapAddressUseCaseTest {
             accountLites = mapOf(WATCH_ADDRESS to WATCH_ACCOUNT_LITE, ALGO_25_ADDRESS to ALGO_25_LITE)
         )
         coEvery { getLastUsedSwapAddress() } returns null
-        coEvery { getAccountLiteCacheData() } returns accountLiteCacheData
+        cacheFlow.value = accountLiteCacheData
 
         val result = sut()
 
@@ -80,7 +88,7 @@ class GetPreselectedSwapAddressUseCaseTest {
             )
         )
         coEvery { getLastUsedSwapAddress() } returns ALGO_25_ADDRESS
-        coEvery { getAccountLiteCacheData() } returns accountLiteCacheData
+        cacheFlow.value = accountLiteCacheData
 
         val result = sut()
 
@@ -88,15 +96,16 @@ class GetPreselectedSwapAddressUseCaseTest {
     }
 
     @Test
-    fun `EXPECT last used address to be updated WHEN cache is not valid and there is valid address`(): TestResult = runTest {
-        coEvery { getLastUsedSwapAddress() } returns "INVALID_ADDRESS"
-        coEvery { getAccountLiteCacheData() } returns Data(emptyList(), ACCOUNT_LITES)
+    fun `EXPECT last used address to be updated WHEN cache is not valid and there is valid address`(): TestResult =
+        runTest {
+            coEvery { getLastUsedSwapAddress() } returns "INVALID_ADDRESS"
+            cacheFlow.value = Data(emptyList(), ACCOUNT_LITES)
 
-        val result = sut()
+            val result = sut()
 
-        assertEquals(ALGO_25_ADDRESS, result)
-        coVerify { setLastUsedSwapAddress(ALGO_25_ADDRESS) }
-    }
+            assertEquals(ALGO_25_ADDRESS, result)
+            coVerify { setLastUsedSwapAddress(ALGO_25_ADDRESS) }
+        }
 
     @Test
     fun `EXPECT null WHEN no valid address exists`(): TestResult = runTest {
@@ -104,11 +113,47 @@ class GetPreselectedSwapAddressUseCaseTest {
             accountLites = mapOf(WATCH_ADDRESS to WATCH_ACCOUNT_LITE)
         )
         coEvery { getLastUsedSwapAddress() } returns null
-        coEvery { getAccountLiteCacheData() } returns accountLiteCacheData
+        cacheFlow.value = accountLiteCacheData
 
         val result = sut()
 
         assertEquals(null, result)
+    }
+
+    @Test
+    fun `EXPECT suspend WHEN cache is idle THEN return address after data emitted`(): TestResult = runTest {
+        coEvery { getLastUsedSwapAddress() } returns ALGO_25_ADDRESS
+        cacheFlow.value = AccountLiteCacheStatus.Idle
+
+        val deferred = async { sut() }
+
+        cacheFlow.value = Data(emptyList(), ACCOUNT_LITES)
+        assertFalse(deferred.isCompleted)
+        assertEquals(ALGO_25_ADDRESS, deferred.await())
+    }
+
+    @Test
+    fun `EXPECT suspend WHEN cache is loading THEN return address after data emitted`(): TestResult = runTest {
+        coEvery { getLastUsedSwapAddress() } returns ALGO_25_ADDRESS
+        cacheFlow.value = AccountLiteCacheStatus.Loading
+
+        val deferred = async { sut() }
+
+        cacheFlow.value = Data(emptyList(), ACCOUNT_LITES)
+        assertFalse(deferred.isCompleted)
+        assertEquals(ALGO_25_ADDRESS, deferred.await())
+    }
+
+    @Test
+    fun `EXPECT null WHEN cache transitions from loading to empty local accounts`(): TestResult = runTest {
+        coEvery { getLastUsedSwapAddress() } returns null
+        cacheFlow.value = AccountLiteCacheStatus.Loading
+
+        val deferred = async { sut() }
+
+        cacheFlow.value = AccountLiteCacheStatus.EmptyLocalAccounts
+        assertFalse(deferred.isCompleted)
+        assertEquals(null, deferred.await())
     }
 
     private companion object {


### PR DESCRIPTION
## Description
- GetPreselectedSwapAddressUseCase wasn't waiting cache to be initialized, which was causing empty address issue. 

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3660
