### PR TITLE
Sync release into dev: version bump to 6.202609.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ android-minSdk = "28"
 android-namespace = "com.algorand.android"
 android-targetSdk = "36"
 android-versionCode = "124"
-android-versionName = "6.202608.0"
+android-versionName = "6.202609.0"
 ndk = "29.0.14206865"
 
 # Pera / Algorand SDK


### PR DESCRIPTION
Merges `release` into `dev`.

**Carries:**
- 827b17ffc chore: Bump Android app version to 6.202609.0